### PR TITLE
Added invocation of functions doing attach

### DIFF
--- a/LanguageFeatures/FinalizationRegistry/ffi/Finalizer/attach_A02_t02.dart
+++ b/LanguageFeatures/FinalizationRegistry/ffi/Finalizer/attach_A02_t02.dart
@@ -25,6 +25,7 @@ void attachToFinalizer() {
 }
 
 main() async {
+  attachToFinalizer();
   await triggerGcWithDelay();
   await triggerGcWithDelay();
   triggerGc();

--- a/LanguageFeatures/FinalizationRegistry/ffi/Finalizer/attach_A04_t11.dart
+++ b/LanguageFeatures/FinalizationRegistry/ffi/Finalizer/attach_A04_t11.dart
@@ -32,8 +32,8 @@ void attachToFinalizer1() {
   finalizer.attach(object2, "Object2", detach: d);
 }
 
-
 main() async {
+  attachToFinalizer1();
   for (int i = 0; i < 10; i++) {
     await triggerGcWithDelay();
     Expect.setEquals({"Object1", "Object2"}, finalizerTokens);


### PR DESCRIPTION
Add missing invocations of `attachToFinalizer1` and `attachToFinalizer` to LanguageFeatures/FinalizationRegistry/ffi/Finalizer/attach_*.dart.