### PR TITLE
Fix type of onError.

### DIFF
--- a/LibTest/async/Stream/handleError_A06_t01.test.dart
+++ b/LibTest/async/Stream/handleError_A06_t01.test.dart
@@ -12,7 +12,7 @@ library handleError_A06_t01;
 import "dart:async";
 import "../../../Utils/expect.dart";
 
-void check<T>(Stream<T> stream, Function? onError(T event), bool test(error)) {
+void check<T>(Stream<T> stream, Function? onError(dynamic event), bool test(error)) {
   Expect.equals(stream.isBroadcast, stream.handleError(onError).isBroadcast);
   Expect.equals(stream.isBroadcast, stream.handleError(onError, test:test).isBroadcast);
 }


### PR DESCRIPTION
The function passed to Stream.handleError needs to accept either a
single argument of type `Object`, or an `Object` and a `StackTrace`.
Since this can't be expressed by the type system, it's checked at
runtime.  As a result, the `check` function (as previously written)
would fail if ever instantiated with a type `T` that was narrower than
`Object`.

Prior to implementation of
https://github.com/dart-lang/language/issues/731 (improved inference
for fold etc.), this worked fine, because type inference always
supplied an argument type of `dynamic` or `Object` for the function
literals passed to `check`.  However, with the inference improvement
enabled, it starts to infer other types, causing runtime failures.

The correct fix is to give the `event` argument of `onError` an
appropriate type.