### PR TITLE
Pass Uint8List to Datagram

### DIFF
--- a/LibTest/io/Datagram/Datagram_A01_t01.dart
+++ b/LibTest/io/Datagram/Datagram_A01_t01.dart
@@ -9,11 +9,12 @@
  * @author sgrekhov@unipro.ru
  */
 import "dart:io";
+import "dart:typed_data";
 import "../../../Utils/expect.dart";
 
 main() {
   InternetAddress address = new InternetAddress("127.0.0.1");
-  Datagram datagram = new Datagram([1, 2, 3], address, 80);
+  Datagram datagram = new Datagram(Uint8List.fromList([1, 2, 3]), address, 80);
   Expect.listEquals([1, 2, 3], datagram.data);
   Expect.equals(address, datagram.address);
   Expect.equals(80, datagram.port);

--- a/LibTest/io/Datagram/Datagram_A01_t02.dart
+++ b/LibTest/io/Datagram/Datagram_A01_t02.dart
@@ -10,11 +10,12 @@
  * @author sgrekhov@unipro.ru
  */
 import "dart:io";
+import "dart:typed_data";
 import "../../../Utils/expect.dart";
 
 main() {
   InternetAddress address = new InternetAddress("::1");
-  Datagram datagram = new Datagram([1, 2, 3], address, 43);
+  Datagram datagram = new Datagram(Uint8List.fromList([1, 2, 3]), address, 43);
   Expect.listEquals([1, 2, 3], datagram.data);
   Expect.equals(address, datagram.address);
   Expect.equals(43, datagram.port);

--- a/LibTest/io/Datagram/address_A01_t01.dart
+++ b/LibTest/io/Datagram/address_A01_t01.dart
@@ -9,11 +9,12 @@
  * @author sgrekhov@unipro.ru
  */
 import "dart:io";
+import "dart:typed_data";
 import "../../../Utils/expect.dart";
 
 main() {
   InternetAddress address = new InternetAddress("127.0.0.1");
-  Datagram datagram = new Datagram([], address, 80);
+  Datagram datagram = new Datagram(new Uint8List(0), address, 80);
   Expect.equals(address, datagram.address);
 
   address = new InternetAddress("::127");

--- a/LibTest/io/Datagram/data_A01_t01.dart
+++ b/LibTest/io/Datagram/data_A01_t01.dart
@@ -9,11 +9,12 @@
  * @author sgrekhov@unipro.ru
  */
 import "dart:io";
+import "dart:typed_data";
 import "../../../Utils/expect.dart";
 
 main() {
   InternetAddress address = new InternetAddress("127.0.0.1");
-  Datagram datagram = new Datagram([], address, 80);
+  Datagram datagram = new Datagram(new Uint8List(0), address, 80);
   Expect.listEquals([], datagram.data);
 
   datagram.data = [1, 2, 3];

--- a/LibTest/io/Datagram/port_A01_t01.dart
+++ b/LibTest/io/Datagram/port_A01_t01.dart
@@ -9,11 +9,12 @@
  * @author sgrekhov@unipro.ru
  */
 import "dart:io";
+import "dart:typed_data";
 import "../../../Utils/expect.dart";
 
 main() {
   InternetAddress address = new InternetAddress("127.0.0.1");
-  Datagram datagram = new Datagram([], address, 80);
+  Datagram datagram = new Datagram(new Uint8List(0), address, 80);
   Expect.equals(80, datagram.port);
 
   datagram.port = 43;


### PR DESCRIPTION
This is in preparation for Datagram requiring a
Uint8List passed to its constructor. This is a
forward-compatible change.

dart-lang/sdk#36900
dart-lang/co19#381