### PR TITLE
Remove now-redundant file delete.

### DIFF
--- a/LibTest/io/Stdin/test.lib.dart
+++ b/LibTest/io/Stdin/test.lib.dart
@@ -24,7 +24,6 @@ run_main(void run(Process _), String expected) async {
     await process.exitCode.then((int c) async {
       File fl = new File(filename);
       await fl.readAsString().then((String contents) {
-        fl.delete();
         Expect.listEquals(expected.codeUnits, contents.codeUnits);
       });
       called++;


### PR DESCRIPTION
After commit 365808e85, the entire sandbox directory is deleted,
but there's still a separate attempt to delete the temp file
created by the test asynchronously as well. If the file deletion
ends up happening after the sandbox is deleted, then we get a
spurious runtime error.

Fixes #212.