### PR TITLE
#1405. Don't use deprecated API in co19 tests. Update generated files

### DIFF
--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t01.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 namedArgumentsFunc1(C0<U0, U1, U2> t1, {C0<U0, U1, U2> t2 = t1Default}) {}
 positionalArgumentsFunc1(C0<U0, U1, U2> t1, [C0<U0, U1, U2> t2 = t1Default]) {}
 
@@ -97,93 +96,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -191,35 +190,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<C0<U0, U1, U2>>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<C0<U0, U1, U2>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<C0<U0, U1, U2>>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<C0<U0, U1, U2>>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<C0<U0, U1, U2>>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<C0<U0, U1, U2>>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t02.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   C0<U0, U1, U2> m;
 
@@ -71,87 +70,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -176,47 +175,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -224,56 +223,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -283,32 +282,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<C0<U0, U1, U2>>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<C0<U0, U1, U2>>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_arguments_binding_fail_A01_t03.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(C0<U0, U1, U2> val) {}
   void superTestPositioned(C0<U0, U1, U2> val, [C0<U0, U1, U2> val2 = t1Default]) {}
@@ -58,87 +57,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -154,63 +153,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -218,31 +217,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -252,27 +251,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<C0<U0, U1, U2>>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<C0<U0, U1, U2>>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t01.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class ClassMemberTestStatic {
   static C0<U0, U1, U2> s = t1Default;
 
@@ -146,75 +145,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -222,46 +219,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<C0<U0, U1, U2>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<C0<U0, U1, U2>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<C0<U0, U1, U2>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<C0<U0, U1, U2>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<C0<U0, U1, U2>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t02.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class ClassMemberSuper1_t02 {
   C0<U0, U1, U2> m = t1Default;
 
@@ -114,49 +113,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<C0<U0, U1, U2>>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_class_member_fail_A01_t03.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class ClassMemberSuper1_t03 {
   C0<U0, U1, U2> m = t1Default;
 
@@ -86,31 +85,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<C0<U0, U1, U2>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<C0<U0, U1, U2>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<C0<U0, U1, U2>>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<C0<U0, U1, U2>>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_global_variable_fail_A01_t01.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -68,21 +67,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_local_variable_fail_A01_t01.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -69,21 +68,21 @@ main() {
 
   Expect.throws(() {
     C0<U0, U1, U2> t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/interface_compositionality_fail_return_value_fail_A01_t01.dart
@@ -44,7 +44,6 @@ const t1Default = const C0<U0, U1, U2>();
 
 
 
-
 C0<U0, U1, U2> returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -65,29 +64,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<C0<U0, U1, U2>>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<C0<U0, U1, U2>>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t01.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 namedArgumentsFunc1(Future? t1, {Future? t2 = t1Default}) {}
 positionalArgumentsFunc1(Future? t1, [Future? t2 = t1Default]) {}
 
@@ -87,93 +86,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -181,35 +180,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<Future?>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<Future?>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Future?>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Future?>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<Future?>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Future?>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t02.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   Future? m;
 
@@ -61,87 +60,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -166,47 +165,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,56 +213,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -273,32 +272,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Future?>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<Future?>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A01_t03.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(Future? val) {}
   void superTestPositioned(Future? val, [Future? val2 = t1Default]) {}
@@ -48,87 +47,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -144,63 +143,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -208,31 +207,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -242,27 +241,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Future?>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<Future?>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -92,93 +91,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -186,35 +185,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t02.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -66,87 +65,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -171,47 +170,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -219,56 +218,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -278,32 +277,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_arguments_binding_fail_A02_t03.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -53,87 +52,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -149,63 +148,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -213,31 +212,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -247,27 +246,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t01.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberTestStatic {
   static Future? s = t1Default;
 
@@ -136,75 +135,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -212,46 +209,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Future?>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Future?>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Future?>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Future?>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Future?>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t02.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberSuper1_t02 {
   Future? m = t1Default;
 
@@ -104,49 +103,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<Future?>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Future?>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A01_t03.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberSuper1_t03 {
   Future? m = t1Default;
 
@@ -76,31 +75,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<Future?>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Future?>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Future?>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Future?>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -141,75 +140,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -217,46 +214,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t02.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -109,49 +108,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_class_member_fail_A02_t03.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -81,31 +80,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_global_variable_fail_A01_t01.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -58,21 +57,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_global_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_global_variable_fail_A02_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -63,21 +62,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_local_variable_fail_A01_t01.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -59,21 +58,21 @@ main() {
 
   Expect.throws(() {
     Future? t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_local_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_local_variable_fail_A02_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -64,21 +63,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_return_value_fail_A01_t01.dart
@@ -34,7 +34,6 @@ const t1Default = null;
 
 
 
-
 Future? returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -55,29 +54,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<Future?>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<Future?>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_return_value_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_FutureOr_fail_return_value_fail_A02_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -60,29 +59,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t01.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 namedArgumentsFunc1(String t1, {String t2 = t1Default}) {}
 positionalArgumentsFunc1(String t1, [String t2 = t1Default]) {}
 
@@ -86,93 +85,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -180,35 +179,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<String>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<String>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<String>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<String>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<String>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<String>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t02.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   String m;
 
@@ -60,87 +59,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -165,47 +164,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -213,56 +212,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -272,32 +271,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<String>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<String>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A01_t03.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(String val) {}
   void superTestPositioned(String val, [String val2 = t1Default]) {}
@@ -47,87 +46,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -143,63 +142,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -207,31 +206,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -241,27 +240,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<String>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<String>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 namedArgumentsFunc1(A t1, {A t2 = t1Default}) {}
 positionalArgumentsFunc1(A t1, [A t2 = t1Default]) {}
 
@@ -90,93 +89,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -184,35 +183,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<A>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<A>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<A>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<A>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<A>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<A>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t02.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   A m;
 
@@ -64,87 +63,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -169,47 +168,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -217,56 +216,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -276,32 +275,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<A>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<A>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A02_t03.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(A val) {}
   void superTestPositioned(A val, [A val2 = t1Default]) {}
@@ -51,87 +50,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -147,63 +146,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -211,31 +210,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -245,27 +244,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<A>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<A>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t01.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 namedArgumentsFunc1(Null t1, {Null t2 = t1Default}) {}
 positionalArgumentsFunc1(Null t1, [Null t2 = t1Default]) {}
 
@@ -86,93 +85,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -180,35 +179,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<Null>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<Null>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Null>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Null>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<Null>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Null>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t02.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   Null m;
 
@@ -60,87 +59,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -165,47 +164,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -213,56 +212,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -272,32 +271,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Null>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<Null>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_arguments_binding_fail_A03_t03.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(Null val) {}
   void superTestPositioned(Null val, [Null val2 = t1Default]) {}
@@ -47,87 +46,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -143,63 +142,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -207,31 +206,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -241,27 +240,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Null>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<Null>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t01.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class ClassMemberTestStatic {
   static String s = t1Default;
 
@@ -135,75 +134,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -211,46 +208,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<String>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<String>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<String>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<String>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<String>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t02.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class ClassMemberSuper1_t02 {
   String m = t1Default;
 
@@ -103,49 +102,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<String>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<String>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A01_t03.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class ClassMemberSuper1_t03 {
   String m = t1Default;
 
@@ -75,31 +74,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<String>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<String>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<String>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<String>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class ClassMemberTestStatic {
   static A s = t1Default;
 
@@ -139,75 +138,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -215,46 +212,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<A>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<A>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<A>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<A>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<A>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t02.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class ClassMemberSuper1_t02 {
   A m = t1Default;
 
@@ -107,49 +106,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<A>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<A>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A02_t03.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class ClassMemberSuper1_t03 {
   A m = t1Default;
 
@@ -79,31 +78,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<A>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<A>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<A>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<A>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t01.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberTestStatic {
   static Null s = t1Default;
 
@@ -135,75 +134,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -211,46 +208,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Null>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Null>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Null>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Null>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Null>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t02.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberSuper1_t02 {
   Null m = t1Default;
 
@@ -103,49 +102,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<Null>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Null>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_class_member_fail_A03_t03.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class ClassMemberSuper1_t03 {
   Null m = t1Default;
 
@@ -75,31 +74,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<Null>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Null>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Null>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Null>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A01_t01.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -57,21 +56,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -61,21 +60,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_global_variable_fail_A03_t01.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -57,21 +56,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A01_t01.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -58,21 +57,21 @@ main() {
 
   Expect.throws(() {
     String t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -62,21 +61,21 @@ main() {
 
   Expect.throws(() {
     A t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_local_variable_fail_A03_t01.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -58,21 +57,21 @@ main() {
 
   Expect.throws(() {
     Null t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A01_t01.dart
@@ -33,7 +33,6 @@ const t1Default = "Lily was here";
 
 
 
-
 String returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -54,29 +53,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<String>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<String>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const A();
 
 
 
-
 A returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -58,29 +57,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<A>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<A>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_legacy_fail_return_value_fail_A03_t01.dart
@@ -33,7 +33,6 @@ const t1Default = null;
 
 
 
-
 Null returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -54,29 +53,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<Null>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<Null>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -92,93 +91,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -186,35 +185,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t02.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -66,87 +65,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -171,47 +170,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -219,56 +218,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -278,32 +277,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A01_t03.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -53,87 +52,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -149,63 +148,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -213,31 +212,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -247,27 +246,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 namedArgumentsFunc1(T1? t1, {T1? t2 = t1Default}) {}
 positionalArgumentsFunc1(T1? t1, [T1? t2 = t1Default]) {}
 
@@ -90,93 +89,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -184,35 +183,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1?>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1?>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1?>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1?>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1?>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1?>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t02.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1? m;
 
@@ -64,87 +63,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -169,47 +168,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -217,56 +216,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -276,32 +275,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1?>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1?>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_arguments_binding_fail_A02_t03.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1? val) {}
   void superTestPositioned(T1? val, [T1? val2 = t1Default]) {}
@@ -51,87 +50,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -147,63 +146,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -211,31 +210,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -245,27 +244,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1?>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1?>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -141,75 +140,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -217,46 +214,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t02.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -109,49 +108,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A01_t03.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -81,31 +80,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberTestStatic {
   static T1? s = t1Default;
 
@@ -139,75 +138,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -215,46 +212,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1?>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1?>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1?>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1?>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1?>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t02.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1? m = t1Default;
 
@@ -107,49 +106,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1?>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1?>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_class_member_fail_A02_t03.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1? m = t1Default;
 
@@ -79,31 +78,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1?>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1?>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1?>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1?>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_global_variable_fail_A01_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -63,21 +62,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_global_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_global_variable_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -61,21 +60,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_local_variable_fail_A01_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -64,21 +63,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_local_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_local_variable_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -62,21 +61,21 @@ main() {
 
   Expect.throws(() {
     T1? t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_return_value_fail_A01_t01.dart
@@ -39,7 +39,6 @@ const t1Default = const T1();
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -60,29 +59,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_return_value_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_nullable_fail_return_value_fail_A02_t01.dart
@@ -37,7 +37,6 @@ const t1Default = const T1();
 
 
 
-
 T1? returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -58,29 +57,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1?>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1?>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t01.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -89,93 +88,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -183,35 +182,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t02.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -63,87 +62,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -168,47 +167,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -216,56 +215,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -275,32 +274,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_arguments_binding_fail_A01_t03.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -50,87 +49,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -146,63 +145,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -210,31 +209,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -244,27 +243,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t01.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -138,75 +137,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -214,46 +211,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t02.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -106,49 +105,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_class_member_fail_A01_t03.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -78,31 +77,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_global_variable_fail_A01_t01.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -60,21 +59,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_local_variable_fail_A01_t01.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -61,21 +60,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/left_type_variable_bound_fail_return_value_fail_A01_t01.dart
@@ -36,7 +36,6 @@ const t1Default = const T1();
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -57,29 +56,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -109,93 +108,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -203,35 +202,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t02.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -83,87 +82,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -188,47 +187,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -236,56 +235,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -295,32 +294,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t03.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -70,87 +69,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -166,63 +165,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -230,31 +229,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -264,27 +263,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -118,93 +117,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -212,6 +211,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t02.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -92,87 +91,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -197,47 +196,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -245,56 +244,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t03.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -79,87 +78,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -175,63 +174,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -239,31 +238,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -110,93 +109,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -204,6 +203,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t02.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -84,87 +83,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -189,47 +188,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -237,56 +236,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t03.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -71,87 +70,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -167,63 +166,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -231,31 +230,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -146,93 +145,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -240,6 +239,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t02.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -120,87 +119,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -225,47 +224,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -273,56 +272,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t03.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -107,87 +106,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -203,63 +202,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -267,31 +266,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -128,93 +127,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -222,6 +221,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t02.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -102,87 +101,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -207,47 +206,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -255,56 +254,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t03.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -89,87 +88,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -185,63 +184,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -249,31 +248,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -111,93 +110,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -205,35 +204,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t02.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -85,87 +84,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -190,47 +189,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -238,56 +237,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -297,32 +296,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t03.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -72,87 +71,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -168,63 +167,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -232,31 +231,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -266,27 +265,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -146,93 +145,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -240,6 +239,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t02.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -120,87 +119,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -225,47 +224,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -273,56 +272,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t03.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -107,87 +106,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -203,63 +202,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -267,31 +266,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -128,93 +127,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -222,6 +221,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t02.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -102,87 +101,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -207,47 +206,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -255,56 +254,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t03.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -89,87 +88,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -185,63 +184,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -249,31 +248,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -109,93 +108,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -203,35 +202,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t02.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -83,87 +82,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -188,47 +187,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -236,56 +235,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -295,32 +294,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t03.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -70,87 +69,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -166,63 +165,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -230,31 +229,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -264,27 +263,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -143,93 +142,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -237,6 +236,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t02.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -117,87 +116,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -222,47 +221,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -270,56 +269,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t03.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -104,87 +103,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -200,63 +199,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -264,31 +263,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -127,93 +126,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -221,6 +220,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t02.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -101,87 +100,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -206,47 +205,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -254,56 +253,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t03.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -88,87 +87,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -184,63 +183,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -248,31 +247,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -116,93 +115,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -210,6 +209,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t02.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -90,87 +89,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -195,47 +194,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -243,56 +242,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t03.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -77,87 +76,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -173,63 +172,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -237,31 +236,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -143,93 +142,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -237,6 +236,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t02.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -117,87 +116,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -222,47 +221,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -270,56 +269,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t03.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -104,87 +103,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -200,63 +199,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -264,31 +263,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -127,93 +126,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -221,6 +220,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t02.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -101,87 +100,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -206,47 +205,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -254,56 +253,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t03.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -88,87 +87,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -184,63 +183,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -248,31 +247,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -158,75 +157,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -234,46 +231,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t02.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -126,49 +125,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t03.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -98,31 +97,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t01.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -167,75 +166,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t02.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -135,25 +134,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t03.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -107,16 +106,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t01.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -159,75 +158,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t02.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -127,25 +126,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t03.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -99,16 +98,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -195,75 +194,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t02.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -163,25 +162,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t03.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -135,16 +134,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -177,75 +176,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t02.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -145,25 +144,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t03.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -117,16 +116,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t01.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -160,75 +159,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -236,46 +233,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t02.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -128,49 +127,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t03.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -100,31 +99,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -195,75 +194,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t02.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -163,25 +162,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t03.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -135,16 +134,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -177,75 +176,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t02.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -145,25 +144,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t03.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -117,16 +116,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -158,75 +157,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -234,46 +231,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t02.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -126,49 +125,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t03.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -98,31 +97,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -192,75 +191,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t02.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -160,25 +159,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t03.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -132,16 +131,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -176,75 +175,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t02.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -144,25 +143,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t03.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -116,16 +115,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t01.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -165,75 +164,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t02.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -133,25 +132,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t03.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -105,16 +104,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -192,75 +191,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t02.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -160,25 +159,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t03.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -132,16 +131,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -176,75 +175,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t02.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -144,25 +143,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t03.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -116,16 +115,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -80,21 +79,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -89,22 +88,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -81,22 +80,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -117,22 +116,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -99,22 +98,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -82,21 +81,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -117,22 +116,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -99,22 +98,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -80,21 +79,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -114,22 +113,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -98,22 +97,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -87,22 +86,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -114,22 +113,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -98,22 +97,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -81,21 +80,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -90,22 +89,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -82,22 +81,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -118,22 +117,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -100,22 +99,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -83,21 +82,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -118,22 +117,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -100,22 +99,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -81,21 +80,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -115,22 +114,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -99,22 +98,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -88,22 +87,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -115,22 +114,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -99,22 +98,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A11_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -77,29 +76,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A12_t01.dart
@@ -65,7 +65,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -86,20 +85,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A21_t01.dart
@@ -57,7 +57,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -78,20 +77,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A22_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -114,20 +113,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A23_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -96,20 +95,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A31_t01.dart
@@ -58,7 +58,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -79,29 +78,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A32_t01.dart
@@ -93,7 +93,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -114,20 +113,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A33_t01.dart
@@ -75,7 +75,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -96,20 +95,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A41_t01.dart
@@ -56,7 +56,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -77,29 +76,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A42_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -111,20 +110,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A43_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -95,20 +94,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A51_t01.dart
@@ -63,7 +63,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -84,20 +83,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A52_t01.dart
@@ -90,7 +90,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -111,20 +110,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A53_t01.dart
@@ -74,7 +74,6 @@ const t1Default = t1Func;
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -95,20 +94,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -105,93 +104,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -199,35 +198,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -79,87 +78,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -184,47 +183,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -232,56 +231,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -291,32 +290,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A01_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -66,87 +65,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -162,63 +161,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -226,31 +225,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -260,27 +259,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t01.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -106,93 +105,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -200,35 +199,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t02.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -80,87 +79,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -185,47 +184,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -233,56 +232,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -292,32 +291,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A02_t03.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -67,87 +66,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -163,63 +162,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -227,31 +226,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -261,27 +260,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -105,93 +104,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -199,35 +198,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -79,87 +78,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -184,47 +183,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -232,56 +231,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -291,32 +290,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A03_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -66,87 +65,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -162,63 +161,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -226,31 +225,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -260,27 +259,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -105,93 +104,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -199,35 +198,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -79,87 +78,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -184,47 +183,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -232,56 +231,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -291,32 +290,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A04_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -66,87 +65,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -162,63 +161,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -226,31 +225,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -260,27 +259,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -135,93 +134,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -229,6 +228,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -109,87 +108,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,47 +213,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -262,56 +261,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A05_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -96,87 +95,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -192,63 +191,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -256,31 +255,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -135,93 +134,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -229,6 +228,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -109,87 +108,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,47 +213,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -262,56 +261,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A06_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -96,87 +95,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -192,63 +191,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -256,31 +255,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -135,93 +134,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -229,6 +228,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -109,87 +108,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,47 +213,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -262,56 +261,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A07_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -96,87 +95,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -192,63 +191,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -256,31 +255,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t01.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -133,93 +132,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -227,6 +226,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t02.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -107,87 +106,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -212,47 +211,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -260,56 +259,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A08_t03.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -94,87 +93,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -190,63 +189,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -254,31 +253,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -108,93 +107,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -202,35 +201,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t02.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -82,87 +81,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -187,47 +186,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -235,56 +234,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -294,32 +293,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A11_t03.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -69,87 +68,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -165,63 +164,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -229,31 +228,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -263,27 +262,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -136,93 +135,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -230,6 +229,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t02.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -110,87 +109,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -215,47 +214,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -263,56 +262,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A12_t03.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -97,87 +96,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -193,63 +192,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -257,31 +256,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -108,93 +107,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -202,35 +201,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t02.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -82,87 +81,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -187,47 +186,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -235,56 +234,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -294,32 +293,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A21_t03.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -69,87 +68,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -165,63 +164,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -229,31 +228,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -263,27 +262,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -135,93 +134,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -229,6 +228,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -109,87 +108,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,47 +213,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -262,56 +261,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A22_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -96,87 +95,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -192,63 +191,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -256,31 +255,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t01.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -126,93 +125,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -220,6 +219,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t02.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -100,87 +99,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -205,47 +204,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -253,56 +252,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A31_t03.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -87,87 +86,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -183,63 +182,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -247,31 +246,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -136,93 +135,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -230,6 +229,6 @@ main() {
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t02.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -110,87 +109,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -215,47 +214,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -263,56 +262,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_arguments_binding_fail_A32_t03.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -97,87 +96,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -193,63 +192,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -257,31 +256,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -154,75 +153,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -230,46 +227,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -122,49 +121,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A01_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -94,31 +93,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t01.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -155,75 +154,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -231,46 +228,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t02.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -123,49 +122,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A02_t03.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -95,31 +94,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -154,75 +153,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -230,46 +227,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -122,49 +121,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A03_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -94,31 +93,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -154,75 +153,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -230,46 +227,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t02.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -122,49 +121,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A04_t03.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -94,31 +93,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -184,75 +183,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -152,25 +151,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A05_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -124,16 +123,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -184,75 +183,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -152,25 +151,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A06_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -124,16 +123,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -184,75 +183,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -152,25 +151,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A07_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -124,16 +123,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t01.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -182,75 +181,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t02.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -150,25 +149,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A08_t03.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -122,16 +121,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -157,75 +156,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -233,46 +230,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t02.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -125,49 +124,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A11_t03.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -97,31 +96,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -185,75 +184,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t02.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -153,25 +152,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A12_t03.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -125,16 +124,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -157,75 +156,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -233,46 +230,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t02.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -125,49 +124,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A21_t03.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -97,31 +96,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -184,75 +183,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t02.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -152,25 +151,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A22_t03.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -124,16 +123,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t01.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -175,75 +174,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t02.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -143,25 +142,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A31_t03.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -115,16 +114,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -185,75 +184,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t02.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -153,25 +152,25 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_class_member_fail_A32_t03.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -125,16 +124,16 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A01_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -76,21 +75,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A02_t01.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -77,21 +76,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A03_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -76,21 +75,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A04_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -76,21 +75,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A05_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -106,22 +105,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A06_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -106,22 +105,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A07_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -106,22 +105,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A08_t01.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -104,22 +103,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A11_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -79,21 +78,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A12_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A21_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -79,21 +78,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A22_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -106,22 +105,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A31_t01.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -97,22 +96,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_global_variable_fail_A32_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A01_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -77,21 +76,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A02_t01.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -78,21 +77,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A03_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -77,21 +76,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A04_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -77,21 +76,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A05_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A06_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A07_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A08_t01.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -105,22 +104,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A11_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -80,21 +79,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A12_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -108,22 +107,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A21_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -80,21 +79,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A22_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -107,22 +106,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A31_t01.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -98,22 +97,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_local_variable_fail_A32_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -108,22 +107,22 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A01_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -73,29 +72,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A02_t01.dart
@@ -53,7 +53,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -74,29 +73,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A03_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -73,29 +72,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A04_t01.dart
@@ -52,7 +52,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -73,29 +72,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A05_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -103,20 +102,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A06_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -103,20 +102,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A07_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -103,20 +102,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A08_t01.dart
@@ -80,7 +80,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -101,20 +100,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A11_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -76,29 +75,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A12_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -104,20 +103,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A21_t01.dart
@@ -55,7 +55,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -76,29 +75,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A22_t01.dart
@@ -82,7 +82,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -103,20 +102,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A31_t01.dart
@@ -73,7 +73,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -94,20 +93,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/positional_function_types_fail_return_value_fail_A32_t01.dart
@@ -83,7 +83,6 @@ T1 t1Instance = t1Func;
 const t1Default = t1Func;
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -104,20 +103,20 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t01.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 namedArgumentsFunc1(FutureOr<S1> t1, {FutureOr<S1> t2 = t1Default}) {}
 positionalArgumentsFunc1(FutureOr<S1> t1, [FutureOr<S1> t2 = t1Default]) {}
 
@@ -94,93 +93,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -188,35 +187,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<FutureOr<S1>>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t02.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   FutureOr<S1> m;
 
@@ -68,87 +67,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -173,47 +172,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -221,56 +220,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -280,32 +279,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A01_t03.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(FutureOr<S1> val) {}
   void superTestPositioned(FutureOr<S1> val, [FutureOr<S1> val2 = t1Default]) {}
@@ -55,87 +54,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -151,63 +150,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -215,31 +214,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -249,27 +248,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<FutureOr<S1>>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 namedArgumentsFunc1(FutureOr<S1> t1, {FutureOr<S1> t2 = t1Default}) {}
 positionalArgumentsFunc1(FutureOr<S1> t1, [FutureOr<S1> t2 = t1Default]) {}
 
@@ -96,93 +95,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -190,35 +189,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<FutureOr<S1>>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<FutureOr<S1>>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t02.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   FutureOr<S1> m;
 
@@ -70,87 +69,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -175,47 +174,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -223,56 +222,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -282,32 +281,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<FutureOr<S1>>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_arguments_binding_fail_A02_t03.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(FutureOr<S1> val) {}
   void superTestPositioned(FutureOr<S1> val, [FutureOr<S1> val2 = t1Default]) {}
@@ -57,87 +56,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -153,63 +152,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -217,31 +216,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -251,27 +250,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<FutureOr<S1>>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<FutureOr<S1>>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t01.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberTestStatic {
   static FutureOr<S1> s = t1Default;
 
@@ -143,75 +142,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -219,46 +216,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t02.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   FutureOr<S1> m = t1Default;
 
@@ -111,49 +110,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A01_t03.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   FutureOr<S1> m = t1Default;
 
@@ -83,31 +82,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberTestStatic {
   static FutureOr<S1> s = t1Default;
 
@@ -145,75 +144,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -221,46 +218,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<FutureOr<S1>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<FutureOr<S1>>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t02.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   FutureOr<S1> m = t1Default;
 
@@ -113,49 +112,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<FutureOr<S1>>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_class_member_fail_A02_t03.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   FutureOr<S1> m = t1Default;
 
@@ -85,31 +84,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<FutureOr<S1>>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_global_variable_fail_A01_t01.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -65,21 +64,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_global_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_global_variable_fail_A02_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -67,21 +66,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_local_variable_fail_A01_t01.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -66,21 +65,21 @@ main() {
 
   Expect.throws(() {
     FutureOr<S1> t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_local_variable_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_local_variable_fail_A02_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -68,21 +67,21 @@ main() {
 
   Expect.throws(() {
     FutureOr<S1> t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_return_value_fail_A01_t01.dart
@@ -41,7 +41,6 @@ const t1Default = const S1();
 
 
 
-
 FutureOr<S1> returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -62,29 +61,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<FutureOr<S1>>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<FutureOr<S1>>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_return_value_fail_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_FutureOr_fail_return_value_fail_A02_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const S1();
 
 
 
-
 FutureOr<S1> returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -64,29 +63,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<FutureOr<S1>>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<FutureOr<S1>>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t01.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 namedArgumentsFunc1(Object t1, {Object t2 = t1Default}) {}
 positionalArgumentsFunc1(Object t1, [Object t2 = t1Default]) {}
 
@@ -95,93 +94,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -189,35 +188,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<Object>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t02.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   Object m;
 
@@ -69,87 +68,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -174,47 +173,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -222,56 +221,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -281,32 +280,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<Object>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A07_t03.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(Object val) {}
   void superTestPositioned(Object val, [Object val2 = t1Default]) {}
@@ -56,87 +55,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -152,63 +151,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -216,31 +215,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -250,27 +249,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<Object>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t01.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 namedArgumentsFunc1(Object t1, {Object t2 = t1Default}) {}
 positionalArgumentsFunc1(Object t1, [Object t2 = t1Default]) {}
 
@@ -93,93 +92,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -187,35 +186,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<Object>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<Object>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t02.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   Object m;
 
@@ -67,87 +66,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -172,47 +171,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -220,56 +219,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -279,32 +278,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<Object>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<Object>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_arguments_binding_fail_A08_t03.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(Object val) {}
   void superTestPositioned(Object val, [Object val2 = t1Default]) {}
@@ -54,87 +53,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -150,63 +149,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -214,31 +213,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -248,27 +247,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<Object>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<Object>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t01.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberTestStatic {
   static Object s = t1Default;
 
@@ -144,75 +143,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -220,46 +217,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t02.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberSuper1_t02 {
   Object m = t1Default;
 
@@ -112,49 +111,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<Object>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A07_t03.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberSuper1_t03 {
   Object m = t1Default;
 
@@ -84,31 +83,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t01.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberTestStatic {
   static Object s = t1Default;
 
@@ -142,75 +141,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -218,46 +215,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<Object>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<Object>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t02.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberSuper1_t02 {
   Object m = t1Default;
 
@@ -110,49 +109,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<Object>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<Object>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_class_member_fail_A08_t03.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class ClassMemberSuper1_t03 {
   Object m = t1Default;
 
@@ -82,31 +81,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<Object>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_global_variable_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_global_variable_fail_A07_t01.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -66,21 +65,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_global_variable_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_global_variable_fail_A08_t01.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -64,21 +63,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_local_variable_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_local_variable_fail_A07_t01.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -67,21 +66,21 @@ main() {
 
   Expect.throws(() {
     Object t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_local_variable_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_local_variable_fail_A08_t01.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -65,21 +64,21 @@ main() {
 
   Expect.throws(() {
     Object t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_return_value_fail_A07_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_return_value_fail_A07_t01.dart
@@ -42,7 +42,6 @@ const t1Default = const Object();
 
 
 
-
 Object returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -63,29 +62,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<Object>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<Object>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_return_value_fail_A08_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/right_object_fail_return_value_fail_A08_t01.dart
@@ -40,7 +40,6 @@ const t1Default = const Object();
 
 
 
-
 Object returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -61,29 +60,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<Object>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<Object>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 namedArgumentsFunc1(T1 t1, {T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(T1 t1, [T1 t2 = t1Default]) {}
 
@@ -96,93 +95,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -190,35 +189,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t02.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t02 {
   T1 m;
 
@@ -70,87 +69,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -175,47 +174,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -223,56 +222,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -282,32 +281,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_arguments_binding_fail_A01_t03.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(T1 val) {}
   void superTestPositioned(T1 val, [T1 val2 = t1Default]) {}
@@ -57,87 +56,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -153,63 +152,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -217,31 +216,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -251,27 +250,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberTestStatic {
   static T1 s = t1Default;
 
@@ -145,75 +144,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -221,46 +218,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t02.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t02 {
   T1 m = t1Default;
 
@@ -113,49 +112,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_class_member_fail_A01_t03.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class ClassMemberSuper1_t03 {
   T1 m = t1Default;
 
@@ -85,31 +84,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_global_variable_fail_A01_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -67,21 +66,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_local_variable_fail_A01_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -68,21 +67,21 @@ main() {
 
   Expect.throws(() {
     T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/super_interface_fail_return_value_fail_A01_t01.dart
@@ -43,7 +43,6 @@ const t1Default = const T1();
 
 
 
-
 T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -64,29 +63,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x01.dart
@@ -6,7 +6,6 @@
 /// be used as an argument of type T1
 /// @author sgrekhov@unipro.ru
 
-
 namedArgumentsFunc1(@T1 t1, {@T1 t2 = t1Default}) {}
 positionalArgumentsFunc1(@T1 t1, [@T1 t2 = t1Default]) {}
 
@@ -59,93 +58,93 @@ main() {
   // Test functions
   Expect.throws(() {
     namedArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClass(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test static methods
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
         t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
         forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -153,35 +152,35 @@ main() {
   // Test generic functions
   Expect.throws(() {
     namedArgumentsFunc2<@T1>(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ArgumentsBindingClassGen<@T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<@T1>.named(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<@T1>.fNamed(t1Instance, t2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test instance methods and setters
   Expect.throws(() {
     new ArgumentsBindingClassGen<@T1>(t1Instance).namedArgumentsMethod(t1Instance,
     t2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBindingClassGen<@T1>(t1Instance).testSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 
   // Test superclass constructor call
   Expect.throws(() {
     new ArgumentsBindingDesc(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x02.dart
@@ -6,7 +6,6 @@
 /// be used as an argument of type T1. Test superclass members
 /// @author sgrekhov@unipro.ru
 
-
 class ArgumentsBindingSuper1_t02 {
   @T1 m;
 
@@ -33,87 +32,87 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -138,47 +137,47 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -186,56 +185,56 @@ main() {
   // test constructors
   Expect.throws(() {
     new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t02(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t02(t1Instance).test();
 
@@ -245,32 +244,32 @@ main() {
   // test generic class constructors
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>(t1Instance).superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t02<@T1>(t1Instance).superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t02<@T1>(t1Instance).test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/arguments_binding_fail_x03.dart
@@ -6,7 +6,6 @@
 /// be used as an argument of type T1. Test mixin members
 /// @author sgrekhov@unipro.ru
 
-
 class ArgumentsBindingSuper1_t03 {
   void superTest(@T1 val) {}
   void superTestPositioned(@T1 val, [@T1 val2 = t1Default]) {}
@@ -20,87 +19,87 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -116,63 +115,63 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTest(forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superSetter = forgetType(t0Instance);
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
 
     Expect.throws(() {
       super.superGetter;
-    }, (e) => e is TypeError || e is CastError);
+    }, (e) => e is TypeError);
   }
 }
 
@@ -180,31 +179,31 @@ main() {
   // test class members
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding1_t03().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding1_t03().test();
 
@@ -214,27 +213,27 @@ main() {
   // test generic class members
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superTest(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ArgumentsBinding2_t03<@T1>().superGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   new ArgumentsBinding2_t03<@T1>().test();
   //# -->

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x01.dart
@@ -6,7 +6,6 @@
 /// be used as a class member of type T1
 /// @author sgrekhov@unipro.ru
 
-
 class ClassMemberTestStatic {
   static @T1 s = t1Default;
 
@@ -108,75 +107,73 @@ class ClassMemberTestGenericPrivate<X> {
   }
 }
 
-
 main() {
-
   // Test initialization
-  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError || e is CastError);
-  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError || e is CastError);
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestPublic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPublic.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestPrivate(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test getters
   Expect.throws(() {
     new ClassMemberTestPublic(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
 
   // Test static stuff
   Expect.throws(() {
     new ClassMemberTestStatic(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticSetter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     ClassMemberTestStatic.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
@@ -184,46 +181,46 @@ main() {
   // Test getters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>(t1Instance).getter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test methods
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<@T1>(t1Instance).test(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test setters
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<@T1>(t1Instance).setter = t0Instance;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test class variables
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test constructors
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPublic<@T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<@T1>(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ClassMemberTestGenericPrivate<@T1>.short(forgetType(t0Instance));
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x02.dart
@@ -6,7 +6,6 @@
 /// instance of T0 cannot be assigned to the superclass member of type T1
 /// @author sgrekhov@unipro.ru
 
-
 class ClassMemberSuper1_t02 {
   @T1 m = t1Default;
 
@@ -76,49 +75,49 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t02();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t02().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t02<@T1>();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>.short();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>.named();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t02<@T1>().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/class_member_fail_x03.dart
@@ -6,7 +6,6 @@
 /// instance of T0 cannot be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 
-
 class ClassMemberSuper1_t03 {
   @T1 m = t1Default;
 
@@ -48,31 +47,31 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 main() {
   Expect.throws(() {
     new ClassMember1_t03().m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember1_t03().test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ClassMember2_t03<@T1>(t1Instance).m = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<@T1>(t1Instance).superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<@T1>(t1Instance).test1();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ClassMember2_t03<@T1>(t1Instance).test2();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/global_variable_fail_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/global_variable_fail_x01.dart
@@ -6,7 +6,6 @@
 /// instance of T0 cannot be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 
-
 class GlobalVariableTest {
   GlobalVariableTest() {
     t1Instance = forgetType(t0Instance);
@@ -30,21 +29,21 @@ main() {
 
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new GlobalVariableTest.valid().foo();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     GlobalVariableTest.test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/local_variable_fail_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/local_variable_fail_x01.dart
@@ -6,7 +6,6 @@
 /// instance of T0 cannot be assigned to the to local variable of type T1
 /// @author sgrekhov@unipro.ru
 
-
 class LocalVariableTest {
 
   LocalVariableTest() {
@@ -31,21 +30,21 @@ main() {
 
   Expect.throws(() {
     @T1 t1 = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     bar();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new LocalVariableTest.valid().test();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     LocalVariableTest.staticTest();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/test_cases/return_value_fail_x01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_cases/return_value_fail_x01.dart
@@ -6,7 +6,6 @@
 /// of T0 cannot be used as a return value of type T1
 /// @author sgrekhov@unipro.ru
 
-
 @T1 returnValueFunc() => forgetType(t0Instance);
 
 class ReturnValueTest {
@@ -27,29 +26,29 @@ main() {
 
   Expect.throws(() {
     returnValueFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     returnValueLocalFunc();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   Expect.throws(() {
     new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 
   // Test type parameters
 
   //# <-- NotGenericFunctionType
   Expect.throws(() {
     new ReturnValueGen<@T1>().testMethod();
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   Expect.throws(() {
     new ReturnValueGen<@T1>().testGetter;
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
   //# -->
 }

--- a/LanguageFeatures/Subtyping/dynamic/tests/right_legacy_fail_A01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/tests/right_legacy_fail_A01.dart
@@ -28,5 +28,5 @@ const t1Default = const Y();
 main() {
   Expect.throws(() {
     t1Instance = forgetType(t0Instance);
-  }, (e) => e is TypeError || e is CastError);
+  }, (e) => e is TypeError);
 }


### PR DESCRIPTION
 ```dart
 }, (e) => e is TypeError || e is CastError);
```
replaced by
```dart
  }, (e) => e is TypeError);
```
No any other changes here