### PR TITLE
Fixes #1511. [Records] Remove `records` experimental flag from legacy libraries

### DIFF
--- a/LanguageFeatures/Records/interaction_with_legacy_A01_t01.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A01_t01.dart
@@ -15,8 +15,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 typedef T1 = Record;
 //           ^^^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Records/interaction_with_legacy_A02_t01.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A02_t01.dart
@@ -14,8 +14,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 void foo(dynamic x) {}
 
 main() {

--- a/LanguageFeatures/Records/interaction_with_legacy_A03_t01.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A03_t01.dart
@@ -14,8 +14,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 typedef T1 = ();
 //           ^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Records/interaction_with_legacy_A04_t01.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A04_t01.dart
@@ -33,8 +33,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 import "interaction_with_legacy_lib.dart";
 
 main() {

--- a/LanguageFeatures/Records/interaction_with_legacy_A04_t02.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A04_t02.dart
@@ -33,8 +33,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 import "interaction_with_legacy_lib.dart";
 
 main() {

--- a/LanguageFeatures/Records/interaction_with_legacy_A04_t03.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A04_t03.dart
@@ -32,8 +32,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 import "interaction_with_legacy_lib.dart";
 
 Record foo<T extends Record>(T t) => t;

--- a/LanguageFeatures/Records/interaction_with_legacy_A04_t04.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A04_t04.dart
@@ -33,8 +33,6 @@
 
 // @dart = 2.18
 
-// SharedOptions=--enable-experiment=records
-
 import "interaction_with_legacy_lib.dart";
 import "../../Utils/expect.dart";
 


### PR DESCRIPTION
You cannot have 
```dart
// @dart = 2.18
// SharedOptions=--enable-experiment=records
```
in the same library