### PR TITLE
Remove unused and uninitialized non-nullable field from a test

### DIFF
--- a/LanguageFeatures/Super-parameters/grammar_A02_t01.dart
+++ b/LanguageFeatures/Super-parameters/grammar_A02_t01.dart
@@ -29,7 +29,6 @@ class S {
 }
 
 class C extends S {
-  int i;
   C(super.s1) : super(super.s1);
 //                    ^^^^^^^^
 // [analyzer] unspecified


### PR DESCRIPTION
The code of the test contains a field that isn't required for the purpose of the test, and yet it causes an additional compile-time error because it is uninitialized and non-nullable.