### PR TITLE
Fix a few remaining call-sites

### DIFF
--- a/LibTest/io/Datagram/data_A01_t01.dart
+++ b/LibTest/io/Datagram/data_A01_t01.dart
@@ -17,9 +17,9 @@ main() {
   Datagram datagram = new Datagram(new Uint8List(0), address, 80);
   Expect.listEquals([], datagram.data);
 
-  datagram.data = [1, 2, 3];
+  datagram.data = Uint8List.fromList([1, 2, 3]);
   Expect.listEquals([1, 2, 3], datagram.data);
 
-  datagram.data = [1000000, 220000, -13];
-  Expect.listEquals([1000000, 220000, -13], datagram.data);
+  datagram.data = Uint8List.fromList([255, 127, 33]);
+  Expect.listEquals([255, 127, 33], datagram.data);
 }

--- a/LibTest/io/HttpClientResponse/redirect_A05_t03.dart
+++ b/LibTest/io/HttpClientResponse/redirect_A05_t03.dart
@@ -68,7 +68,7 @@ test(String method) async {
       });
       resp.redirect("GET", new Uri(path: "xxx"), true).then(
           (HttpClientResponse resp2) {
-            resp2.transform(utf8.decoder).listen((content3) {
+            resp2.cast<List<int>>().transform(utf8.decoder).listen((content3) {
               Expect.equals("xxx2", content3);
               asyncEnd();
             });

--- a/LibTest/io/HttpClientResponse/redirects_A03_t01.dart
+++ b/LibTest/io/HttpClientResponse/redirects_A03_t01.dart
@@ -48,7 +48,7 @@ test(String method) async {
     });
     response.redirect("get", new Uri(path: "yyy")).then((
         HttpClientResponse resp2) {
-      resp2.transform(utf8.decoder).listen((content2) {
+      resp2.cast<List<int>>().transform(utf8.decoder).listen((content2) {
         Expect.equals("yyy", content2);
       });
       resp2.redirect("post", new Uri(path: "zzz")).then((
@@ -63,7 +63,7 @@ test(String method) async {
         Expect.equals("zzz", resp3.redirects[1].location.path);
         Expect.equals(200, resp3.redirects[1].statusCode);
 
-        resp3.transform(utf8.decoder).listen((content3) {
+        resp3.cast<List<int>>().transform(utf8.decoder).listen((content3) {
           Expect.equals("zzz", content3);
           asyncEnd();
         });


### PR DESCRIPTION
There were a few places where `.cast<List<int>>()` calls were
missed in #384 and #385, and likewise for `Datagram.data` in #382.

Note that I had to change one of the tests of `Datagram.data`, since
the existing test was setting invalid values as the data (signed
integers or integers that didn't fit in 8-bytes).

dart-lang/sdk#36900
https://github.com/dart-lang/co19/issues/381
https://github.com/dart-lang/co19/issues/383