### PR TITLE
Update tests for RandomAccessFile.close

### DIFF
--- a/LibTest/io/RandomAccessFile/close_A01_t01.dart
+++ b/LibTest/io/RandomAccessFile/close_A01_t01.dart
@@ -25,9 +25,9 @@ main() {
   raFile.then((RandomAccessFile rf) {
     Expect.isNotNull(rf);
     var clf = rf.close();
-    Expect.isTrue(clf is Future<RandomAccessFile>);
-    clf.then((RandomAccessFile f) {
-      Expect.isTrue(f == rf);
+    Expect.isTrue(clf is Future);
+    clf.then((f) {
+      Expect.isNull(f);
       asyncEnd();
     }).whenComplete(() {
       file.delete();

--- a/LibTest/io/RandomAccessFile/close_A01_t02.dart
+++ b/LibTest/io/RandomAccessFile/close_A01_t02.dart
@@ -25,7 +25,7 @@ main() {
   Future<RandomAccessFile> raFile = file.open(mode: FileMode.READ);
   raFile.then((RandomAccessFile rf) {
     Expect.isNotNull(rf);
-    rf.close().then((RandomAccessFile f) {
+    rf.close().then((_) {
       try {
         rf.lengthSync();
         Expect.fail('should not be here');


### PR DESCRIPTION
This PR updates co19 tests for https://github.com/dart-lang/sdk/issues/32015.
CL for the core libraries: https://dart-review.googlesource.com/c/sdk/+/44060.

If it's already possible, `Future` should probably be changed to `Future<void>`.