### PR TITLE
Remove extra `be`

### DIFF
--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A03_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A05_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A06_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A06.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A07_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A07.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A08_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A08.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A09_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A09_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A09.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A10_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A10_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A10.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A11_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A11.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A12_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A12.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A13_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A13_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A13.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A14_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A14_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A14.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A15_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A15_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A15.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A16_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A16_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A16.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A17_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A17_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A17.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A18_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_global_variable_A18_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A18.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_global_variable_A01_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_global_variable_A02_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A01_t01.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A02_t01.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A03_t01.dart
@@ -13,7 +13,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A02_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A03_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A05_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_global_variable_A06_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A06.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_top_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_top_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_type_variable_bound_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A01_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A02_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A03_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A04_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A05_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A01_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A02_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A03_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A04_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A11_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A11.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A12_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A12.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A13_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A13_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A13.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A14_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A14_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A14.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A21_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A21.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A22_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A22.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A23_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A23.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A24_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A24_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A24.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A31_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A31.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A32_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A32.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A33_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A33.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A34_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A34_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A34.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A41_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A41.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A42_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A42.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A43_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A43.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A44_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_global_variable_A44_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A44.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A02_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A03_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A01_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A02_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A03_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A01_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A02_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_global_variable_A03_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A01_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A04_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_global_variable_A05_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A02_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A03_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A02_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_global_variable_A03_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/global_variable_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/global_variable_x01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 
 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A03_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A05_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A06_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A06.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A07_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A07.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A08_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A08.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A09_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A09_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A09.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A10_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A10_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A10.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A11_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A11.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A12_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A12.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A13_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A13_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A13.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A14_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A14_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A14.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A15_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A15_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A15.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A16_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A16_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A16.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A17_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A17_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A17.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A18_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_global_variable_A18_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A18.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/interface_compositionality_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/interface_compositionality_global_variable_A01_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/interface_compositionality_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/interface_compositionality_global_variable_A02_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A01_t01.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A02_t01.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A03_t01.dart
@@ -13,7 +13,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_legacy_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_legacy_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_legacy_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_legacy_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A02_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A03_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A05_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_global_variable_A06_t01.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A06.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_nullable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_nullable_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_promoted_variable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_promoted_variable_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_top_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_top_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_type_variable_bound_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_type_variable_bound_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_type_variable_bound_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A01_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A02_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A03_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A04_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A05_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A01_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A02_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A03_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A04_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A11_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A11.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A12_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A12.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A13_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A13_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A13.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A14_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A14_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A14.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A21_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A21.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A22_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A22.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A23_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A23.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A24_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A24_t01.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A24.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A31_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A31.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A32_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A32.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A33_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A33.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A34_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A34_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A34.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A41_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A41.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A42_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A42.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A43_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A43.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A44_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_global_variable_A44_t01.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A44.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A02_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A03_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A01_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A02_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A03_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_global_variable_A04_t01.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A01_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A02_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_global_variable_A03_t01.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A01_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A02_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A03_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A04_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_global_variable_A05_t01.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_promoted_variable_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_promoted_variable_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_promoted_variable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A01_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A02_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A03_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_global_variable_A04_t01.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A02_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_global_variable_A03_t01.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_global_variable_A01_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from type_variable_reflexivity_1_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_global_variable_A02_t01.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from type_variable_reflexivity_1_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/test_cases/global_variable_x01.dart
+++ b/LanguageFeatures/Subtyping/static/test_cases/global_variable_x01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the to global variable of type T1
+/// of T0 can be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 
 


### PR DESCRIPTION
This PR replaces

```dart
/// of T0 can be be assigned to the to global variable of type T1
```
with
```dart
/// of T0 can be assigned to the to global variable of type T1
```