### PR TITLE
Fixes #959. Fix flaky test. Enable user-select for Safari

### DIFF
--- a/LibTest/html/Element/isContentEditable_A01_t01.dart
+++ b/LibTest/html/Element/isContentEditable_A01_t01.dart
@@ -28,9 +28,15 @@ main() {
 
   x = new Element.html('<div contenteditable="true"></div>',
       treeSanitizer: new NullTreeSanitizer());
+  // Enable user-select CSS for Safari
+  x.style.setProperty("-webkit-user-select", "text");
+  x.style.setProperty("user-select", "text");
   Expect.isTrue(x.isContentEditable, 'explicit true');
 
   x = new Element.html('<div contenteditable=""></div>',
       treeSanitizer: new NullTreeSanitizer());
+  // Enable user-select CSS for Safari
+  x.style.setProperty("-webkit-user-select", "text");
+  x.style.setProperty("user-select", "text");
   Expect.isTrue(x.isContentEditable, 'empty string is true');
 }


### PR DESCRIPTION
I'm unable to test this fix. But, I believe that it may help. Safari has the `user-select` CSS setting as `none` by default. This fix enables it. Probably, the test is flaky because Safary has different settings on differenf bots. Where this setting is enabled the test completes succesfully, where not it fails.

@athomas is there a way to test this PR?