### PR TITLE
Cast HttpRequest and HttpClientResponse streams to List<int>

### DIFF
--- a/LibTest/io/HttpClient/addCredentials_A01_t01.dart
+++ b/LibTest/io/HttpClient/addCredentials_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
     .then((HttpClientRequest request) {
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
       });
     });

--- a/LibTest/io/HttpClient/authenticateProxy_A01_t01.dart
+++ b/LibTest/io/HttpClient/authenticateProxy_A01_t01.dart
@@ -75,7 +75,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/authenticateProxy_A01_t02.dart
+++ b/LibTest/io/HttpClient/authenticateProxy_A01_t02.dart
@@ -79,7 +79,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/authenticateProxy_A02_t01.dart
+++ b/LibTest/io/HttpClient/authenticateProxy_A02_t01.dart
@@ -73,7 +73,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/authenticate_A01_t01.dart
+++ b/LibTest/io/HttpClient/authenticate_A01_t01.dart
@@ -76,7 +76,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/authenticate_A01_t02.dart
+++ b/LibTest/io/HttpClient/authenticate_A01_t02.dart
@@ -69,7 +69,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/authenticate_A02_t01.dart
+++ b/LibTest/io/HttpClient/authenticate_A02_t01.dart
@@ -64,7 +64,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/autoUncompress_A02_t01.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A02_t01.dart
@@ -58,7 +58,7 @@ test() async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/autoUncompress_A02_t02.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A02_t02.dart
@@ -58,7 +58,7 @@ test() async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(gzip.decoder).transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(gzip.decoder).transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/autoUncompress_A03_t01.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A03_t01.dart
@@ -62,7 +62,7 @@ test() async {
     Expect.listEquals([helloWorld.length.toString()],
         response.headers[HttpHeaders.contentLengthHeader]);
     Expect.listEquals(["utf-8"], response.headers[HttpHeaders.contentEncodingHeader]);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/autoUncompress_A04_t01.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A04_t01.dart
@@ -58,7 +58,7 @@ test() async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       Expect.equals("gzip", response.headers.value(HttpHeaders.contentEncodingHeader));
       asyncEnd();

--- a/LibTest/io/HttpClient/autoUncompress_A04_t02.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A04_t02.dart
@@ -62,7 +62,7 @@ test() async {
   }).then((HttpClientResponse response) {
     // Server sends uncompressed data. autoUncompress sets to true but
     // uncompression should not be performed
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/autoUncompress_A04_t03.dart
+++ b/LibTest/io/HttpClient/autoUncompress_A04_t03.dart
@@ -63,7 +63,7 @@ test() async {
     // Server sends uncompressed data but on client autoUncompress sets to true
     // and Content-Encoding header value is gzip so we are trying to uncompress
     // not compressed data
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
     }, onError: (_) {
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/close_A01_t01.dart
+++ b/LibTest/io/HttpClient/close_A01_t01.dart
@@ -41,7 +41,7 @@ test() async {
   client.getUrl(Uri.parse("http://${localhost}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       client.close(force: true);
 

--- a/LibTest/io/HttpClient/deleteUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/deleteUrl_A01_t01.dart
@@ -38,7 +38,7 @@ test() async {
   client.deleteUrl(Uri.parse("http://${localhost}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/deleteUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/deleteUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/delete_A01_t01.dart
+++ b/LibTest/io/HttpClient/delete_A01_t01.dart
@@ -41,7 +41,7 @@ test() async {
   client.delete(localhost, server.port, "/xxx")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/delete_A01_t02.dart
+++ b/LibTest/io/HttpClient/delete_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.delete(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A01_t01.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A01_t01.dart
@@ -75,7 +75,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t01.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t01.dart
@@ -80,7 +80,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t02.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t02.dart
@@ -86,7 +86,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t03.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t03.dart
@@ -86,7 +86,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t04.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t04.dart
@@ -87,7 +87,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t05.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A02_t05.dart
@@ -87,7 +87,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A03_t01.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A03_t01.dart
@@ -80,7 +80,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxyFromEnvironment_A04_t01.dart
+++ b/LibTest/io/HttpClient/findProxyFromEnvironment_A04_t01.dart
@@ -90,7 +90,7 @@ test() async {
   client.get(localhost, server.port, "")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(hello, content);
     });
   });

--- a/LibTest/io/HttpClient/findProxy_A01_t01.dart
+++ b/LibTest/io/HttpClient/findProxy_A01_t01.dart
@@ -79,7 +79,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/findProxy_A01_t02.dart
+++ b/LibTest/io/HttpClient/findProxy_A01_t02.dart
@@ -79,7 +79,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/findProxy_A02_t01.dart
+++ b/LibTest/io/HttpClient/findProxy_A02_t01.dart
@@ -69,7 +69,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/findProxy_A02_t02.dart
+++ b/LibTest/io/HttpClient/findProxy_A02_t02.dart
@@ -69,7 +69,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/findProxy_A03_t01.dart
+++ b/LibTest/io/HttpClient/findProxy_A03_t01.dart
@@ -88,7 +88,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/findProxy_A03_t02.dart
+++ b/LibTest/io/HttpClient/findProxy_A03_t02.dart
@@ -91,7 +91,7 @@ test() async {
       "http://${InternetAddress.loopbackIPv4.address}:${server.port}"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClient/getUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/getUrl_A01_t01.dart
@@ -40,7 +40,7 @@ test() async {
         Expect.equals("GET", request.method);
         return request.close();
       }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/getUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/getUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/get_A01_t01.dart
+++ b/LibTest/io/HttpClient/get_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
         Expect.equals("GET", request.method);
         return request.close();
       }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/get_A01_t02.dart
+++ b/LibTest/io/HttpClient/get_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.get(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/headUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/headUrl_A01_t01.dart
@@ -40,7 +40,7 @@ test() async {
       Expect.equals("HEAD", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/headUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/headUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/head_A01_t01.dart
+++ b/LibTest/io/HttpClient/head_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
       Expect.equals("HEAD", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/head_A01_t02.dart
+++ b/LibTest/io/HttpClient/head_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.head(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/idleTimeout_A02_t01.dart
+++ b/LibTest/io/HttpClient/idleTimeout_A02_t01.dart
@@ -41,7 +41,7 @@ test() async {
     request.headers.set(HttpHeaders.connectionHeader, "keep-alive");
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld + helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/openUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/openUrl_A01_t01.dart
@@ -48,7 +48,7 @@ test() async {
       Expect.equals("GET", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/openUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/openUrl_A01_t02.dart
@@ -47,7 +47,7 @@ test() async {
       Uri.parse("http://${localhost}:${server.port}/y/xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/openUrl_A01_t03.dart
+++ b/LibTest/io/HttpClient/openUrl_A01_t03.dart
@@ -47,7 +47,7 @@ test() async {
       Uri.parse("http://${localhost}:${server.port}/Xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/openUrl_A01_t04.dart
+++ b/LibTest/io/HttpClient/openUrl_A01_t04.dart
@@ -51,7 +51,7 @@ test() async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/openUrl_A01_t05.dart
+++ b/LibTest/io/HttpClient/openUrl_A01_t05.dart
@@ -54,7 +54,7 @@ test() async {
     request.headers.port = 111;
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/open_A01_t01.dart
+++ b/LibTest/io/HttpClient/open_A01_t01.dart
@@ -52,7 +52,7 @@ test() async {
       Expect.equals("GET", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/open_A01_t02.dart
+++ b/LibTest/io/HttpClient/open_A01_t02.dart
@@ -50,7 +50,7 @@ test() async {
   client.open("GET", localhost, server.port, "y/xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/open_A01_t03.dart
+++ b/LibTest/io/HttpClient/open_A01_t03.dart
@@ -50,7 +50,7 @@ test() async {
   client.open("get", localhost, server.port, "/Xxx")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/open_A01_t04.dart
+++ b/LibTest/io/HttpClient/open_A01_t04.dart
@@ -54,7 +54,7 @@ test() async {
       .then((HttpClientRequest request){
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/open_A01_t05.dart
+++ b/LibTest/io/HttpClient/open_A01_t05.dart
@@ -57,7 +57,7 @@ test() async {
     request.headers.port = 111;
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/patchUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/patchUrl_A01_t01.dart
@@ -40,7 +40,7 @@ test() async {
       Expect.equals("PATCH", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/patchUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/patchUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/Xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/patch_A01_t01.dart
+++ b/LibTest/io/HttpClient/patch_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
       Expect.equals("PATCH", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/patch_A01_t02.dart
+++ b/LibTest/io/HttpClient/patch_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.patch(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/postUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/postUrl_A01_t01.dart
@@ -40,7 +40,7 @@ test() async {
       Expect.equals("POST", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/postUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/postUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/Xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/post_A01_t01.dart
+++ b/LibTest/io/HttpClient/post_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
       Expect.equals("POST", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/post_A01_t02.dart
+++ b/LibTest/io/HttpClient/post_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.post(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/putUrl_A01_t01.dart
+++ b/LibTest/io/HttpClient/putUrl_A01_t01.dart
@@ -40,7 +40,7 @@ test() async {
       Expect.equals("PUT", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/putUrl_A01_t02.dart
+++ b/LibTest/io/HttpClient/putUrl_A01_t02.dart
@@ -39,7 +39,7 @@ test() async {
           .parse("http://${localhost}:${server.port}/y/Xxx?q=12&i=j#fragment"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/put_A01_t01.dart
+++ b/LibTest/io/HttpClient/put_A01_t01.dart
@@ -43,7 +43,7 @@ test() async {
       Expect.equals("PUT", request.method);
       return request.close();
     }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/put_A01_t02.dart
+++ b/LibTest/io/HttpClient/put_A01_t02.dart
@@ -41,7 +41,7 @@ test() async {
   client.put(localhost, server.port, "y/Xxx?q=12&i=j#fragment")
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
     });
   });

--- a/LibTest/io/HttpClient/userAgent_A01_t01.dart
+++ b/LibTest/io/HttpClient/userAgent_A01_t01.dart
@@ -46,7 +46,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClient/userAgent_A02_t01.dart
+++ b/LibTest/io/HttpClient/userAgent_A02_t01.dart
@@ -43,7 +43,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpClientBasicCredentials/HttpClientBasicCredentials_A01_t01.dart
+++ b/LibTest/io/HttpClientBasicCredentials/HttpClientBasicCredentials_A01_t01.dart
@@ -50,7 +50,7 @@ test() async {
           "http://${InternetAddress.loopbackIPv4.address}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientDigestCredentials/HttpClientDigestCredentials_A01_t01.dart
+++ b/LibTest/io/HttpClientDigestCredentials/HttpClientDigestCredentials_A01_t01.dart
@@ -60,7 +60,7 @@ test() async {
       .getUrl(Uri.parse("http://${localhost}:${server.port}/xxx"))
       .then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientRequest/addError_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/addError_A02_t01.dart
@@ -54,7 +54,7 @@ test(String method) async {
       request.addError("Error");
     });
     f.then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/addStream_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/addStream_A01_t01.dart
@@ -43,7 +43,7 @@ test(String method) async {
     request.addStream(stream).then((var request) {
       return request.close();
     }).then((var response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/addStream_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/addStream_A02_t01.dart
@@ -45,7 +45,7 @@ test(String method) async {
       request.addStream(stream2).then((HttpClientRequest request) {
         return request.close();
       }).then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {});
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
         asyncEnd();
       });
     });

--- a/LibTest/io/HttpClientRequest/addStream_A02_t02.dart
+++ b/LibTest/io/HttpClientRequest/addStream_A02_t02.dart
@@ -49,7 +49,7 @@ test(String method) async {
       request.addStream(stream2);
     });
     f.then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/add_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/add_A01_t01.dart
@@ -46,7 +46,7 @@ test(String method) async {
     request.add([0, 1, 2, 3]);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/add_A01_t02.dart
+++ b/LibTest/io/HttpClientRequest/add_A01_t02.dart
@@ -49,7 +49,7 @@ test(String method) async {
     request.add(list);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/add_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/add_A02_t01.dart
@@ -49,7 +49,7 @@ test(String method) async {
     request.add(list);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/add_A03_t01.dart
+++ b/LibTest/io/HttpClientRequest/add_A03_t01.dart
@@ -55,7 +55,7 @@ test(String method) async {
       request.add([1]);
     });
     f.then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/add_A03_t02.dart
+++ b/LibTest/io/HttpClientRequest/add_A03_t02.dart
@@ -52,7 +52,7 @@ test(String method) async {
       request.add([2, 6]);
       return request.close();
     }).then((var response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/add_A04_t01.dart
+++ b/LibTest/io/HttpClientRequest/add_A04_t01.dart
@@ -48,7 +48,7 @@ test(String method) async {
     request.add([]);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/add_A05_t01.dart
+++ b/LibTest/io/HttpClientRequest/add_A05_t01.dart
@@ -51,7 +51,7 @@ test(String method) async {
     list[0] = 0;
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/bufferOutput_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/bufferOutput_A01_t01.dart
@@ -35,7 +35,7 @@ test() async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/bufferOutput_A01_t02.dart
+++ b/LibTest/io/HttpClientRequest/bufferOutput_A01_t02.dart
@@ -35,7 +35,7 @@ test() async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/close_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/close_A01_t01.dart
@@ -30,7 +30,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     request.done.then((HttpClientResponse response) {
       asyncEnd();
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       });
     });
     return request.close();

--- a/LibTest/io/HttpClientRequest/close_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/close_A02_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
     Expect.throws(() {request.writeln("Lily was here");});
     return result;
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/connectionInfo_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/connectionInfo_A01_t01.dart
@@ -36,7 +36,7 @@ test() async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/contentLength_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/contentLength_A01_t01.dart
@@ -36,7 +36,7 @@ test(String method, int expected) async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/contentLength_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/contentLength_A02_t01.dart
@@ -38,7 +38,7 @@ test(method) async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/cookies_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/cookies_A01_t01.dart
@@ -39,7 +39,7 @@ test(String method) async {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           Expect.equals(helloWorld, content);
         });
       });

--- a/LibTest/io/HttpClientRequest/done_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/done_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
         request.done.then((HttpClientResponse response) {
           asyncEnd();
-          response.transform(utf8.decoder).listen((content) {
+          response.cast<List<int>>().transform(utf8.decoder).listen((content) {
           });
         });
         return request.close();

--- a/LibTest/io/HttpClientRequest/encoding_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/encoding_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
     Expect.equals("iso-8859-1", request.encoding.name);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/encoding_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/encoding_A02_t01.dart
@@ -33,7 +33,7 @@ test(String method) async {
     Expect.throws(() {request.encoding = Encoding.getByName("UTF-8");});
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/encoding_A03_t01.dart
+++ b/LibTest/io/HttpClientRequest/encoding_A03_t01.dart
@@ -36,7 +36,7 @@ test(String method) async {
     Expect.throws(() {request.writeln("Кириллица прекрасна");});
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/flush_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/flush_A01_t01.dart
@@ -41,7 +41,7 @@ test(String method) async {
     });
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
     });
   });
 }

--- a/LibTest/io/HttpClientRequest/flush_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/flush_A02_t01.dart
@@ -46,7 +46,7 @@ test(String method) async {
     request.addStream(stream).then((var request) {
       return request.close();
     }).then((var response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
     Expect.throws(() {request.flush();});

--- a/LibTest/io/HttpClientRequest/flush_A02_t02.dart
+++ b/LibTest/io/HttpClientRequest/flush_A02_t02.dart
@@ -47,7 +47,7 @@ test(String method) async {
       request.flush();
       return request.close();
     }).then((var response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
   });

--- a/LibTest/io/HttpClientRequest/followRedirects_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/followRedirects_A01_t01.dart
@@ -44,7 +44,7 @@ test(String method) async {
         Expect.isTrue(request.followRedirects);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/followRedirects_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/followRedirects_A02_t01.dart
@@ -57,7 +57,7 @@ test(String method, int statusCode) async {
         Expect.isTrue(request.followRedirects);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientRequest/followRedirects_A03_t01.dart
+++ b/LibTest/io/HttpClientRequest/followRedirects_A03_t01.dart
@@ -59,7 +59,7 @@ test(String method, int statusCode) async {
         Expect.isFalse(request.followRedirects);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientRequest/followRedirects_A04_t01.dart
+++ b/LibTest/io/HttpClientRequest/followRedirects_A04_t01.dart
@@ -57,7 +57,7 @@ test(String method, int statusCode) async {
       .then((HttpClientRequest request) {
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientRequest/followRedirects_A05_t01.dart
+++ b/LibTest/io/HttpClientRequest/followRedirects_A05_t01.dart
@@ -56,7 +56,7 @@ test(String method, int statusCode) async {
       .then((HttpClientRequest request) {
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientRequest/headers_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/headers_A01_t01.dart
@@ -39,7 +39,7 @@ test(String method, int contentLength) async {
         Expect.equals(contentLength, contentLength);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/headers_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/headers_A02_t01.dart
@@ -36,7 +36,7 @@ test(String method) async {
         request.headers.set(HttpHeaders.ageHeader, 21);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/headers_A03_t01.dart
+++ b/LibTest/io/HttpClientRequest/headers_A03_t01.dart
@@ -39,7 +39,7 @@ test(String method) async {
         Expect.throws(() {request.headers.set(HttpHeaders.ageHeader, 21);});
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/headers_A03_t02.dart
+++ b/LibTest/io/HttpClientRequest/headers_A03_t02.dart
@@ -37,7 +37,7 @@ test(String method) async {
         Expect.throws(() {request.headers.set(HttpHeaders.ageHeader, 21);});
         return result;
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/maxRedirects_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/maxRedirects_A01_t01.dart
@@ -36,7 +36,7 @@ test(String method) async {
         Expect.equals(5, request.maxRedirects);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/maxRedirects_A02_t01.dart
+++ b/LibTest/io/HttpClientRequest/maxRedirects_A02_t01.dart
@@ -47,7 +47,7 @@ test(String method, int maxRedirects, int status) async {
         }
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/maxRedirects_A03_t01.dart
+++ b/LibTest/io/HttpClientRequest/maxRedirects_A03_t01.dart
@@ -49,7 +49,7 @@ test(String method, int maxRedirects, int status) async {
         }
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/maxRedirects_A04_t01.dart
+++ b/LibTest/io/HttpClientRequest/maxRedirects_A04_t01.dart
@@ -49,7 +49,7 @@ test(String method, int maxRedirects) async {
         }
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/method_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/method_A01_t01.dart
@@ -31,7 +31,7 @@ test(String method) async {
         Expect.equals(method.toUpperCase(), request.method);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/persistentConnection_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/persistentConnection_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
         Expect.isTrue(request.persistentConnection);
         return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientRequest/uri_A01_t01.dart
+++ b/LibTest/io/HttpClientRequest/uri_A01_t01.dart
@@ -32,7 +32,7 @@ test(String method) async {
           request.uri.toString());
       return request.close();
     }).then((HttpClientResponse response) {
-      response.transform(utf8.decoder).listen((content) {});
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
       asyncEnd();
     });
 }

--- a/LibTest/io/HttpClientResponse/certificate_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/certificate_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isNull(response.certificate);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/connectionInfo_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/connectionInfo_A01_t01.dart
@@ -36,7 +36,7 @@ test(String method) async {
     Expect.isNotNull(response.connectionInfo);
     Expect.equals(localhost, response.connectionInfo.remoteAddress.address);
     Expect.equals(port, response.connectionInfo.remotePort);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A01_t01.dart
@@ -38,7 +38,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(helloWorld.length, response.contentLength);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A01_t02.dart
@@ -36,7 +36,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(0, response.contentLength);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A02_t01.dart
@@ -37,7 +37,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(-1, response.contentLength);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A02_t02.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A02_t02.dart
@@ -35,7 +35,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(0, response.contentLength, method);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A03_t01.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A03_t01.dart
@@ -38,7 +38,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(-1, response.contentLength);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/contentLength_A04_t01.dart
+++ b/LibTest/io/HttpClientResponse/contentLength_A04_t01.dart
@@ -41,7 +41,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(-1, response.contentLength);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/detachSocket_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/detachSocket_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
 
     });
     response.detachSocket().then((Socket socket) {

--- a/LibTest/io/HttpClientResponse/isRedirect_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/isRedirect_A01_t02.dart
@@ -49,7 +49,7 @@ test(String method, int statusCode) async {
   }).then((HttpClientResponse response) {
     Expect.isTrue(response.isRedirect);
     asyncEnd();
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
 
     });
   });

--- a/LibTest/io/HttpClientResponse/persistentConnection_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/persistentConnection_A01_t01.dart
@@ -37,7 +37,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isTrue(response.persistentConnection);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/persistentConnection_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/persistentConnection_A01_t02.dart
@@ -37,7 +37,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isFalse(response.persistentConnection);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/persistentConnection_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/persistentConnection_A02_t01.dart
@@ -37,7 +37,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isTrue(response.persistentConnection);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/persistentConnection_A02_t02.dart
+++ b/LibTest/io/HttpClientResponse/persistentConnection_A02_t02.dart
@@ -37,7 +37,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isTrue(response.persistentConnection);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/persistentConnection_A03_t01.dart
+++ b/LibTest/io/HttpClientResponse/persistentConnection_A03_t01.dart
@@ -40,7 +40,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isFalse(response.persistentConnection);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/reasonPhrase_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/reasonPhrase_A01_t01.dart
@@ -35,7 +35,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals("OK", response.reasonPhrase);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/reasonPhrase_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/reasonPhrase_A01_t02.dart
@@ -36,7 +36,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals("Reason-Phrase", response.reasonPhrase);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/reasonPhrase_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/reasonPhrase_A02_t01.dart
@@ -38,7 +38,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals("OK", response.reasonPhrase);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/redirect_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A01_t01.dart
@@ -55,7 +55,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirect_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A02_t01.dart
@@ -58,7 +58,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response.redirect().then((HttpClientResponse resp) {

--- a/LibTest/io/HttpClientResponse/redirect_A03_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A03_t01.dart
@@ -61,7 +61,7 @@ test(String method) async {
     request.headers.set(HttpHeaders.fromHeader, "From Dart with Love");
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirect_A04_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A04_t01.dart
@@ -65,7 +65,7 @@ test(String method) async {
     request.writeln(lily);
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirect_A05_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A05_t01.dart
@@ -59,7 +59,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirect_A05_t02.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A05_t02.dart
@@ -59,7 +59,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirect_A05_t03.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A05_t03.dart
@@ -59,7 +59,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx0", content);
     });
     response.redirect("GET", new Uri(path: "xxx")).then((HttpClientResponse resp) {

--- a/LibTest/io/HttpClientResponse/redirects_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A01_t01.dart
@@ -34,7 +34,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.isTrue(response.redirects.isEmpty);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/redirects_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A01_t02.dart
@@ -48,7 +48,7 @@ test(String method, int statusCode) async {
   }).then((HttpClientResponse response) {
     Expect.equals(1, response.redirects.length);
     Expect.equals("/yyy", response.redirects[0].location.path);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 

--- a/LibTest/io/HttpClientResponse/redirects_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t01.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A02_t02.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t02.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A02_t03.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t03.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A02_t04.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t04.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A02_t05.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t05.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A02_t06.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A02_t06.dart
@@ -41,7 +41,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response

--- a/LibTest/io/HttpClientResponse/redirects_A03_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A03_t01.dart
@@ -43,7 +43,7 @@ test(String method) async {
       .then((HttpClientRequest request) {
     return request.close();
   }).then((HttpClientResponse response) {
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals("xxx", content);
     });
     response.redirect("get", new Uri(path: "yyy")).then((

--- a/LibTest/io/HttpClientResponse/redirects_A04_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A04_t01.dart
@@ -49,7 +49,7 @@ test(String method, int maxRedirects, int status) async {
       Expect.equals("/${count++}", redirectInfo.location.path);
       Expect.equals(method.toUpperCase(), redirectInfo.method);
     }
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/statusCode_A01_t01.dart
+++ b/LibTest/io/HttpClientResponse/statusCode_A01_t01.dart
@@ -35,7 +35,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/statusCode_A01_t02.dart
+++ b/LibTest/io/HttpClientResponse/statusCode_A01_t02.dart
@@ -35,7 +35,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.accepted, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpClientResponse/statusCode_A02_t01.dart
+++ b/LibTest/io/HttpClientResponse/statusCode_A02_t01.dart
@@ -38,7 +38,7 @@ test(String method) async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {});
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
     asyncEnd();
   });
 }

--- a/LibTest/io/HttpServer/HttpServer.listenOn_A01_t01.dart
+++ b/LibTest/io/HttpServer/HttpServer.listenOn_A01_t01.dart
@@ -36,7 +36,7 @@ test() async {
   var response = await request.close();
   Expect.equals(HttpStatus.ok, response.statusCode);
 
-  response.transform(utf8.decoder).listen((content) {
+  response.cast<List<int>>().transform(utf8.decoder).listen((content) {
     Expect.equals(helloWorld, content);
     serverSocket.close();
   });

--- a/LibTest/io/HttpServer/autoCompress_A02_t01.dart
+++ b/LibTest/io/HttpServer/autoCompress_A02_t01.dart
@@ -44,7 +44,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/autoCompress_A02_t02.dart
+++ b/LibTest/io/HttpServer/autoCompress_A02_t02.dart
@@ -49,7 +49,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.isFalse(
           response.headers.value(HttpHeaders.contentEncodingHeader) == "gzip");
       Expect.equals(helloWorld, content);

--- a/LibTest/io/HttpServer/autoCompress_A02_t03.dart
+++ b/LibTest/io/HttpServer/autoCompress_A02_t03.dart
@@ -49,7 +49,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(gzip.decoder).transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(gzip.decoder).transform(utf8.decoder).listen((content) {
       Expect.isTrue(
           response.headers.value(HttpHeaders.contentEncodingHeader) == "gzip");
       Expect.equals(helloWorld, content);

--- a/LibTest/io/HttpServer/bind_A01_t01.dart
+++ b/LibTest/io/HttpServer/bind_A01_t01.dart
@@ -41,7 +41,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/bind_A01_t02.dart
+++ b/LibTest/io/HttpServer/bind_A01_t02.dart
@@ -40,7 +40,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/bind_A02_t01.dart
+++ b/LibTest/io/HttpServer/bind_A02_t01.dart
@@ -51,7 +51,7 @@ test() async {
       return request.close();
     }).then((HttpClientResponse response) {
       Expect.equals(HttpStatus.ok, response.statusCode);
-      response.transform(utf8.decoder).listen((content) {
+      response.cast<List<int>>().transform(utf8.decoder).listen((content) {
         Expect.equals(helloWorld, content);
         asyncEnd();
       });

--- a/LibTest/io/HttpServer/bind_A02_t02.dart
+++ b/LibTest/io/HttpServer/bind_A02_t02.dart
@@ -47,7 +47,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/bind_A02_t03.dart
+++ b/LibTest/io/HttpServer/bind_A02_t03.dart
@@ -49,7 +49,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/bind_A03_t01.dart
+++ b/LibTest/io/HttpServer/bind_A03_t01.dart
@@ -45,7 +45,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/close_A01_t01.dart
+++ b/LibTest/io/HttpServer/close_A01_t01.dart
@@ -39,7 +39,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       bool thrown = false;
       try {

--- a/LibTest/io/HttpServer/close_A02_t01.dart
+++ b/LibTest/io/HttpServer/close_A02_t01.dart
@@ -40,7 +40,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/close_A03_t01.dart
+++ b/LibTest/io/HttpServer/close_A03_t01.dart
@@ -40,7 +40,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/close_A04_t01.dart
+++ b/LibTest/io/HttpServer/close_A04_t01.dart
@@ -43,7 +43,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/close_A05_t01.dart
+++ b/LibTest/io/HttpServer/close_A05_t01.dart
@@ -43,7 +43,7 @@ test() async {
     return request.close();
   }).then((HttpClientResponse response) {
     Expect.equals(HttpStatus.ok, response.statusCode);
-    response.transform(utf8.decoder).listen((content) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((content) {
       Expect.equals(helloWorld, content);
       asyncEnd();
     });

--- a/LibTest/io/HttpServer/connectionsInfo_A01_t01.dart
+++ b/LibTest/io/HttpServer/connectionsInfo_A01_t01.dart
@@ -47,11 +47,11 @@ test() async {
       .parse("http://${InternetAddress.loopbackIPv4.address}:${server.port}");
   client.getUrl(uri).then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {});
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
   client.getUrl(uri).then((HttpClientRequest request) => request.close())
       .then((HttpClientResponse response) {
-        response.transform(utf8.decoder).listen((content) {});
+        response.cast<List<int>>().transform(utf8.decoder).listen((content) {});
   });
 }
 


### PR DESCRIPTION
In preparation for a change to HttpRequest and HttpClientResponse
whereby they'll implement `Stream<Uint8List>` rather than
`Stream<List<int>>`, this change casts those streams to
`Stream<List<int>>` before any calls to `transform()` those
streams.

This is a forwards-compatible change that should be a no-op for
existing usages.

dart-lang/sdk#36900
https://github.com/dart-lang/co19/issues/383