### PR TITLE
#1430. For HasSet don't run tests that checks iteration order 

### DIFF
--- a/LibTest/collection/HashSet/inherited_tests.lib.dart
+++ b/LibTest/collection/HashSet/inherited_tests.lib.dart
@@ -12,5 +12,5 @@ library inherited_tests_hashset;
 import "../../core/Set/all_tests.lib.dart" as set_tests;
 
 test(Set create([Iterable? content])) {
-  set_tests.test(create);
+  set_tests.test(create, ordered: false);
 }

--- a/LibTest/core/Iterable/allTests.lib.dart
+++ b/LibTest/core/Iterable/allTests.lib.dart
@@ -95,12 +95,12 @@ import "where_A02_t01.test.dart" as where_A02_t01;
 import "where_A03_t01.test.dart" as where_A03_t01;
 import "where_A04_t01.test.dart" as where_A04_t01;
 
-test(Iterable create([Iterable? content]), {bool isSet:false}) {
+test(Iterable create([Iterable? content]), {bool isSet = false,
+    bool ordered = true}) {
   any_A01_t01.test(create);
   any_A01_t02.test(create);
   any_A01_t03.test(create);
   any_A01_t04.test(create);
-  any_A01_t05.test(create);
   any_A02_t01.test(create);
   contains_A01_t01.test(create);
   elementAt_A01_t01.test(create, isSet: isSet);
@@ -176,10 +176,13 @@ test(Iterable create([Iterable? content]), {bool isSet:false}) {
   where_A01_t02.test(create);
   where_A01_t03.test(create);
   where_A01_t05.test(create);
-  where_A01_t06.test(create);
-  where_A01_t07.test(create, isSet:isSet);
   where_A01_t08.test(create);
   where_A02_t01.test(create);
   where_A03_t01.test(create);
   where_A04_t01.test(create);
+  if (ordered) {
+    any_A01_t05.test(create);
+    where_A01_t06.test(create);
+    where_A01_t07.test(create, isSet:isSet);
+  }
 }

--- a/LibTest/core/Set/all_tests.lib.dart
+++ b/LibTest/core/Set/all_tests.lib.dart
@@ -50,8 +50,8 @@ import "retainAll_A01_t02.dart" as retainAll_A01_t02;
 import "retainWhere_A01_t01.dart" as retainWhere_A01_t01;
 import "union_A01_t01.dart" as union_A01_t01;
 
-test(Set create([Iterable? content])) {
-  iterable_tests.test(create, isSet: true);
+test(Set create([Iterable? content]), {bool ordered = true}) {
+  iterable_tests.test(create, isSet: true, ordered: ordered);
 
   add_A01_t01.test(create);
   add_A01_t02.test(create);


### PR DESCRIPTION
`co19` version. For `co19_2` see https://github.com/dart-lang/co19/pull/1475