### PR TITLE
Avoid Function.apply in utility code

### DIFF
--- a/Utils/async_utils.dart
+++ b/Utils/async_utils.dart
@@ -159,8 +159,8 @@ class AsyncExpect {
         return future;
       },
        onError: (e) {
-        if (error is Function) {
-          Expect.isTrue(Function.apply(error, [e]), msg);
+        if (error is Function(Object)) {
+          Expect.isTrue(error(e), msg);
         } else {
           Expect.equals(error, e, msg);
         }


### PR DESCRIPTION
The dart2wasm compiler does not support `Function.apply` and may not do so in the foreseeable future. For this reason, we should avoid using `Function.apply` outside of code that specifically tests `Function.apply`.