### PR TITLE
#1401. [Patterns] Constant pattern tests update according to the new spec

### DIFF
--- a/LanguageFeatures/Patterns/constant_A01_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A01_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -20,9 +21,12 @@
 /// expressions like so:
 ///
 /// Simple "primitive" literals like Booleans and numbers are valid patterns
-/// since they aren't ambiguous.
+/// since they aren't ambiguous. We also allow unary - expressions on numeric
+/// literals since users think of -2 as a single literal and not the literal 2
+/// with a unary - applied to it (which is how the language views it).
 ///
-/// @description Check booleans, numbers and strings in constant patterns
+/// @description Check booleans, numbers and strings in constant patterns. Test
+/// switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -48,6 +52,10 @@ String testNum(num value) {
       return "pi";
     case 42:
       return "answer";
+    case -1:
+      return "negative";
+    case -3.14:
+      return "negative-pi";
     case 0x1FFFFFFFFFFFFF:
       return "max_int";
     default:
@@ -78,6 +86,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A01_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A01_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -20,7 +21,9 @@
 /// expressions like so:
 ///
 /// Simple "primitive" literals like Booleans and numbers are valid patterns
-/// since they aren't ambiguous.
+/// since they aren't ambiguous. We also allow unary - expressions on numeric
+/// literals since users think of -2 as a single literal and not the literal 2
+/// with a unary - applied to it (which is how the language views it).
 ///
 /// @description Check booleans, numbers and strings in constant patterns.
 /// Test if-case statement
