### PR TITLE
Skip surrogates in decode test

### DIFF
--- a/LibTest/core/Uri/decodeComponent_A01_t02.dart
+++ b/LibTest/core/Uri/decodeComponent_A01_t02.dart
@@ -31,6 +31,10 @@ manuallyEncode(String s) => s.runes
 
 main() {
   for (int i = 0; i < 65279; i++) {
+    if ((i & 0xF800) == 0xD800) {
+      // Skip surrogates.
+      continue;
+    }
     String char = new String.fromCharCode(i);
     String encoded = Uri.encodeComponent(char);
     Expect.equals(char, Uri.decodeComponent(encoded), "Failed for $i");


### PR DESCRIPTION
It is not legal to encode surrogates in UTF-8. This has so far been possible, but this is likely [going away](https://github.com/dart-lang/sdk/issues/41100). Thus, tests should not do it.