### PR TITLE
Add expected CFE errors on concrete 'index' members

### DIFF
--- a/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t01.dart
+++ b/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t01.dart
@@ -27,6 +27,8 @@ class C implements Enum {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 42;
+//        ^^^^^
+// [cfe] unspecified
 }
 
 main() {

--- a/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t04.dart
+++ b/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t04.dart
@@ -32,6 +32,8 @@ class C1 implements A {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 42;
+//        ^^^^^
+// [cfe] unspecified
   int foo() => 42;
 }
 
@@ -40,6 +42,8 @@ class C2 extends A {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 42;
+//        ^^^^^
+// [cfe] unspecified
   int foo() => 42;
 }
 

--- a/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t06.dart
+++ b/LanguageFeatures/Enhanced-Enum/implementing_enum_A01_t06.dart
@@ -33,6 +33,8 @@ class C1 implements M1 {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 1;
+//        ^^^^^
+// [cfe] unspecified
 }
 
 class C2 implements M2 {
@@ -40,6 +42,8 @@ class C2 implements M2 {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 2;
+//        ^^^^^
+// [cfe] unspecified
 }
 
 class C3 with M3 {
@@ -47,6 +51,8 @@ class C3 with M3 {
 // [analyzer] unspecified
 // [cfe] unspecified
   int get index => 3;
+//        ^^^^^
+// [cfe] unspecified
 }
 
 main() {


### PR DESCRIPTION
This PR adds expected errors that the CFE reports on concrete members named `index` in implementers of the `Enum` interface. The discrepancy between the CFE and the Analyzer in this case is that the Analyzer doesn't report the error on `index` if the implementer is concrete and, therefore, already erroneous.