### PR TITLE
Update namespace_changes_t10.dart

### DIFF
--- a/Language/Libraries_and_Scripts/Imports/namespace_changes_t10.dart
+++ b/Language/Libraries_and_Scripts/Imports/namespace_changes_t10.dart
@@ -48,7 +48,7 @@
 
 library import_itself_library;
 
-import "1_Imports_A02_t10.dart";
+import "namespace_changes_t10.dart";
 
 var foo;
 class bar { }

--- a/Language/Libraries_and_Scripts/Parts/compilation_t09.dart
+++ b/Language/Libraries_and_Scripts/Parts/compilation_t09.dart
@@ -24,7 +24,7 @@
  */
  
 library Parts_test_lib;
-part "3_Parts_A01_t05.dart";
+part "compilation_t09.dart";
 
 main() {
 }


### PR DESCRIPTION
The self-reference in the test was not updated when the name was changed.