### PR TITLE
Remove extra `be`

### DIFF
--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A03_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A05_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A06_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A06.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A07_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A07.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A08_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A08.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A09_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A09_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A09.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A10_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A10_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A10.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A11_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A11.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A12_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A12.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A13_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A13_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A13.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A14_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A14_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A14.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A15_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A15_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A15.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A16_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A16_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A16.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A17_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A17_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A17.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A18_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_function_class_member_A18_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A18.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_class_member_A01_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_class_member_A02_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A01_t03.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A02_t03.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A03_t03.dart
@@ -13,7 +13,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A02_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A03_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A05_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_null_class_member_A06_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A06.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_top_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_top_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_type_variable_bound_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A01_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A02_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A03_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A04_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A11_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A11.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A12_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A12.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A13_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A13_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A13.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A14_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A14_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A14.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A21_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A21.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A22_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A22.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A23_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A23.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A24_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A24_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A24.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A31_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A31.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A32_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A32.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A33_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A33.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A34_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A34_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A34.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A41_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A41.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A42_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A42.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A43_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A43.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A44_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_class_member_A44_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A44.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A02_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A03_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/reflexivity_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A01_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A02_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A03_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A01_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A02_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_nullable_class_member_A03_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A01_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A04_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_class_member_A05_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A05.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A02_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A03_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_top_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A04.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A01.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A02_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A02.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_class_member_A03_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A03.dart and 

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_x03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_x03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 
 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A03_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A05_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A06_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A06.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A07_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A07.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A08_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A08.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A09_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A09_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A09.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A10_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A10_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A10.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A11_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A11.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A12_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A12.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A13_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A13_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A13.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A14_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A14_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A14.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A15_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A15_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A15.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A16_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A16_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A16.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A17_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A17_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A17.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A18_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_function_class_member_A18_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from function_type_function_A18.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/interface_compositionality_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/interface_compositionality_class_member_A01_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/interface_compositionality_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/interface_compositionality_class_member_A02_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from interface_compositionality_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A01_t03.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A02_t03.dart
@@ -13,7 +13,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A03_t03.dart
@@ -13,7 +13,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_FutureOr_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_legacy_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_legacy_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_legacy_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_legacy_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_legacy_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A02_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A03_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A05_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_null_class_member_A06_t03.dart
@@ -14,7 +14,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_null_A06.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_nullable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_nullable_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_promoted_variable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_promoted_variable_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_promoted_variable_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_top_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_top_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/left_type_variable_bound_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/left_type_variable_bound_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from left_type_variable_bound_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from named_function_types_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A01_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A02_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A03_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A04_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A11_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A11.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A12_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A12.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A13_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A13_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A13.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A14_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A14_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A14.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A21_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A21.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A22_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A22.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A23_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A23.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A24_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A24_t03.dart
@@ -20,7 +20,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A24.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A31_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A31.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A32_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A32.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A33_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A33.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A34_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A34_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A34.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A41_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A41.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A42_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A42.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A43_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A43.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A44_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/positional_function_types_class_member_A44_t03.dart
@@ -19,7 +19,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from positional_function_types_A44.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A02_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A03_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/reflexivity_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from reflexivity_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A01_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A02_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A03_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_FutureOr_class_member_A04_t03.dart
@@ -14,7 +14,7 @@
 /// @author ngl@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_FutureOr_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A01_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A02_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_nullable_class_member_A03_t03.dart
@@ -15,7 +15,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_nullable_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A01_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A02_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A03_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A04_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_object_class_member_A05_t03.dart
@@ -18,7 +18,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_object_A05.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_promoted_variable_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_promoted_variable_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_promoted_variable_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A01_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A02_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A03_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/right_top_class_member_A04_t03.dart
@@ -10,7 +10,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from right_top_A04.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A02_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/super_interface_class_member_A03_t03.dart
@@ -12,7 +12,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from super_interface_A03.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_class_member_A01_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from type_variable_reflexivity_1_A01.dart and 

--- a/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/type_variable_reflexivity_1_class_member_A02_t03.dart
@@ -11,7 +11,7 @@
 /// @author sgrekhov@unipro.ru
 ///
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
 /// This test is generated from type_variable_reflexivity_1_A02.dart and 

--- a/LanguageFeatures/Subtyping/static/test_cases/class_member_x03.dart
+++ b/LanguageFeatures/Subtyping/static/test_cases/class_member_x03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @description Check that if type T0 is a subtype of a type T1, then instance
-/// of T0 can be be assigned to the mixin member of type T1
+/// of T0 can be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 
 


### PR DESCRIPTION
Replace

```dart
/// of T0 can be be assigned to the mixin member of type T1
```
with
```dart
/// of T0 can be assigned to the mixin member of type T1
```