### PR TITLE
Avoid sender making more progress than the receiver in Isolate/pause_…

### DIFF
--- a/LibTest/isolate/Isolate/pause_A01_t01.dart
+++ b/LibTest/isolate/Isolate/pause_A01_t01.dart
@@ -15,6 +15,7 @@
 ///
 /// @author a.semenov@unipro.ru
 
+import "dart:io";
 import "dart:isolate";
 import "dart:math";
 import "../../../Utils/expect.dart";
@@ -27,6 +28,10 @@ entryPoint(List<SendPort> sendPorts) {
   while (true) {
     s = -s + random.nextInt(100);
     sendPorts[1].send(s);
+
+    // Synchronous sleep does not yield to the message loop, so the pause
+    // doesn't take effect.
+    sleep(const Duration(milliseconds: 1));
   }
 }
 
@@ -45,7 +50,7 @@ test() async {
   // check that messages are received from paused isolate
   int count = 0;
   await for (var _ in receivePort2) {
-    if (count++ == 1000000) {
+    if (count++ == 100) {
       break;
     }
   }

--- a/LibTest/isolate/Isolate/pause_A01_t02.dart
+++ b/LibTest/isolate/Isolate/pause_A01_t02.dart
@@ -16,6 +16,7 @@
 ///
 /// @author a.semenov@unipro.ru
 
+import "dart:io";
 import "dart:isolate";
 import "dart:math";
 import "../../../Utils/expect.dart";
@@ -28,6 +29,10 @@ entryPoint(List<SendPort> sendPorts) {
   while (true) {
     s = -s + random.nextInt(100);
     sendPorts[1].send(s);
+
+    // Synchronous sleep does not yield to the message loop, so the pause
+    // doesn't take effect.
+    sleep(const Duration(milliseconds: 1));
   }
 }
 
@@ -46,7 +51,7 @@ test() async {
   // check that messages are received from paused isolate
   int count = 0;
   await for (var _ in receivePort2) {
-    if (count++ == 1000000) {
+    if (count++ == 100) {
       break;
     }
   }


### PR DESCRIPTION
…A01_t01/2.

In these tests, one isolate continuously sends messages to another without back pressure. If the system is loaded, the sender may send messages at a faster rate then the receiver can process them and the test can time out before receiver processes enough messages to end the test. Instead of processing a large number of messages to ensure some of them would happen after the pause request, use synchronous sleeps.