@@ -47,6 +50,10 @@ String testNum(num value) {
     return "pi";
   } else if (value case 42) {
     return "answer";
+  } else if (value case -1) {
+    return "negative";
+  } else if (value case -3.14) {
+    return "negative-pi";
   } else if (value case 0x1FFFFFFFFFFFFF) {
     return "max_int";
   } else {
@@ -76,6 +83,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A01_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A01_t03.dart
@@ -43,7 +43,7 @@ String testBool(bool value) {
 
 String testNum(num value) {
   return switch (value) {
-    case 0: => "zero";
+    case 0 => "zero";
     case 3.14 => "pi";
     case 42 => "answer";
     case -1 => "negative";

--- a/LanguageFeatures/Patterns/constant_A01_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A01_t03.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -20,30 +21,64 @@
 /// expressions like so:
 ///
 /// Simple "primitive" literals like Booleans and numbers are valid patterns
-/// since they aren't ambiguous.
+/// since they aren't ambiguous. We also allow unary - expressions on numeric
+/// literals since users think of -2 as a single literal and not the literal 2
+/// with a unary - applied to it (which is how the language views it).
 ///
-/// @description Check that it is a compile-time error if [Symbol] is used in
-/// constant patterns
+/// @description Check booleans, numbers and strings in constant patterns. Test
+/// switch expressions
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-void test(Symbol value) {
-  switch (value) {
-    case #+:
-//       ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-      break;
-    case #foo:
-//       ^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-      break;
-    default:
-  }
+import "../../Utils/expect.dart";
+
+String testBool(bool value) {
+  return switch (value) {
+    case true => "true";
+    case false => "false";
+    default => "default";
+  };
+}
+
+String testNum(num value) {
+  return switch (value) {
+    case 0: => "zero";
+    case 3.14 => "pi";
+    case 42 => "answer";
+    case -1 => "negative";
+    case -3.14 => "negative-pi";
+    case 0x1FFFFFFFFFFFFF => "max_int";
+    default => "default";
+  };
+}
+
+String testString(String value) {
+  return switch (value) {
+    case "0" => "zero";
+    case "3.14" => "pi";
+    case "42" => "answer";
+    case "" => "empty";
+    default => "default";
+  };
 }
 
 main() {
-  test(Symbol("+"));
+  Expect.equals("true", testBool(true));
+  Expect.equals("false", testBool(false));
+
+  Expect.equals("zero", testNum(0));
+  Expect.equals("zero", testNum(0.0));
+  Expect.equals("pi", testNum(3.14));
+  Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
+  Expect.equals("max_int", testNum(9007199254740991));
+  Expect.equals("default", testNum(1));
+
+  Expect.equals("zero", testString("0"));
+  Expect.equals("pi", testString("3.14"));
+  Expect.equals("answer", testString("42"));
+  Expect.equals("empty", testString(""));
+  Expect.equals("default", testString("Lily was here"));
 }

--- a/LanguageFeatures/Patterns/constant_A01_t04.dart
+++ b/LanguageFeatures/Patterns/constant_A01_t04.dart
@@ -22,24 +22,66 @@
 /// Simple "primitive" literals like Booleans and numbers are valid patterns
 /// since they aren't ambiguous.
 ///
-/// @description Check that it is a compile-time error if [Symbol] is used in
-/// constant patterns. Test if-case statement
+/// @description Check that [Symbol] can be used in constant patterns.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-void test(Symbol value) {
-  if (value case #+) {
-//               ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  } else if (value case #foo) {
-//                      ^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+import "../../Utils/expect.dart";
+
+String test1(Symbol value) {
+  switch (value) {
+    case #+:
+      return "+";
+    case #foo:
+      return "foo";
+    case Symbol.unaryMinus:
+      return "-";
+    case const Symbol("bar"):
+      return "bar";
+    default:
+      return "default";
   }
 }
 
+String test2(Symbol value) {
+  return switch (value) {
+    case #+ => "+";
+    case #foo => "foo";
+    case Symbol.unaryMinus => "-";
+    case const Symbol("bar") => "bar";
+    default => "default";
+  };
+}
+
+String test3(Symbol value) {
+  if (value case #+) {
+    return "+";
+  }
+  if (value case #foo) {
+    return "foo";
+  }
+  if (value case Symbol.unaryMinus) {
+    return "-";
+  }
+  if (value case const Symbol("bar")) {
+    return "bar";
+  }
+  return "default";
+}
+
+
 main() {
-  test(Symbol("foo"));
+  Expect.equals("+", test1(Symbol("+")));
+  Expect.equals("foo", test1(Symbol("foo")));
+  Expect.equals("-", test1(Symbol("unary-")));
+  Expect.equals("bar", test1(Symbol("bar")));
+  Expect.equals("+", test2(Symbol("+")));
+  Expect.equals("foo", test2(Symbol("foo")));
+  Expect.equals("-", test2(Symbol("unary-")));
+  Expect.equals("bar", test2(Symbol("bar")));
+  Expect.equals("+", test3(Symbol("+")));
+  Expect.equals("foo", test3(Symbol("foo")));
+  Expect.equals("-", test3(Symbol("unary-")));
+  Expect.equals("bar", test3(Symbol("bar")));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,7 +29,8 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns
+/// @description Check named constants in constant patterns. Test switch
+/// statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -38,6 +40,8 @@ import "../../Utils/expect.dart";
 const Zero = 0;
 const Pi = 3.14;
 const Answer = 42;
+const Negative = -1;
+const NegativePi = -3.14;
 const MaxJSInt = 0x1FFFFFFFFFFFFF;
 const Melody = "Lily was here";
 const True = true;
@@ -62,6 +66,10 @@ String testNum(num value) {
       return "pi";
     case Answer:
       return "answer";
+    case Negative:
+      return "nagative";
+    case NegativePi:
+      return "nagative-pi";
     case MaxJSInt:
       return "max_int";
     default:
@@ -86,6 +94,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -39,6 +40,8 @@ import "../../Utils/expect.dart";
 const Zero = 0;
 const Pi = 3.14;
 const Answer = 42;
+const Negative = -1;
+const NegativePi = -3.14;
 const MaxJSInt = 0x1FFFFFFFFFFFFF;
 const Melody = "Lily was here";
 const True = true;
@@ -61,6 +64,10 @@ String testNum(num value) {
     return "pi";
   } else if (value case Answer) {
     return "answer";
+  } else if (value case Negative) {
+    return "negative";
+  } else if (value case NegativePi) {
+    return "negative-pi";
   } else if (value case MaxJSInt) {
     return "max_int";
   } else {
@@ -84,6 +91,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t04.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t04.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -29,7 +30,7 @@
 /// constant patterns are prohibited.
 ///
 /// @description Check static constants on classes in constant patterns. Test
-/// if-case statement
+/// switch statements
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -40,6 +41,8 @@ class C {
   static const Zero = 0;
   static const Pi = 3.14;
   static const Answer = 42;
+  static const Negative = -1;
+  static const NegativePi = -3.14;
   static const MaxJSInt = 0x1FFFFFFFFFFFFF;
   static const Melody = "Lily was here";
   static const True = true;
@@ -47,34 +50,41 @@ class C {
 }
 
 String testBool(bool value) {
-  if (value case C.True) {
-    return "true";
-  } else if (value case C.False) {
-    return "false";
-  } else {
-    return "default";
+  switch (value) {
+    case C.True:
+      return "true";
+    case C.False:
+      return "false";
+    default:
+      return "default";
   }
 }
 
 String testNum(num value) {
-  if (value case C.Zero) {
-    return "zero";
-  } else if (value case C.Pi) {
-    return "pi";
-  } else if (value case C.Answer) {
-    return "answer";
-  } else if (value case C.MaxJSInt) {
-    return "max_int";
-  } else {
-    return "default";
+  switch (value) {
+    case C.Zero:
+      return "zero";
+    case C.Pi:
+      return "pi";
+    case C.Answer:
+      return "answer";
+    case C.Negative:
+      return "negative";
+    case C.NegativePi:
+      return "negative-pi";
+    case C.MaxJSInt:
+      return "max_int";
+    default:
+      return "default";
   }
 }
 
 String testString(String value) {
-  if (value case C.Melody) {
-    return "Melody";
-  } else {
-    return "default";
+  switch (value) {
+    case C.Melody:
+      return "Melody";
+    default:
+      return "default";
   }
 }
 
@@ -86,6 +96,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t05.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t05.dart
@@ -28,47 +28,59 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants with a library prefix in constant
-/// patterns
+/// @description Check static constants on classes in constant patterns. Test
+/// if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
+class C {
+  static const Zero = 0;
+  static const Pi = 3.14;
+  static const Answer = 42;
+  static const Negative = -1;
+  static const NegativePi = -3.14;
+  static const MaxJSInt = 0x1FFFFFFFFFFFFF;
+  static const Melody = "Lily was here";
+  static const True = true;
+  static const False = false;
+}
+
 String testBool(bool value) {
-  switch (value) {
-    case p.True:
-      return "true";
-    case p.False:
-      return "false";
-    default:
-      return "default";
+  if (value case C.True) {
+    return "true";
+  } else if (value case C.False) {
+    return "false";
+  } else {
+    return "default";
   }
 }
 
 String testNum(num value) {
-  switch (value) {
-    case p.Zero:
-      return "zero";
-    case p.Pi:
-      return "pi";
-    case p.Answer:
-      return "answer";
-    case p.MaxJSInt:
-      return "max_int";
-    default:
-      return "default";
+  if (value case C.Zero) {
+    return "zero";
+  } else if (value case C.Pi) {
+    return "pi";
+  } else if (value case C.Answer) {
+    return "answer";
+  } else if (value case C.Negative) {
+    return "negative";
+  } else if (value case C.NegativePi) {
+    return "negative-pi";
+  } else if (value case C.MaxJSInt) {
+    return "max_int";
+  } else {
+    return "default";
   }
 }
 
 String testString(String value) {
-  switch (value) {
-    case p.Melody:
-      return "Melody";
-    default:
-      return "default";
+  if (value case C.Melody) {
+    return "Melody";
+  } else {
+    return "default";
   }
 }
 
@@ -80,6 +92,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t06.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t06.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,45 +29,51 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants with a library prefix in constant
-/// patterns. Test if-case statement
+/// @description Check static constants on classes in constant patterns. Test
+/// switch expressions
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
+class C {
+  static const Zero = 0;
+  static const Pi = 3.14;
+  static const Answer = 42;
+  static const Negative = -1;
+  static const NegativePi = -3.14;
+  static const MaxJSInt = 0x1FFFFFFFFFFFFF;
+  static const Melody = "Lily was here";
+  static const True = true;
+  static const False = false;
+}
+
 String testBool(bool value) {
-  if (value case p.True) {
-    return "true";
-  } else if (value case p.False) {
-    return "false";
-  } else {
-    return "default";
-  }
+  return switch (value) {
+    case C.True => "true";
+    case C.False => "false";
+    default => "default";
+  };
 }
 
 String testNum(num value) {
-  if (value case p.Zero) {
-    return "zero";
-  } else if (value case p.Pi) {
-    return "pi";
-  } else if (value case p.Answer) {
-    return "answer";
-  } else if (value case p.MaxJSInt) {
-    return "max_int";
-  } else {
-    return "default";
-  }
+  return switch (value) {
+    case C.Zero => "zero";
+    case C.Pi => "pi";
+    case C.Answer => "answer";
+    case C.Negative => "negative";
+    case C.NegativePi => "negative-pi";
+    case C.MaxJSInt => "max_int";
+    default => "default";
+  };
 }
 
 String testString(String value) {
-  if (value case p.Melody) {
-    return "Melody";
-  } else {
-    return "default";
-  }
+  return switch (value) {
+    case C.Melody => "Melody";
+    default => "default";
+  };
 }
 
 main() {
@@ -77,6 +84,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t07.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t07.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,8 +29,8 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check static constants on classes with a library prefix in
-/// constant patterns
+/// @description Check named constants with a library prefix in constant
+/// patterns. Test switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -39,9 +40,9 @@ import "../../Utils/expect.dart";
 
 String testBool(bool value) {
   switch (value) {
-    case p.C0.True:
+    case p.True:
       return "true";
-    case p.C0.False:
+    case p.False:
       return "false";
     default:
       return "default";
@@ -50,13 +51,17 @@ String testBool(bool value) {
 
 String testNum(num value) {
   switch (value) {
-    case p.C0.Zero:
+    case p.Zero:
       return "zero";
-    case p.C0.Pi:
+    case p.Pi:
       return "pi";
-    case p.C0.Answer:
+    case p.Answer:
       return "answer";
-    case p.C0.MaxJSInt:
+    case p.Negative:
+      return "negative";
+    case p.NegativePi:
+      return "negative-pi";
+    case p.MaxJSInt:
       return "max_int";
     default:
       return "default";
@@ -65,7 +70,7 @@ String testNum(num value) {
 
 String testString(String value) {
   switch (value) {
-    case p.C0.Melody:
+    case p.Melody:
       return "Melody";
     default:
       return "default";
@@ -80,6 +85,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t08.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t08.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,8 +29,8 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check static constants on classes with a library prefix in
-/// constant patterns. Test if-case statement
+/// @description Check named constants with a library prefix in constant
+/// patterns. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -38,9 +39,9 @@ import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
 String testBool(bool value) {
-  if (value case p.C0.True) {
+  if (value case p.True) {
     return "true";
-  } else if (value case p.C0.False) {
+  } else if (value case p.False) {
     return "false";
   } else {
     return "default";
@@ -48,13 +49,17 @@ String testBool(bool value) {
 }
 
 String testNum(num value) {
-  if (value case p.C0.Zero) {
+  if (value case p.Zero) {
     return "zero";
-  } else if (value case p.C0.Pi) {
+  } else if (value case p.Pi) {
     return "pi";
-  } else if (value case p.C0.Answer) {
+  } else if (value case p.Answer) {
     return "answer";
-  } else if (value case p.C0.MaxJSInt) {
+  } else if (value case p.Negative) {
+    return "negative";
+  } else if (value case p.NegativePi) {
+    return "negative-pi";
+  } else if (value case p.MaxJSInt) {
     return "max_int";
   } else {
     return "default";
@@ -62,7 +67,7 @@ String testNum(num value) {
 }
 
 String testString(String value) {
-  if (value case p.C0.Melody) {
+  if (value case p.Melody) {
     return "Melody";
   } else {
     return "default";
@@ -77,6 +82,8 @@ main() {
   Expect.equals("zero", testNum(0.0));
   Expect.equals("pi", testNum(3.14));
   Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
   Expect.equals("max_int", testNum(9007199254740991));
   Expect.equals("default", testNum(1));
 

--- a/LanguageFeatures/Patterns/constant_A02_t09.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t09.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,47 +29,55 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check enums in constant patterns
+/// @description Check named constants with a library prefix in constant
+/// patterns. Test switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-enum Color {
-  white,
-  red,
-  yellow,
-  blue,
-  black;
+String testBool(bool value) {
+  return switch (value) {
+    case p.True => "true";
+    case p.False => "false";
+    default => "default";
+  };
 }
 
-void test(Color value) {
-  switch (value) {
-    case Color.white:
-      Expect.equals(Color.white, value);
-      break;
-    case Color.red:
-      Expect.equals(Color.red, value);
-      break;
-    case Color.yellow:
-      Expect.equals(Color.yellow, value);
-      break;
-    case Color.blue:
-      Expect.equals(Color.blue, value);
-      break;
-    case Color.black:
-      Expect.equals(Color.black, value);
-      break;
-    default:
-      Expect.fail("No such color found");
-  }
+String testNum(num value) {
+  return switch (value) {
+    case p.Zero => "zero";
+    case p.Pi => "pi";
+    case p.Answer => "answer";
+    case p.Negative => "negative";
+    case p.NegativePi => "negative-pi";
+    case p.MaxJSInt => "max_int";
+    default => "default";
+  };
+}
+
+String testString(String value) {
+  return switch (value) {
+    case p.Melody => "Melody";
+    default => "default";
+  };
 }
 
 main() {
-  test(Color.white);
-  test(Color.red);
-  test(Color.yellow);
-  test(Color.blue);
-  test(Color.black);
+  Expect.equals("true", testBool(true));
+  Expect.equals("false", testBool(false));
+
+  Expect.equals("zero", testNum(0));
+  Expect.equals("zero", testNum(0.0));
+  Expect.equals("pi", testNum(3.14));
+  Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
+  Expect.equals("max_int", testNum(9007199254740991));
+  Expect.equals("default", testNum(1));
+
+  Expect.equals("Melody", testString("Lily was here"));
+  Expect.equals("default", testString(""));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t10.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t10.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,41 +29,67 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check enums in constant patterns. Test if-case statement
+/// @description Check static constants on classes with a library prefix in
+/// constant patterns. Test switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-enum Color {
-  white,
-  red,
-  yellow,
-  blue,
-  black;
+String testBool(bool value) {
+  switch (value) {
+    case p.C0.True:
+      return "true";
+    case p.C0.False:
+      return "false";
+    default:
+      return "default";
+  }
 }
 
-void test(Color value) {
-  if (value case Color.white) {
-    Expect.equals(Color.white, value);
-  } else if (value case Color.red) {
-    Expect.equals(Color.red, value);
-  } else if (value case Color.yellow) {
-    Expect.equals(Color.yellow, value);
-  } else if (value case Color.blue) {
-    Expect.equals(Color.blue, value);
-  } else if (value case Color.black) {
-    Expect.equals(Color.black, value);
-  } else {
-    Expect.fail("No such color found");
+String testNum(num value) {
+  switch (value) {
+    case p.C0.Zero:
+      return "zero";
+    case p.C0.Pi:
+      return "pi";
+    case p.C0.Answer:
+      return "answer";
+    case p.C0.Negative:
+      return "negative";
+    case p.C0.NegativePi:
+      return "negative-pi";
+    case p.C0.MaxJSInt:
+      return "max_int";
+    default:
+      return "default";
+  }
+}
+
+String testString(String value) {
+  switch (value) {
+    case p.C0.Melody:
+      return "Melody";
+    default:
+      return "default";
   }
 }
 
 main() {
-  test(Color.white);
-  test(Color.red);
-  test(Color.yellow);
-  test(Color.blue);
-  test(Color.black);
+  Expect.equals("true", testBool(true));
+  Expect.equals("false", testBool(false));
+
+  Expect.equals("zero", testNum(0));
+  Expect.equals("zero", testNum(0.0));
+  Expect.equals("pi", testNum(3.14));
+  Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
+  Expect.equals("max_int", testNum(9007199254740991));
+  Expect.equals("default", testNum(1));
+
+  Expect.equals("Melody", testString("Lily was here"));
+  Expect.equals("default", testString(""));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t11.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t11.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,7 +29,8 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check enums with a library prefix in constant patterns
+/// @description Check static constants on classes with a library prefix in
+/// constant patterns. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -36,32 +38,55 @@
 import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-void test(p.Color value) {
-  switch (value) {
-    case p.Color.white:
-      Expect.equals(p.Color.white, value);
-      break;
-    case p.Color.red:
-      Expect.equals(p.Color.red, value);
-      break;
-    case p.Color.yellow:
-      Expect.equals(p.Color.yellow, value);
-      break;
-    case p.Color.blue:
-      Expect.equals(p.Color.blue, value);
-      break;
-    case p.Color.black:
-      Expect.equals(p.Color.black, value);
-      break;
-    default:
-      Expect.fail("No such color found");
+String testBool(bool value) {
+  if (value case p.C0.True) {
+    return "true";
+  } else if (value case p.C0.False) {
+    return "false";
+  } else {
+    return "default";
+  }
+}
+
+String testNum(num value) {
+  if (value case p.C0.Zero) {
+    return "zero";
+  } else if (value case p.C0.Pi) {
+    return "pi";
+  } else if (value case p.C0.Answer) {
+    return "answer";
+  } else if (value case p.C0.Negative) {
+    return "negative";
+  } else if (value case p.C0.NegativePi) {
+    return "negative-pi";
+  } else if (value case p.C0.MaxJSInt) {
+    return "max_int";
+  } else {
+    return "default";
+  }
+}
+
+String testString(String value) {
+  if (value case p.C0.Melody) {
+    return "Melody";
+  } else {
+    return "default";
   }
 }
 
 main() {
-  test(p.Color.white);
-  test(p.Color.red);
-  test(p.Color.yellow);
-  test(p.Color.blue);
-  test(p.Color.black);
+  Expect.equals("true", testBool(true));
+  Expect.equals("false", testBool(false));
+
+  Expect.equals("zero", testNum(0));
+  Expect.equals("zero", testNum(0.0));
+  Expect.equals("pi", testNum(3.14));
+  Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
+  Expect.equals("max_int", testNum(9007199254740991));
+  Expect.equals("default", testNum(1));
+
+  Expect.equals("Melody", testString("Lily was here"));
+  Expect.equals("default", testString(""));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t12.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t12.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -28,8 +29,8 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check enums with a library prefix in constant patterns. Test
-/// if-case statement
+/// @description Check static constants on classes with a library prefix in
+/// constant patterns. Test switch expressions
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -37,26 +38,46 @@
 import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-void test(p.Color value) {
-  if (value case p.Color.white) {
-    Expect.equals(p.Color.white, value);
-  } else if (value case p.Color.red) {
-    Expect.equals(p.Color.red, value);
-  } else if (value case p.Color.yellow) {
-    Expect.equals(p.Color.yellow, value);
-  } else if (value case p.Color.blue) {
-    Expect.equals(p.Color.blue, value);
-  } else if (value case p.Color.black) {
-    Expect.equals(p.Color.black, value);
-  } else {
-    Expect.fail("No such color found");
-  }
+String testBool(bool value) {
+  return switch (value) {
+    case p.C0.True => "true";
+    case p.C0.False => "false";
+    default => "default";
+  };
+}
+
+String testNum(num value) {
+  return switch (value) {
+    case p.C0.Zero => "zero";
+    case p.C0.Pi => "pi";
+    case p.C0.Answer => "answer";
+    case p.C0.Negative => "negative";
+    case p.C0.NegativePi => "negative-pi";
+    case p.C0.MaxJSInt => "max_int";
+    default => "default";
+  };
+}
+
+String testString(String value) {
+  return switch (value) {
+    case p.C0.Melody => "Melody";
+    default => "default";
+  };
 }
 
 main() {
-  test(p.Color.white);
-  test(p.Color.red);
-  test(p.Color.yellow);
-  test(p.Color.blue);
-  test(p.Color.black);
+  Expect.equals("true", testBool(true));
+  Expect.equals("false", testBool(false));
+
+  Expect.equals("zero", testNum(0));
+  Expect.equals("zero", testNum(0.0));
+  Expect.equals("pi", testNum(3.14));
+  Expect.equals("answer", testNum(42));
+  Expect.equals("negative", testNum(-1));
+  Expect.equals("negative-pi", testNum(-3.14));
+  Expect.equals("max_int", testNum(9007199254740991));
+  Expect.equals("default", testNum(1));
+
+  Expect.equals("Melody", testString("Lily was here"));
+  Expect.equals("default", testString(""));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t13.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t13.dart
@@ -29,64 +29,47 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums in constant patterns. Test switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
-  return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
+enum Color {
+  white,
+  red,
+  yellow,
+  blue,
+  black;
 }
 
-String testNum(num value) {
-  return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
-    default => "default";
-  };
+void test(Color value) {
+  switch (value) {
+    case Color.white:
+      Expect.equals(Color.white, value);
+      break;
+    case Color.red:
+      Expect.equals(Color.red, value);
+      break;
+    case Color.yellow:
+      Expect.equals(Color.yellow, value);
+      break;
+    case Color.blue:
+      Expect.equals(Color.blue, value);
+      break;
+    case Color.black:
+      Expect.equals(Color.black, value);
+      break;
+    default:
+      Expect.fail("No such color found");
+  }
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  test(Color.white);
+  test(Color.red);
+  test(Color.yellow);
+  test(Color.blue);
+  test(Color.black);
 }

--- a/LanguageFeatures/Patterns/constant_A02_t14.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t14.dart
@@ -29,64 +29,41 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums in constant patterns. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
-  return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
+enum Color {
+  white,
+  red,
+  yellow,
+  blue,
+  black;
 }
 
-String testNum(num value) {
-  return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
-    default => "default";
-  };
+void test(Color value) {
+  if (value case Color.white) {
+    Expect.equals(Color.white, value);
+  } else if (value case Color.red) {
+    Expect.equals(Color.red, value);
+  } else if (value case Color.yellow) {
+    Expect.equals(Color.yellow, value);
+  } else if (value case Color.blue) {
+    Expect.equals(Color.blue, value);
+  } else if (value case Color.black) {
+    Expect.equals(Color.black, value);
+  } else {
+    Expect.fail("No such color found");
+  }
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  test(Color.white);
+  test(Color.red);
+  test(Color.yellow);
+  test(Color.blue);
+  test(Color.black);
 }

--- a/LanguageFeatures/Patterns/constant_A02_t15.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t15.dart
@@ -29,64 +29,36 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums in constant patterns. Test switch expressions
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
-  return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
+enum Color {
+  white,
+  red,
+  yellow,
+  blue,
+  black;
 }
 
-String testNum(num value) {
+String test(Color value) {
   return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
+    case Color.white => "white";
+    case Color.red => "red";
+    case Color.yellow => "yellow";
+    case Color.blue => "default";
+    case Color.black => "black";
     default => "default";
   };
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  Expect.equals("white", test(Color.white));
+  Expect.equals("red", test(Color.red));
+  Expect.equals("yellow", test(Color.yellow));
+  Expect.equals("blue", test(Color.blue));
+  Expect.equals("black", test(Color.black));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t16.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t16.dart
@@ -29,64 +29,41 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums with a library prefix in constant patterns. Test
+/// switch statements
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
-  return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
-}
-
-String testNum(num value) {
-  return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
-    default => "default";
-  };
+void test(p.Color value) {
+  switch (value) {
+    case p.Color.white:
+      Expect.equals(p.Color.white, value);
+      break;
+    case p.Color.red:
+      Expect.equals(p.Color.red, value);
+      break;
+    case p.Color.yellow:
+      Expect.equals(p.Color.yellow, value);
+      break;
+    case p.Color.blue:
+      Expect.equals(p.Color.blue, value);
+      break;
+    case p.Color.black:
+      Expect.equals(p.Color.black, value);
+      break;
+    default:
+      Expect.fail("No such color found");
+  }
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  test(p.Color.white);
+  test(p.Color.red);
+  test(p.Color.yellow);
+  test(p.Color.blue);
+  test(p.Color.black);
 }

--- a/LanguageFeatures/Patterns/constant_A02_t17.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t17.dart
@@ -29,64 +29,35 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums with a library prefix in constant patterns. Test
+/// if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
-  return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
-}
-
-String testNum(num value) {
-  return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
-    default => "default";
-  };
+void test(p.Color value) {
+  if (value case p.Color.white) {
+    Expect.equals(p.Color.white, value);
+  } else if (value case p.Color.red) {
+    Expect.equals(p.Color.red, value);
+  } else if (value case p.Color.yellow) {
+    Expect.equals(p.Color.yellow, value);
+  } else if (value case p.Color.blue) {
+    Expect.equals(p.Color.blue, value);
+  } else if (value case p.Color.black) {
+    Expect.equals(p.Color.black, value);
+  } else {
+    Expect.fail("No such color found");
+  }
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  test(p.Color.white);
+  test(p.Color.red);
+  test(p.Color.yellow);
+  test(p.Color.blue);
+  test(p.Color.black);
 }

--- a/LanguageFeatures/Patterns/constant_A02_t18.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t18.dart
@@ -29,64 +29,30 @@
 /// unmarked variable patterns are only allowed in irrefutable contexts where
 /// constant patterns are prohibited.
 ///
-/// @description Check named constants in constant patterns. Test switch
-/// expression
+/// @description Check enums with a library prefix in constant patterns. Test
+/// switch expressions
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+import "patterns_lib.dart" as p;
 import "../../Utils/expect.dart";
 
-const Zero = 0;
-const Pi = 3.14;
-const Answer = 42;
-const Negative = -1;
-const NegativePi = -3.14;
-const MaxJSInt = 0x1FFFFFFFFFFFFF;
-const Melody = "Lily was here";
-const True = true;
-const False = false;
-
-String testBool(bool value) {
+String test(p.Color value) {
   return switch (value) {
-    case True => "true";
-    case False => "false";
-    default => "default";
-  };
-}
-
-String testNum(num value) {
-  return switch (value) {
-    case Zero => "zero";
-    case Pi =>"pi";
-    case Answer => "answer";
-    case Negative => "nagative";
-    case NegativePi => "nagative-pi";
-    case MaxJSInt => "max_int";
-    default => "default";
-  };
-}
-
-String testString(String value) {
-  return switch (value) {
-    case Melody => "Melody";
+    case p.Color.white => "white";
+    case p.Color.red => "red";
+    case p.Color.yellow => "yellow";
+    case p.Color.blue => "default";
+    case p.Color.black => "black";
     default => "default";
   };
 }
 
 main() {
-  Expect.equals("true", testBool(true));
-  Expect.equals("false", testBool(false));
-
-  Expect.equals("zero", testNum(0));
-  Expect.equals("zero", testNum(0.0));
-  Expect.equals("pi", testNum(3.14));
-  Expect.equals("answer", testNum(42));
-  Expect.equals("negative", testNum(-1));
-  Expect.equals("negative-pi", testNum(-3.14));
-  Expect.equals("max_int", testNum(9007199254740991));
-  Expect.equals("default", testNum(1));
-
-  Expect.equals("Melody", testString("Lily was here"));
-  Expect.equals("default", testString(""));
+  Expect.equals("white", test(p.Color.white));
+  Expect.equals("red", test(p.Color.red));
+  Expect.equals("yellow", test(p.Color.yellow));
+  Expect.equals("blue", test(p.Color.blue));
+  Expect.equals("black", test(p.Color.black));
 }

--- a/LanguageFeatures/Patterns/constant_A02_t19.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t19.dart
@@ -1,0 +1,156 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion constantPattern ::= booleanLiteral
+///                   | nullLiteral
+///                   | '-'? numericLiteral
+///                   | stringLiteral
+///                   | symbolLiteral
+///                   | identifier
+///                   | qualifiedName
+///                   | constObjectExpression
+///                   | 'const' typeArguments? '[' elements? ']'
+///                   | 'const' typeArguments? '{' elements? '}'
+///                   | 'const' '(' expression ')'
+///
+/// A constant pattern determines if the matched value is equal to the
+/// constant's value. We don't allow all expressions here because many
+/// expression forms syntactically overlap other kinds of patterns. We avoid
+/// ambiguity while supporting terse forms of the most common constant
+/// expressions like so:
+/// ...
+/// Named constants are also allowed because they aren't ambiguous. That
+/// includes simple identifiers like someConstant, prefixed constants like
+/// some_library.aConstant, static constants on classes like
+/// SomeClass.aConstant, and prefixed static constants like
+/// some_library.SomeClass.aConstant. Simple identifiers would be ambiguous with
+/// variable patterns that aren't marked with var, final, or a type, but
+/// unmarked variable patterns are only allowed in irrefutable contexts where
+/// constant patterns are prohibited.
+///
+/// @description Check that it is a compile-time error if named numerical
+/// constant is prefixed by '-'
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+const Zero = 0;
+const Pi = 3.14;
+const Answer = 42;
+const Negative = -1;
+const NegativePi = -3.14;
+const MaxJSInt = 0x1FFFFFFFFFFFFF;
+
+String test1(num value) {
+  switch (value) {
+    case -Zero:
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "zero";
+    case -Pi:
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "pi";
+    case -Answer:
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "answer";
+    case -Negative:
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative";
+    case -NegativePi:
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative-pi";
+    case -MaxJSInt:
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "max_int";
+    default:
+      return "default";
+  }
+}
+
+String test2(num value) {
+  if (value case -Zero) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "zero";
+  }
+  if (value case -Pi) {
+//               ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "pi";
+  }
+  if (value case -Answer) {
+//               ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "answer";
+  }
+  if (value case -Negative) {
+//               ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative";
+  }
+  if (value case -NegativePi) {
+//               ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative-pi";
+  }
+  if (value case -MaxJSInt) {
+//               ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "max_int";
+  }
+  return "default";
+}
+
+String test3(num value) {
+  return switch (value) {
+    case -Zero => "zero";
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -Pi => "pi";
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -Answer => "answer";
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -Negative => "nagative";
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -NegativePi => "nagative-pi";
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -MaxJSInt => "max_int";
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    default => "default";
+  };
+}
+
+main() {
+  test1(0);
+  test2(0);
+  test3(0);
+}

--- a/LanguageFeatures/Patterns/constant_A02_t20.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t20.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion constantPattern ::= booleanLiteral
+///                   | nullLiteral
+///                   | '-'? numericLiteral
+///                   | stringLiteral
+///                   | symbolLiteral
+///                   | identifier
+///                   | qualifiedName
+///                   | constObjectExpression
+///                   | 'const' typeArguments? '[' elements? ']'
+///                   | 'const' typeArguments? '{' elements? '}'
+///                   | 'const' '(' expression ')'
+///
+/// A constant pattern determines if the matched value is equal to the
+/// constant's value. We don't allow all expressions here because many
+/// expression forms syntactically overlap other kinds of patterns. We avoid
+/// ambiguity while supporting terse forms of the most common constant
+/// expressions like so:
+/// ...
+/// Named constants are also allowed because they aren't ambiguous. That
+/// includes simple identifiers like someConstant, prefixed constants like
+/// some_library.aConstant, static constants on classes like
+/// SomeClass.aConstant, and prefixed static constants like
+/// some_library.SomeClass.aConstant. Simple identifiers would be ambiguous with
+/// variable patterns that aren't marked with var, final, or a type, but
+/// unmarked variable patterns are only allowed in irrefutable contexts where
+/// constant patterns are prohibited.
+///
+/// @description Check that it is a compile-time error if named numerical
+/// constant is prefixed by '-'. Test named constants with a library prefix
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "patterns_lib.dart" as p;
+
+String test1(num value) {
+  switch (value) {
+    case -p.Zero:
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "zero";
+    case -p.Pi:
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "pi";
+    case -p.Answer:
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "answer";
+    case -p.Negative:
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative";
+    case -p.NegativePi:
+//       ^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative-pi";
+    case -p.MaxJSInt:
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "max_int";
+    default:
+      return "default";
+  }
+}
+
+String test2(num value) {
+  if (value case -p.Zero) {
+//               ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "zero";
+  }
+  if (value case -p.Pi) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "pi";
+  }
+  if (value case -p.Answer) {
+//               ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "answer";
+  }
+  if (value case -p.Negative) {
+//               ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative";
+  }
+  if (value case -p.NegativePi) {
+//               ^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative-pi";
+  }
+  if (value case -p.MaxJSInt) {
+//               ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "max_int";
+  }
+  return "default";
+}
+
+String test3(num value) {
+  return switch (value) {
+    case -p.Zero => "zero";
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.Pi => "pi";
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.Answer => "answer";
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.Negative => "nagative";
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.NegativePi => "nagative-pi";
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.MaxJSInt => "max_int";
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    default => "default";
+  };
+}
+
+main() {
+  test1(0);
+  test2(0);
+  test3(0);
+}

--- a/LanguageFeatures/Patterns/constant_A02_t21.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t21.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion constantPattern ::= booleanLiteral
+///                   | nullLiteral
+///                   | '-'? numericLiteral
+///                   | stringLiteral
+///                   | symbolLiteral
+///                   | identifier
+///                   | qualifiedName
+///                   | constObjectExpression
+///                   | 'const' typeArguments? '[' elements? ']'
+///                   | 'const' typeArguments? '{' elements? '}'
+///                   | 'const' '(' expression ')'
+///
+/// A constant pattern determines if the matched value is equal to the
+/// constant's value. We don't allow all expressions here because many
+/// expression forms syntactically overlap other kinds of patterns. We avoid
+/// ambiguity while supporting terse forms of the most common constant
+/// expressions like so:
+/// ...
+/// Named constants are also allowed because they aren't ambiguous. That
+/// includes simple identifiers like someConstant, prefixed constants like
+/// some_library.aConstant, static constants on classes like
+/// SomeClass.aConstant, and prefixed static constants like
+/// some_library.SomeClass.aConstant. Simple identifiers would be ambiguous with
+/// variable patterns that aren't marked with var, final, or a type, but
+/// unmarked variable patterns are only allowed in irrefutable contexts where
+/// constant patterns are prohibited.
+///
+/// @description Check that it is a compile-time error if named numerical
+/// constant is prefixed by '-'. Test static constants
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+class C {
+  static const Zero = 0;
+  static const Pi = 3.14;
+  static const Answer = 42;
+  static const Negative = -1;
+  static const NegativePi = -3.14;
+  static const MaxJSInt = 0x1FFFFFFFFFFFFF;
+}
+
+String test1(num value) {
+  switch (value) {
+    case -C.Zero:
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "zero";
+    case -C.Pi:
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "pi";
+    case -C.Answer:
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "answer";
+    case -C.Negative:
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative";
+    case -C.NegativePi:
+//       ^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative-pi";
+    case -C.MaxJSInt:
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "max_int";
+    default:
+      return "default";
+  }
+}
+
+String test2(num value) {
+  if (value case -C.Zero) {
+//               ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "zero";
+  }
+  if (value case -C.Pi) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "pi";
+  }
+  if (value case -C.Answer) {
+//               ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "answer";
+  }
+  if (value case -C.Negative) {
+//               ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative";
+  }
+  if (value case -C.NegativePi) {
+//               ^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative-pi";
+  }
+  if (value case -C.MaxJSInt) {
+//               ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "max_int";
+  }
+  return "default";
+}
+
+String test3(num value) {
+  return switch (value) {
+    case -C.Zero => "zero";
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -C.Pi => "pi";
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -C.Answer => "answer";
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -C.Negative => "nagative";
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -C.NegativePi => "nagative-pi";
+//       ^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -C.MaxJSInt => "max_int";
+//       ^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    default => "default";
+  };
+}
+
+main() {
+  test1(0);
+  test2(0);
+  test3(0);
+}

--- a/LanguageFeatures/Patterns/constant_A02_t22.dart
+++ b/LanguageFeatures/Patterns/constant_A02_t22.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion constantPattern ::= booleanLiteral
+///                   | nullLiteral
+///                   | '-'? numericLiteral
+///                   | stringLiteral
+///                   | symbolLiteral
+///                   | identifier
+///                   | qualifiedName
+///                   | constObjectExpression
+///                   | 'const' typeArguments? '[' elements? ']'
+///                   | 'const' typeArguments? '{' elements? '}'
+///                   | 'const' '(' expression ')'
+///
+/// A constant pattern determines if the matched value is equal to the
+/// constant's value. We don't allow all expressions here because many
+/// expression forms syntactically overlap other kinds of patterns. We avoid
+/// ambiguity while supporting terse forms of the most common constant
+/// expressions like so:
+/// ...
+/// Named constants are also allowed because they aren't ambiguous. That
+/// includes simple identifiers like someConstant, prefixed constants like
+/// some_library.aConstant, static constants on classes like
+/// SomeClass.aConstant, and prefixed static constants like
+/// some_library.SomeClass.aConstant. Simple identifiers would be ambiguous with
+/// variable patterns that aren't marked with var, final, or a type, but
+/// unmarked variable patterns are only allowed in irrefutable contexts where
+/// constant patterns are prohibited.
+///
+/// @description Check that it is a compile-time error if named numerical
+/// constant is prefixed by '-'. Test static constants in a perfixed library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "patterns_lib.dart" as p;
+
+String test1(num value) {
+  switch (value) {
+    case -p.C0.Zero:
+//       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "zero";
+    case -p.C0.Pi:
+//       ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "pi";
+    case -p.C0.Answer:
+//       ^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "answer";
+    case -p.C0.Negative:
+//       ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative";
+    case -p.C0.NegativePi:
+//       ^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "nagative-pi";
+    case -p.C0.MaxJSInt:
+//       ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      return "max_int";
+    default:
+      return "default";
+  }
+}
+
+String test2(num value) {
+  if (value case -p.C0.Zero) {
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "zero";
+  }
+  if (value case -p.C0.Pi) {
+//               ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "pi";
+  }
+  if (value case -p.C0.Answer) {
+//               ^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "answer";
+  }
+  if (value case -p.C0.Negative) {
+//               ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative";
+  }
+  if (value case -p.C0.NegativePi) {
+//               ^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "nagative-pi";
+  }
+  if (value case -p.C0.MaxJSInt) {
+//               ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return "max_int";
+  }
+  return "default";
+}
+
+String test3(num value) {
+  return switch (value) {
+    case -p.C0.Zero => "zero";
+//       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.C0.Pi => "pi";
+//       ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.C0.Answer => "answer";
+//       ^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.C0.Negative => "nagative";
+//       ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.C0.NegativePi => "nagative-pi";
+//       ^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case -p.C0.MaxJSInt => "max_int";
+//       ^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    default => "default";
+  };
+}
+
+main() {
+  test1(0);
+  test2(0);
+  test3(0);
+}

--- a/LanguageFeatures/Patterns/constant_A03_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -23,7 +24,8 @@
 /// literals explicitly marked const. Likewise with set and map literals versus
 /// map patterns.
 ///
-/// @description Check list, map and set literals in constant patterns
+/// @description Check list, map and set literals in constant patterns. Test
+/// switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -34,6 +36,8 @@ String testList(List value) {
   switch (value) {
     case const [1, 2]:
       return "[1, 2]";
+    case const [1, -2]:
+      return "[1, -2]";
     case const ["3", "4"]:
       return "['3', '4']";
     case const [true, true]:
@@ -49,8 +53,8 @@ String testMap(Map value) {
   switch (value) {
     case const {1: 2}:
       return "{1: 2}";
-    case const {'answer': 42}:
-      return "{'answer': 42}";
+    case const {'answer': -42}:
+      return "{'answer': -42}";
     case const {'true': true}:
       return "{'true': true}";
     case const {}:
@@ -62,8 +66,8 @@ String testMap(Map value) {
 
 String testSet(Set value) {
   switch (value) {
-    case const {1, 2, 3}:
-      return "{1, 2, 3}";
+    case const {1, 2, -3}:
+      return "{1, 2, -3}";
     case const {'1', '2', '3'}:
       return "{'1', '2', '3'}";
     case const {}:
@@ -75,30 +79,32 @@ String testSet(Set value) {
 
 main() {
   Expect.equals("[1, 2]", testList(const [1, 2]));
+  Expect.equals("[1, -2]", testList(const [1, -2]));
   Expect.equals("['3', '4']", testList(const ["3", "4"]));
   Expect.equals("[true, true]", testList(const [true, true]));
   Expect.equals("[]", testList(const []));
   Expect.equals("default", testList([1]));
   Expect.equals("default", testList([1, 2]));
+  Expect.equals("default", testList([1, -2]));
   Expect.equals("default", testList(["3", "4"]));
   Expect.equals("default", testList([true, true]));
   Expect.equals("default", testList([]));
 
   Expect.equals("{1: 2}", testMap(const {1: 2}));
-  Expect.equals("{'answer': 42}", testMap(const {'answer': 42}));
+  Expect.equals("{'answer': -42}", testMap(const {'answer': -42}));
   Expect.equals("{'true': true}", testMap(const {'true': true}));
   Expect.equals("{}", testMap(const {}));
   Expect.equals("default", testMap({'x': 'y'}));
   Expect.equals("default", testMap({1: 2}));
-  Expect.equals("default", testMap({'answer': 42}));
+  Expect.equals("default", testMap({'answer': -42}));
   Expect.equals("default", testMap({'true': true}));
   Expect.equals("default", testMap({}));
 
-  Expect.equals("{1, 2, 3}", testSet(const {1, 2, 3}));
+  Expect.equals("{1, 2, -3}", testSet(const {1, 2, -3}));
   Expect.equals("{'1', '2', '3'}", testSet(const {'1', '2', '3'}));
   Expect.equals("{}", testSet(const {}));
   Expect.equals("default", testSet({1}));
-  Expect.equals("default", testSet({1, 2, 3}));
+  Expect.equals("default", testSet({1, 2, -3}));
   Expect.equals("default", testSet({'1', '2', '3'}));
   Expect.equals("default", testSet({}));
 }

--- a/LanguageFeatures/Patterns/constant_A03_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t01.dart
@@ -66,11 +66,11 @@ String testMap(Map value) {
 
 String testSet(Set value) {
   switch (value) {
-    case const {1, 2, -3}:
+    case const ({1, 2, -3}):
       return "{1, 2, -3}";
-    case const {'1', '2', '3'}:
+    case const ({'1', '2', '3'}):
       return "{'1', '2', '3'}";
-    case const {}:
+    case const (<dynamic>{}):
       return "{}";
     default:
       return "default";

--- a/LanguageFeatures/Patterns/constant_A03_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t02.dart
@@ -63,11 +63,11 @@ String testMap(Map value) {
 }
 
 String testSet(Set value) {
-  if (value case const {1, 2, -3}) {
+  if (value case const ({1, 2, -3})) {
     return "{1, 2, 3}";
-  } else if (value case const {'1', '2', '3'}) {
+  } else if (value case const ({'1', '2', '3'})) {
     return "{'1', '2', '3'}";
-  } else if (value case const {}) {
+  } else if (value case const (<dynamic>{})) {
     return "{}";
   } else {
     return "default";

--- a/LanguageFeatures/Patterns/constant_A03_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -34,6 +35,8 @@ import "../../Utils/expect.dart";
 String testList(List value) {
   if (value case const [1, 2]) {
     return "[1, 2]";
+  } else if (value case const [1, -2]) {
+    return "[1, -2]";
   } else if (value case const ["3", "4"]) {
     return "['3', '4']";
   } else if (value case const [true, true]) {
@@ -48,8 +51,8 @@ String testList(List value) {
 String testMap(Map value) {
   if (value case const {1: 2}) {
     return "{1: 2}";
-  } else if (value case const {'answer': 42}) {
-    return "{'answer': 42}";
+  } else if (value case const {'answer': -42}) {
+    return "{'answer': -42}";
   } else if (value case const {'true': true}) {
     return "{'true': true}";
   } else if (value case const {}) {
@@ -60,7 +63,7 @@ String testMap(Map value) {
 }
 
 String testSet(Set value) {
-  if (value case const {1, 2, 3}) {
+  if (value case const {1, 2, -3}) {
     return "{1, 2, 3}";
   } else if (value case const {'1', '2', '3'}) {
     return "{'1', '2', '3'}";
@@ -73,6 +76,7 @@ String testSet(Set value) {
 
 main() {
   Expect.equals("[1, 2]", testList(const [1, 2]));
+  Expect.equals("[1, -2]", testList(const [1, -2]));
   Expect.equals("['3', '4']", testList(const ["3", "4"]));
   Expect.equals("[true, true]", testList(const [true, true]));
   Expect.equals("[]", testList(const []));
@@ -83,20 +87,20 @@ main() {
   Expect.equals("default", testList([]));
 
   Expect.equals("{1: 2}", testMap(const {1: 2}));
-  Expect.equals("{'answer': 42}", testMap(const {'answer': 42}));
+  Expect.equals("{'answer': -42}", testMap(const {'answer': -42}));
   Expect.equals("{'true': true}", testMap(const {'true': true}));
   Expect.equals("{}", testMap(const {}));
   Expect.equals("default", testMap({'x': 'y'}));
   Expect.equals("default", testMap({1: 2}));
-  Expect.equals("default", testMap({'answer': 42}));
+  Expect.equals("default", testMap({'answer': -42}));
   Expect.equals("default", testMap({'true': true}));
   Expect.equals("default", testMap({}));
 
-  Expect.equals("{1, 2, 3}", testSet(const {1, 2, 3}));
+  Expect.equals("{1, 2, -3}", testSet(const {1, 2, -3}));
   Expect.equals("{'1', '2', '3'}", testSet(const {'1', '2', '3'}));
   Expect.equals("{}", testSet(const {}));
   Expect.equals("default", testSet({1}));
-  Expect.equals("default", testSet({1, 2, 3}));
+  Expect.equals("default", testSet({1, 2, -3}));
   Expect.equals("default", testSet({'1', '2', '3'}));
   Expect.equals("default", testSet({}));
 }

--- a/LanguageFeatures/Patterns/constant_A03_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t03.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -23,8 +24,8 @@
 /// literals explicitly marked const. Likewise with set and map literals versus
 /// map patterns.
 ///
-/// @description Check list, map and set literals with type argument specified
-/// in constant patterns
+/// @description Check list, map and set literals in constant patterns. Test
+/// switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -32,108 +33,63 @@
 import "../../Utils/expect.dart";
 
 String testList(List value) {
-  switch (value) {
-    case const <int>[1, 2]:
-      return "<int>[1, 2]";
-    case const <dynamic>[1, 2]:
-      return "<dynamic>[1, 2]";
-    case const <String>["3", "4"]:
-      return "<String>['3', '4']";
-    case const <dynamic>["3", "4"]:
-      return "<dynamic>['3', '4']";
-    case const <double>[]:
-      return "<double>[]";
-    case const <dynamic>[]:
-      return "<dynamic>[]";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const [1, 2] => "[1, 2]";
+    case const [1, -2] => "[1, -2]";
+    case const ["3", "4"] => "['3', '4']";
+    case const [true, true] => "[true, true]";
+    case const [] => "[]";
+    default => "default";
+  };
 }
 
 String testMap(Map value) {
-  switch (value) {
-    case const <int, int>{1: 2}:
-      return "<int, int>{1: 2}";
-    case const <dynamic, dynamic>{1: 2}:
-      return "<dynamic, dynamic>{1: 2}";
-    case const <String, num>{'answer': 42}:
-      return "<String, num>{'answer': 42}";
-    case const <dynamic, dynamic>{'answer': 42}:
-      return "<dynamic, dynamic>{'answer': 42}";
-    case const <String, Object>{'true': true}:
-      return "<String, Object>{'true': true}";
-    case const <dynamic, dynamic>{'true': true}:
-      return "<dynamic, dynamic>{'true': true}";
-    case const <String, int>{}:
-      return "<String, int>{}";
-    case const <dynamic, dynamic>{}:
-      return "<dynamic, dynamic>{}";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const {1: 2} => "{1: 2}";
+    case const {'answer': -42} => "{'answer': -42}";
+    case const {'true': true} => "{'true': true}";
+    case const {} => "{}";
+    default => "default";
+  };
 }
 
 String testSet(Set value) {
-  switch (value) {
-    case const <num>{1, 2, 3}:
-      return "<num>{1, 2, 3}";
-    case const <dynamic>{1, 2, 3}:
-      return "<dynamic>{1, 2, 3}";
-    case const <String>{'1', '2', '3'}:
-      return "<String>{'1', '2', '3'}";
-    case const <dynamic>{'1', '2', '3'}:
-      return "<dynamic>{'1', '2', '3'}";
-    case const <double>{}:
-      return "<double>{}";
-    case const <dynamic>{}:
-      return "<dynamic>{}";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const {1, 2, -3} => "{1, 2, -3}";
+    case const {'1', '2', '3'} => "{'1', '2', '3'}";
+    case const {} => "{}";
+    default => "default";
+  };
 }
 
 main() {
-  Expect.equals("<dynamic>[1, 2]", testList(const [1, 2]));
-  Expect.equals("<int>[1, 2]", testList(const <int>[1, 2]));
+  Expect.equals("[1, 2]", testList(const [1, 2]));
+  Expect.equals("[1, -2]", testList(const [1, -2]));
+  Expect.equals("['3', '4']", testList(const ["3", "4"]));
+  Expect.equals("[true, true]", testList(const [true, true]));
+  Expect.equals("[]", testList(const []));
+  Expect.equals("default", testList([1]));
   Expect.equals("default", testList([1, 2]));
-  Expect.equals("default", testList(const <num>[1, 2]));
-  Expect.equals("default", testList(const <Object>[1, 2]));
-  Expect.equals("<dynamic>['3', '4']", testList(const ["3", "4"]));
-  Expect.equals("<String>['3', '4']", testList(const <String>["3", "4"]));
+  Expect.equals("default", testList([1, -2]));
   Expect.equals("default", testList(["3", "4"]));
-  Expect.equals("default", testList(const <Object>["3", "4"]));
-  Expect.equals("<double>[]", testList(const <double>[]));
-  Expect.equals("<dynamic>[]", testList(const []));
-  Expect.equals("default", testList(const <num>[]));
-  Expect.equals("default", testList(const <Object>[]));
+  Expect.equals("default", testList([true, true]));
+  Expect.equals("default", testList([]));
 
-  Expect.equals("<dynamic, dynamic>{1: 2}", testMap(const {1: 2}));
-  Expect.equals("<int, int>{1: 2}", testMap(const <int, int>{1: 2}));
+  Expect.equals("{1: 2}", testMap(const {1: 2}));
+  Expect.equals("{'answer': -42}", testMap(const {'answer': -42}));
+  Expect.equals("{'true': true}", testMap(const {'true': true}));
+  Expect.equals("{}", testMap(const {}));
+  Expect.equals("default", testMap({'x': 'y'}));
   Expect.equals("default", testMap({1: 2}));
-  Expect.equals("default", testMap(const <num, num>{1: 2}));
-  Expect.equals("<dynamic, dynamic>{'answer': 42}",
-      testMap(const {'answer': 42}));
-  Expect.equals("<String, num>{'answer': 42}",
-      testMap(const <String, num>{'answer': 42}));
-  Expect.equals("default", testMap(const <Object, int>{'answer': 42}));
-  Expect.equals("<dynamic, dynamic>{'true': true}",
-      testMap(const {'true': true}));
-  Expect.equals("<String, Object>{'true': true}",
-      testMap(const <String, Object>{'true': true}));
-  Expect.equals("<String, int>{}", testMap(const <String, int>{}));
-  Expect.equals("<dynamic, dynamic>{}", testMap(const {}));
-  Expect.equals("default", testMap(const {'x': 'y'}));
+  Expect.equals("default", testMap({'answer': -42}));
+  Expect.equals("default", testMap({'true': true}));
+  Expect.equals("default", testMap({}));
 
-  Expect.equals("<num>{1, 2, 3}", testSet(const <num>{1, 2, 3}));
-  Expect.equals("default", testSet(<num>{1, 2, 3}));
-  Expect.equals("<dynamic>{1, 2, 3}", testSet(const {1, 2, 3}));
-  Expect.equals("<dynamic>{'1', '2', '3'}", testSet(const {'1', '2', '3'}));
-  Expect.equals("<String>{'1', '2', '3'}",
-      testSet(const <String>{'1', '2', '3'}));
-  Expect.equals("default", testSet(const <Object>{'1', '2', '3'}));
-  Expect.equals("default", testSet(<Object>{'1', '2', '3'}));
-  Expect.equals("<double>{}", testSet(const <double>{}));
-  Expect.equals("<dynamic>{}", testSet(const {}));
-  Expect.equals("default", testSet(<double>{}));
-  Expect.equals("default", testSet(const {1}));
+  Expect.equals("{1, 2, -3}", testSet(const {1, 2, -3}));
+  Expect.equals("{'1', '2', '3'}", testSet(const {'1', '2', '3'}));
+  Expect.equals("{}", testSet(const {}));
+  Expect.equals("default", testSet({1}));
+  Expect.equals("default", testSet({1, 2, -3}));
+  Expect.equals("default", testSet({'1', '2', '3'}));
+  Expect.equals("default", testSet({}));
 }

--- a/LanguageFeatures/Patterns/constant_A03_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t03.dart
@@ -55,9 +55,9 @@ String testMap(Map value) {
 
 String testSet(Set value) {
   return switch (value) {
-    case const {1, 2, -3} => "{1, 2, -3}";
-    case const {'1', '2', '3'} => "{'1', '2', '3'}";
-    case const {} => "{}";
+    case const ({1, 2, -3}) => "{1, 2, -3}";
+    case const ({'1', '2', '3'}) => "{'1', '2', '3'}";
+    case const (<dynamic>{}) => "{}";
     default => "default";
   };
 }

--- a/LanguageFeatures/Patterns/constant_A03_t04.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t04.dart
@@ -76,17 +76,17 @@ String testMap(Map value) {
 
 String testSet(Set value) {
   switch (value) {
-    case const <num>{1, 2, -3}:
+    case const (<num>{1, 2, -3}):
       return "<num>{1, 2, -3}";
-    case const <dynamic>{1, 2, -3}:
+    case const (<dynamic>{1, 2, -3}):
       return "<dynamic>{1, 2, -3}";
-    case const <String>{'1', '2', '3'}:
+    case const (<String>{'1', '2', '3'}):
       return "<String>{'1', '2', '3'}";
-    case const <dynamic>{'1', '2', '3'}:
+    case const (<dynamic>{'1', '2', '3'}):
       return "<dynamic>{'1', '2', '3'}";
-    case const <double>{}:
+    case const (<double>{}):
       return "<double>{}";
-    case const <dynamic>{}:
+    case const (<dynamic>{}):
       return "<dynamic>{}";
     default:
       return "default";

--- a/LanguageFeatures/Patterns/constant_A03_t05.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t05.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -23,74 +24,131 @@
 /// literals explicitly marked const. Likewise with set and map literals versus
 /// map patterns.
 ///
-/// @description Check empty map and set literals in constant patterns
+/// @description Check list, map and set literals with type argument specified
+/// in constant patterns. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
 
-String testObject1(Object value) {
-  switch (value) {
-    case const {}:
-      return "{}";
-    default:
-      return "default";
+String testList(List value) {
+  if (value case const <int>[1, -2]) {
+    return "<int>[1, -2]";
   }
-}
-
-String testObject2(Object value) {
-  if (value case const {}) {
-    return "{}";
+  if (value case const <dynamic>[1, -2]) {
+    return "<dynamic>[1, -2]";
+  }
+  if (value case const <String>["3", "4"]) {
+    return "<String>['3', '4']";
+  }
+  if (value case const <dynamic>["3", "4"]) {
+    return "<dynamic>['3', '4']";
+  }
+  if (value case const <double>[]) {
+    return "<double>[]";
+  }
+  if (value case const <dynamic>[]) {
+    return "<dynamic>[]";
   } else {
     return "default";
   }
 }
 
-String testMap1(Map value) {
-  switch (value) {
-    case const {}:
-      return "{}";
-    default:
-      return "default";
+String testMap(Map value) {
+  if (value case const <int, int>{1: -2}) {
+    return "<int, int>{1: -2}";
   }
-}
-
-String testMap2(Map value) {
-  if (value case const {}) {
-    return "{}";
+  if (value case const <dynamic, dynamic>{1: 2}) {
+    return "<dynamic, dynamic>{1: -2}";
+  }
+  if (value case const <String, num>{'answer': 42}) {
+    return "<String, num>{'answer': 42}";
+  }
+  if (value case const <dynamic, dynamic>{'answer': 42}) {
+    return "<dynamic, dynamic>{'answer': 42}";
+  }
+  if (value case const <String, Object>{'true': true}) {
+    return "<String, Object>{'true': true}";
+  }
+  if (value case const <dynamic, dynamic>{'true': true}) {
+    return "<dynamic, dynamic>{'true': true}";
+  }
+  if (value case const <String, int>{}) {
+    return "<String, int>{}";
+  }
+  if (value case const <dynamic, dynamic>{}) {
+    return "<dynamic, dynamic>{}";
   } else {
     return "default";
   }
 }
 
-String testSet1(Set value) {
-  switch (value) {
-    case const {}:
-      return "{}";
-    default:
-      return "default";
+String testSet(Set value) {
+  if (value case const <num>{1, 2, -3}) {
+    return "<num>{1, 2, -3}";
   }
-}
-
-String testSet2(Set value) {
-  if (value case const {}) {
-    return "{}";
+  if (value case const <dynamic>{1, 2, -3}) {
+    return "<dynamic>{1, 2, -3}";
+  }
+  if (value case const <String>{'1', '2', '3'}) {
+    return "<String>{'1', '2', '3'}";
+  }
+  if (value case const <dynamic>{'1', '2', '3'}) {
+    return "<dynamic>{'1', '2', '3'}";
+  }
+  if (value case const <double>{}) {
+    return "<double>{}";
+  }
+  if (value case const <dynamic>{}) {
+    return "<dynamic>{}";
   } else {
     return "default";
   }
 }
 
 main() {
-  const Map m = {};
-  Expect.equals("{}", testObject1(m));
-  Expect.equals("{}", testObject2(m));
-  Expect.equals("{}", testMap1(m));
-  Expect.equals("{}", testMap2(m));
+  Expect.equals("<dynamic>[1, -2]", testList(const [1, 2]));
+  Expect.equals("<int>[1, -2]", testList(const <int>[1, -2]));
+  Expect.equals("default", testList([1, -2]));
+  Expect.equals("default", testList(const <num>[1, -2]));
+  Expect.equals("default", testList(const <Object>[1, -2]));
+  Expect.equals("<dynamic>['3', '4']", testList(const ["3", "4"]));
+  Expect.equals("<String>['3', '4']", testList(const <String>["3", "4"]));
+  Expect.equals("default", testList(["3", "4"]));
+  Expect.equals("default", testList(const <Object>["3", "4"]));
+  Expect.equals("<double>[]", testList(const <double>[]));
+  Expect.equals("<dynamic>[]", testList(const []));
+  Expect.equals("default", testList(const <num>[]));
+  Expect.equals("default", testList(const <Object>[]));
 
-  const Set s = {};
-  Expect.equals("default", testObject1(s));
-  Expect.equals("default", testObject2(s));
-  Expect.equals("{}", testSet1(s));
-  Expect.equals("{}", testSet2(s));
+  Expect.equals("<dynamic, dynamic>{1: -2}", testMap(const {1: -2}));
+  Expect.equals("<int, int>{1: -2}", testMap(const <int, int>{1: -2}));
+  Expect.equals("default", testMap({1: -2}));
+  Expect.equals("default", testMap(const <num, num>{1: -2}));
+  Expect.equals("<dynamic, dynamic>{'answer': 42}",
+      testMap(const {'answer': 42}));
+  Expect.equals("<String, num>{'answer': 42}",
+      testMap(const <String, num>{'answer': 42}));
+  Expect.equals("default", testMap(const <Object, int>{'answer': 42}));
+  Expect.equals("<dynamic, dynamic>{'true': true}",
+      testMap(const {'true': true}));
+  Expect.equals("<String, Object>{'true': true}",
+      testMap(const <String, Object>{'true': true}));
+  Expect.equals("<String, int>{}", testMap(const <String, int>{}));
+  Expect.equals("<dynamic, dynamic>{}", testMap(const {}));
+  Expect.equals("default", testMap(const {'x': 'y'}));
+
+  Expect.equals("<num>{1, 2, -3}", testSet(const <num>{1, 2, -3}));
+  Expect.equals("default", testSet(<num>{1, 2, -3}));
+  Expect.equals("<dynamic>{1, 2, -3}", testSet(const {1, 2, -3}));
+  Expect.equals("<dynamic>{'1', '2', '3'}", testSet(const {'1', '2', '3'}));
+  Expect.equals("<String>{'1', '2', '3'}",
+      testSet(const <String>{'1', '2', '3'}));
+  Expect.equals("default", testSet(const <Object>{'1', '2', '3'}));
+  Expect.equals("default", testSet(<Object>{'1', '2', '3'}));
+  Expect.equals("<double>{}", testSet(const <double>{}));
+  Expect.equals("<dynamic>{}", testSet(const {}));
+  Expect.equals("default", testSet(<double>{}));
+  Expect.equals("default", testSet(const {1}));
 }

--- a/LanguageFeatures/Patterns/constant_A03_t05.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t05.dart
@@ -85,22 +85,22 @@ String testMap(Map value) {
 }
 
 String testSet(Set value) {
-  if (value case const <num>{1, 2, -3}) {
+  if (value case const (<num>{1, 2, -3})) {
     return "<num>{1, 2, -3}";
   }
-  if (value case const <dynamic>{1, 2, -3}) {
+  if (value case const (<dynamic>{1, 2, -3})) {
     return "<dynamic>{1, 2, -3}";
   }
-  if (value case const <String>{'1', '2', '3'}) {
+  if (value case const (<String>{'1', '2', '3'})) {
     return "<String>{'1', '2', '3'}";
   }
-  if (value case const <dynamic>{'1', '2', '3'}) {
+  if (value case const (<dynamic>{'1', '2', '3'})) {
     return "<dynamic>{'1', '2', '3'}";
   }
-  if (value case const <double>{}) {
+  if (value case const (<double>{})) {
     return "<double>{}";
   }
-  if (value case const <dynamic>{}) {
+  if (value case const (<dynamic>{})) {
     return "<dynamic>{}";
   } else {
     return "default";

--- a/LanguageFeatures/Patterns/constant_A03_t06.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t06.dart
@@ -25,7 +25,7 @@
 /// map patterns.
 ///
 /// @description Check list, map and set literals with type argument specified
-/// in constant patterns. Test switch statement
+/// in constant patterns. Test switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -33,64 +33,44 @@
 import "../../Utils/expect.dart";
 
 String testList(List value) {
-  switch (value) {
-    case const <int>[1, -2]:
-      return "<int>[1, -2]";
-    case const <dynamic>[1, -2]:
-      return "<dynamic>[1, -2]";
-    case const <String>["3", "4"]:
-      return "<String>['3', '4']";
-    case const <dynamic>["3", "4"]:
-      return "<dynamic>['3', '4']";
-    case const <double>[]:
-      return "<double>[]";
-    case const <dynamic>[]:
-      return "<dynamic>[]";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const <int>[1, -2] => "<int>[1, -2]";
+    case const <dynamic>[1, -2] => "<dynamic>[1, -2]";
+    case const <String>["3", "4"] => "<String>['3', '4']";
+    case const <dynamic>["3", "4"] => "<dynamic>['3', '4']";
+    case const <double>[] => "<double>[]";
+    case const <dynamic>[] => "<dynamic>[]";
+    default => "default";
+  };
 }
 
 String testMap(Map value) {
-  switch (value) {
-    case const <int, int>{1: -2}:
-      return "<int, int>{1: -2}";
-    case const <dynamic, dynamic>{1: -2}:
-      return "<dynamic, dynamic>{1: -2}";
-    case const <String, num>{'answer': 42}:
-      return "<String, num>{'answer': 42}";
-    case const <dynamic, dynamic>{'answer': 42}:
-      return "<dynamic, dynamic>{'answer': 42}";
-    case const <String, Object>{'true': true}:
-      return "<String, Object>{'true': true}";
-    case const <dynamic, dynamic>{'true': true}:
-      return "<dynamic, dynamic>{'true': true}";
-    case const <String, int>{}:
-      return "<String, int>{}";
-    case const <dynamic, dynamic>{}:
-      return "<dynamic, dynamic>{}";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const <int, int>{1: -2} => "<int, int>{1: -2}";
+    case const <dynamic, dynamic>{1: -2} => "<dynamic, dynamic>{1: -2}";
+    case const <String, num>{'answer': 42} => "<String, num>{'answer': 42}";
+    case const <dynamic, dynamic>{'answer': 42} =>
+        "<dynamic, dynamic>{'answer': 42}";
+    case const <String, Object>{'true': true} =>
+        "<String, Object>{'true': true}";
+    case const <dynamic, dynamic>{'true': true} =>
+        "<dynamic, dynamic>{'true': true}";
+    case const <String, int>{} => "<String, int>{}";
+    case const <dynamic, dynamic>{} => "<dynamic, dynamic>{}";
+    default => "default";
+  };
 }
 
 String testSet(Set value) {
-  switch (value) {
-    case const <num>{1, 2, -3}:
-      return "<num>{1, 2, -3}";
-    case const <dynamic>{1, 2, -3}:
-      return "<dynamic>{1, 2, -3}";
-    case const <String>{'1', '2', '3'}:
-      return "<String>{'1', '2', '3'}";
-    case const <dynamic>{'1', '2', '3'}:
-      return "<dynamic>{'1', '2', '3'}";
-    case const <double>{}:
-      return "<double>{}";
-    case const <dynamic>{}:
-      return "<dynamic>{}";
-    default:
-      return "default";
-  }
+  return switch (value) {
+    case const <num>{1, 2, -3} => "<num>{1, 2, -3}";
+    case const <dynamic>{1, 2, -3} => "<dynamic>{1, 2, -3}";
+    case const <String>{'1', '2', '3'} => "<String>{'1', '2', '3'}";
+    case const <dynamic>{'1', '2', '3'} => "<dynamic>{'1', '2', '3'}";
+    case const <double>{} => "<double>{}";
+    case const <dynamic>{} => "<dynamic>{}";
+    default => "default";
+  };
 }
 
 main() {

--- a/LanguageFeatures/Patterns/constant_A03_t06.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t06.dart
@@ -63,12 +63,12 @@ String testMap(Map value) {
 
 String testSet(Set value) {
   return switch (value) {
-    case const <num>{1, 2, -3} => "<num>{1, 2, -3}";
-    case const <dynamic>{1, 2, -3} => "<dynamic>{1, 2, -3}";
-    case const <String>{'1', '2', '3'} => "<String>{'1', '2', '3'}";
-    case const <dynamic>{'1', '2', '3'} => "<dynamic>{'1', '2', '3'}";
-    case const <double>{} => "<double>{}";
-    case const <dynamic>{} => "<dynamic>{}";
+    case const (<num>{1, 2, -3}) => "<num>{1, 2, -3}";
+    case const (<dynamic>{1, 2, -3}) => "<dynamic>{1, 2, -3}";
+    case const (<String>{'1', '2', '3'}) => "<String>{'1', '2', '3'}";
+    case const (<dynamic>{'1', '2', '3'}) => "<dynamic>{'1', '2', '3'}";
+    case const (<double>{}) => "<double>{}";
+    case const (<dynamic>{}) => "<dynamic>{}";
     default => "default";
   };
 }

--- a/LanguageFeatures/Patterns/constant_A03_t07.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t07.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion constantPattern ::= booleanLiteral
+///                   | nullLiteral
+///                   | '-'? numericLiteral
+///                   | stringLiteral
+///                   | symbolLiteral
+///                   | identifier
+///                   | qualifiedName
+///                   | constObjectExpression
+///                   | 'const' typeArguments? '[' elements? ']'
+///                   | 'const' typeArguments? '{' elements? '}'
+///                   | 'const' '(' expression ')'
+///
+/// A constant pattern determines if the matched value is equal to the
+/// constant's value. We don't allow all expressions here because many
+/// expression forms syntactically overlap other kinds of patterns. We avoid
+/// ambiguity while supporting terse forms of the most common constant
+/// expressions like so:
+/// ...
+/// List literals are ambiguous with list patterns, so we only allow list
+/// literals explicitly marked const. Likewise with set and map literals versus
+/// map patterns.
+///
+/// @description Check empty map and set literals in constant patterns
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+
+String testObject1(Object value) {
+  switch (value) {
+    case const {}:
+      return "{}";
+    default:
+      return "default";
+  }
+}
+
+String testObject2(Object value) {
+  if (value case const {}) {
+    return "{}";
+  } else {
+    return "default";
+  }
+}
+
+String testObject3(Object value) {
+  return switch (value) {
+    case const {} => return "{}";
+    default => "default";
+  };
+}
+
+String testMap1(Map value) {
+  switch (value) {
+    case const {}:
+      return "{}";
+    default:
+      return "default";
+  }
+}
+
+String testMap2(Map value) {
+  if (value case const {}) {
+    return "{}";
+  } else {
+    return "default";
+  }
+}
+
+String testMap3(Map value) {
+  return switch (value) {
+    case const {} => "{}";
+    default => "default";
+  };
+}
+
+String testSet1(Set value) {
+  switch (value) {
+    case const {}:
+      return "{}";
+    default:
+      return "default";
+  }
+}
+
+String testSet2(Set value) {
+  if (value case const {}) {
+    return "{}";
+  } else {
+    return "default";
+  }
+}
+
+String testSet3(Set value) {
+  return switch (value) {
+    case const {} => "{}";
+    default => "default";
+  }
+}
+
+main() {
+  const Map m = {};
+  Expect.equals("{}", testObject1(m));
+  Expect.equals("{}", testObject2(m));
+  Expect.equals("{}", testObject3(m));
+  Expect.equals("{}", testMap1(m));
+  Expect.equals("{}", testMap2(m));
+  Expect.equals("{}", testMap3(m));
+
+  const Set s = {};
+  Expect.equals("default", testObject1(s));
+  Expect.equals("default", testObject2(s));
+  Expect.equals("default", testObject3(s));
+  Expect.equals("{}", testSet1(s));
+  Expect.equals("{}", testSet2(s));
+  Expect.equals("{}", testSet3(s));
+}

--- a/LanguageFeatures/Patterns/constant_A03_t07.dart
+++ b/LanguageFeatures/Patterns/constant_A03_t07.dart
@@ -81,7 +81,7 @@ String testMap3(Map value) {
 
 String testSet1(Set value) {
   switch (value) {
-    case const {}:
+    case const (<dynamic>{}):
       return "{}";
     default:
       return "default";
@@ -89,7 +89,7 @@ String testSet1(Set value) {
 }
 
 String testSet2(Set value) {
-  if (value case const {}) {
+  if (value case const (<dynamic>{})) {
     return "{}";
   } else {
     return "default";
@@ -98,7 +98,7 @@ String testSet2(Set value) {
 
 String testSet3(Set value) {
   return switch (value) {
-    case const {} => "{}";
+    case const (<dynamic>{}) => "{}";
     default => "default";
   }
 }

--- a/LanguageFeatures/Patterns/constant_A04_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A04_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -22,7 +23,7 @@
 /// Constructor calls are ambiguous with object patterns, so we require const
 /// constructor calls to be explicitly marked const.
 ///
-/// @description Check const constructors calls in constant patterns
+/// @description Check const constructors calls in constant patterns.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -59,6 +60,15 @@ String test2(C value) {
   }
 }
 
+String test3(C value) {
+  return switch (value) {
+    case const C(0) => "0";
+    case const C(1) => "1";
+    case const C("x") => "x";
+    default => "default";
+  };
+}
+
 main() {
   Expect.equals("0", test1(const C(0)));
   Expect.equals("default", test1(C(0)));
@@ -77,4 +87,13 @@ main() {
   Expect.equals("default", test2(C("x")));
   Expect.equals("default", test2(const C(2)));
   Expect.equals("default", test2(const C("y")));
+
+  Expect.equals("0", test3(const C(0)));
+  Expect.equals("default", test3(C(0)));
+  Expect.equals("1", test3(const C(1)));
+  Expect.equals("default", test3(C(1)));
+  Expect.equals("x", test3(const C("x")));
+  Expect.equals("default", test3(C("x")));
+  Expect.equals("default", test3(const C(2)));
+  Expect.equals("default", test3(const C("y")));
 }

--- a/LanguageFeatures/Patterns/constant_A04_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A04_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -59,6 +60,15 @@ String test2(C value) {
   }
 }
 
+String test3(C value) {
+  return switch (value) {
+    case const C<String>(0) => "0";
+    case const C<num>(1) => "1";
+    case const C<bool>("x") => "x";
+    default => "default";
+  };
+}
+
 main() {
   Expect.equals("0", test1(const C<String>(0)));
   Expect.equals("default", test1(C<String>(0)));
@@ -81,4 +91,15 @@ main() {
   Expect.equals("default", test2(C("x")));
   Expect.equals("default", test2(const C("x")));
   Expect.equals("default", test2(const C("y")));
+
+  Expect.equals("0", test3(const C<String>(0)));
+  Expect.equals("default", test3(C<String>(0)));
+  Expect.equals("default", test3(const C<int>(0)));
+  Expect.equals("1", test3(const C<num>(1)));
+  Expect.equals("default", test3(C<num>(1)));
+  Expect.equals("default", test3(const C<String>(1)));
+  Expect.equals("x", test3(const C<bool>("x")));
+  Expect.equals("default", test3(C("x")));
+  Expect.equals("default", test3(const C("x")));
+  Expect.equals("default", test3(const C("y")));
 }

--- a/LanguageFeatures/Patterns/constant_A05_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A05_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -19,12 +20,13 @@
 /// ambiguity while supporting terse forms of the most common constant
 /// expressions like so:
 /// ...
-/// Other constant expressions must be marked const and surrounded by
+/// Other  must be marked const and surrounded by
 /// parentheses. This avoids ambiguity with null-assert, logical-or, and
 /// logical-and patterns. It also makes future extensions to patterns and
 /// expressions less likely to collide.
 ///
-/// @description Check const constructors calls in constant patterns
+/// @description Check constant expressions in constant patterns. Test switch
+/// statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
@@ -55,9 +57,9 @@ String test(Object value) {
       return "case =43";
     case const (19 << 1):
       return "case =38";
-    case const (1 > 2):
+    case const (-1 > 2):
       return "case =false";
-    case const (1 < 2):
+    case const (-1 < 2):
       return "case =true";
     case const ("Lily" + " " "was" " " + "here"):
       return "case String";
@@ -70,7 +72,7 @@ String test2(Object value) {
   switch (value) {
     case const (1 >= 2):
       return "case =false";
-    case const (1 <= 2):
+    case const (-1 <= 2):
       return "case =true";
     default:
       return "default";
@@ -79,7 +81,7 @@ String test2(Object value) {
 
 String test3(Object value) {
   switch (value) {
-    case const (1 == 2):
+    case const (1 == -2):
       return "case =false";
     case const (1 != 2):
       return "case =true";

--- a/LanguageFeatures/Patterns/constant_A05_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A05_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -66,10 +67,10 @@ String test(Object value) {
   if (value case const (19 << 1)) {
     return "case =38";
   }
-  if (value case const (1 > 2)) {
+  if (value case const (-1 > 2)) {
     return "case =false";
   }
-  if (value case const (1 < 2)) {
+  if (value case const (-1 < 2)) {
     return "case =true";
   }
   if (value case const ("Lily" + " " "was" " " + "here")) {
@@ -80,7 +81,7 @@ String test(Object value) {
 }
 
 String test2(Object value) {
-  if (value case const (1 >= 2)) {
+  if (value case const (-1 >= 2)) {
     return "case =false";
   }
   if (value case const (1 <= 2)) {
@@ -91,7 +92,7 @@ String test2(Object value) {
 }
 
 String test3(Object value) {
-  if (value case const (1 == 2)) {
+  if (value case const (1 == -2)) {
     return "case =false";
   }
   if (value case const (1 != 2)) {

--- a/LanguageFeatures/Patterns/constant_A06_t01.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t01.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -23,7 +24,7 @@
 /// constant expression.
 ///
 /// @description Check that it is a compile-time error if a constant pattern's
-/// value is not a valid constant expression.
+/// value is not a valid constant expression. Test switch statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns

--- a/LanguageFeatures/Patterns/constant_A06_t02.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t02.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression

--- a/LanguageFeatures/Patterns/constant_A06_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t03.dart
@@ -39,7 +39,7 @@ int test() {
   int x = 1;
   final s = "";
   C c = C();
-  switch (value) {
+  return switch (value) {
     case x => 1;
 //       ^
 // [analyzer] unspecified
@@ -69,7 +69,7 @@ int test() {
 // [analyzer] unspecified
 // [cfe] unspecified
     default  => -1;
-  }
+  };
 }
 
 main() {

--- a/LanguageFeatures/Patterns/constant_A06_t03.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t03.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -22,68 +23,55 @@
 /// It is a compile-time error if a constant pattern's value is not a valid
 /// constant expression.
 ///
-/// @description Check that a syntax error is emitted for a term which could be
-/// derived from <caseHead> in Dart 2.19, but cannot be derived from <caseHead>
-/// when patterns are added to Dart.
+/// @description Check that it is a compile-time error if a constant pattern's
+/// value is not a valid constant expression. Test switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-main() {
+class C {
+  final v = 42;
+  static final s = "s";
+}
+
+int test() {
   Object value = Object();
+  int x = 1;
+  final s = "";
+  C c = C();
   switch (value) {
-    case 1 + 2:
-//       ^^^^^
+    case x => 1;
+//       ^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 - 2:
-//       ^^^^^
+    case s => 2;
+//       ^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 * 2:
-//       ^^^^^
+    case C.s => 3;
+//       ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 ^ 2:
-//       ^^^^^
+    case c => 4;
+//       ^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 % 2:
-//       ^^^^^
+    case const C() => 5;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 ~/ 2:
-//       ^^^^^^
+    case const (C().v) => 6;
+//       ^^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 << 2:
-//       ^^^^^^
+    case "x is $x" => 7;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 >> 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >>> 2:
-//       ^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 > 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 < 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 <= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    default:
+    default  => -1;
   }
+}
+
+main() {
+  test();
 }

--- a/LanguageFeatures/Patterns/constant_A06_t05.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t05.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -24,32 +25,76 @@
 ///
 /// @description Check that a syntax error is emitted for a term which could be
 /// derived from <caseHead> in Dart 2.19, but cannot be derived from <caseHead>
-/// when patterns are added to Dart.
+/// when patterns are added to Dart. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-const l = [1, 2, 3];
-
 main() {
   Object value = Object();
-  switch (value) {
-    case 2 / 1:
+  if (value case 1 + 2) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 - 2) {
 //       ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case true && true:
-//       ^^^^^^^^^^^^
+  }
+  if (value case 1 * 2) {
+//               ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case false || true:
-//       ^^^^^^^^^^^^^
+  }
+  if (value case 1 ^ 2) {
+//               ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case l[0]:
-//       ^^^^
+  }
+  if (value case 1 % 2) {
+//               ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    default:
+  }
+  if (value case 1 ~/ 2) {
+//               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 << 2) {
+//               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 >> 2) {
+//               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 >>> 2) {
+//               ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 > 2) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 >= 2) {
+//               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 < 2) {
+//               ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  if (value case 1 <= 2) {
+//               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   }
 }

--- a/LanguageFeatures/Patterns/constant_A06_t06.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t06.dart
@@ -4,8 +4,9 @@
 
 /// @assertion constantPattern ::= booleanLiteral
 ///                   | nullLiteral
-///                   | numericLiteral
+///                   | '-'? numericLiteral
 ///                   | stringLiteral
+///                   | symbolLiteral
 ///                   | identifier
 ///                   | qualifiedName
 ///                   | constObjectExpression
@@ -24,33 +25,70 @@
 ///
 /// @description Check that a syntax error is emitted for a term which could be
 /// derived from <caseHead> in Dart 2.19, but cannot be derived from <caseHead>
-/// when patterns are added to Dart. Test if-case statement
+/// when patterns are added to Dart. Test switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-const l = [1, 2, 3];
+int test() {
+  Object value = Object();
+  return switch (value) {
+    case 1 + 2 => 1;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 - 2 => 2;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 * 2 => 3;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 ^ 2 => 4;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 % 2 => 5;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 ~/ 2 => 6;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 << 2 => 7;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 >> 2 => 8;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 >>> 2 => 9;
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 > 2 => 10;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 >= 2:  => 11;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 < 2: => 12;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case 1 <= 2 => 13;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    default => -1;
+  };
+}
 
 main() {
-  Object value = Object();
-  if (value case 2 / 1) {
-//               ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-  if (value case true && true) {
-//               ^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-  if (value case false || true) {
-//               ^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-  if (value case l[0]) {
-//               ^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
+  test();
 }

--- a/LanguageFeatures/Patterns/constant_A06_t07.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t07.dart
@@ -30,59 +30,25 @@
 
 // SharedOptions=--enable-experiment=patterns
 
+const l = [1, 2, 3];
+
 main() {
   Object value = Object();
   switch (value) {
-    case 1 + 2:
+    case 2 / 1:
 //       ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 - 2:
-//       ^^^^^
+    case true && true:
+//       ^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 * 2:
-//       ^^^^^
+    case false || true:
+//       ^^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 ^ 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 % 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 ~/ 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 << 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >> 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >>> 2:
-//       ^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 > 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 < 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 <= 2:
-//       ^^^^^^
+    case l[0]:
+//       ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     default:

--- a/LanguageFeatures/Patterns/constant_A06_t08.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t08.dart
@@ -25,66 +25,33 @@
 ///
 /// @description Check that a syntax error is emitted for a term which could be
 /// derived from <caseHead> in Dart 2.19, but cannot be derived from <caseHead>
-/// when patterns are added to Dart. Test switch statement
+/// when patterns are added to Dart. Test if-case statement
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
+const l = [1, 2, 3];
+
 main() {
   Object value = Object();
-  switch (value) {
-    case 1 + 2:
-//       ^^^^^
+  if (value case 2 / 1) {
+//               ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 - 2:
-//       ^^^^^
+  }
+  if (value case true && true) {
+//               ^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 * 2:
-//       ^^^^^
+  }
+  if (value case false || true) {
+//               ^^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 ^ 2:
-//       ^^^^^
+  }
+  if (value case l[0]) {
+//               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 % 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 ~/ 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 << 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >> 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >>> 2:
-//       ^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 > 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 < 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 <= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    default:
   }
 }

--- a/LanguageFeatures/Patterns/constant_A06_t09.dart
+++ b/LanguageFeatures/Patterns/constant_A06_t09.dart
@@ -25,66 +25,36 @@
 ///
 /// @description Check that a syntax error is emitted for a term which could be
 /// derived from <caseHead> in Dart 2.19, but cannot be derived from <caseHead>
-/// when patterns are added to Dart. Test switch statement
+/// when patterns are added to Dart. Test switch expression
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-main() {
+const l = [1, 2, 3];
+
+int test() {
   Object value = Object();
-  switch (value) {
-    case 1 + 2:
+  return switch (value) {
+    case 2 / 1 => 1;
 //       ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 - 2:
-//       ^^^^^
+    case true && true => 2;
+//       ^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 * 2:
-//       ^^^^^
+    case false || true => 3;
+//       ^^^^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 ^ 2:
-//       ^^^^^
+    case l[0] => 4;
+//       ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    case 1 % 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 ~/ 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 << 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >> 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >>> 2:
-//       ^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 > 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 >= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 < 2:
-//       ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    case 1 <= 2:
-//       ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    default:
-  }
+    default => -1;
+  };
+}
+
+main() {
+  test();
 }

--- a/LanguageFeatures/Patterns/patterns_lib.dart
+++ b/LanguageFeatures/Patterns/patterns_lib.dart
@@ -12,6 +12,8 @@ library patterns_lib;
 const Zero = 0;
 const Pi = 3.14;
 const Answer = 42;
+const Negative = -1;
+const NegativePi = -3.14;
 const MaxJSInt = 0x1FFFFFFFFFFFFF;
 const Melody = "Lily was here";
 const True = true;
@@ -21,6 +23,8 @@ class C0 {
   static const Zero = 0;
   static const Pi = 3.14;
   static const Answer = 42;
+  static const Negative = -1;
+  static const NegativePi = -3.14;
   static const MaxJSInt = 0x1FFFFFFFFFFFFF;
   static const Melody = "Lily was here";
   static const True = true;


### PR DESCRIPTION
- Added check for negative numbers in constant patterns
- Symbols now are allowed in  constant patterns
- Added check for constant patterns in a switch expressions

Some tests were renamed and this made diffscomplicated. Sorry, but I don't know the way to avoid it