### PR TITLE
Fix wait for window.onLoad event

### DIFF
--- a/LayoutTests/fast/css-generated-content/pseudo-animation_t01.dart
+++ b/LayoutTests/fast/css-generated-content/pseudo-animation_t01.dart
@@ -108,8 +108,13 @@ main() {
   }
 
   asyncMultiStart(2);
-  window.onLoad.listen((_) {
+  doTest(_) {
     testAnimation('before');
     testAnimation('after');
-  });
+  }
+  if (document.readyState == "complete") {
+    doTest(null);
+  } else {
+    window.addEventListener('load', doTest, false);
+  }  
 }


### PR DESCRIPTION
This test was timing out because window.onLoad was not triggering after a listener was added.

Also, addEventListener is preferred to onLoad = , because it does not overwrite a previous handler.