### PR TITLE
Remove 'dart:mirrors' import.

### DIFF
--- a/WebPlatformTest/shadow-dom/testcommon.dart
+++ b/WebPlatformTest/shadow-dom/testcommon.dart
@@ -13,7 +13,6 @@
 library test_common;
 
 import 'dart:html';
-import 'dart:mirrors';
 export 'testharness.dart';
 
 var HTML5_ELEMENT_NAMES = [


### PR DESCRIPTION
dart:mirrors seems to be unused.
Since mirrors are unsupported in the fast-startup emitter and usually slow down compilation I removed it.