### PR TITLE
#1399. [Records] Allow legacy libraries that don't support records be able to see the Record class

### DIFF
--- a/LanguageFeatures/Records/interaction_with_legacy_A01_lib.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A01_lib.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @description Non-legacy library for interaction with legacy ones
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=records
+
+library interaction_with_legacy_2_lib;
+import "dart:core" as core;
+
+typedef Record = core.Record;

--- a/LanguageFeatures/Records/interaction_with_legacy_A01_t01.dart
+++ b/LanguageFeatures/Records/interaction_with_legacy_A01_t01.dart
@@ -2,35 +2,27 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Assuming that v is the language version in which records are
-/// released, the following errors apply.
+/// @assertion The records feature is language versioned, as usual with new Dart
+/// features. This means that it will be an error to use the syntax for records
+/// in libraries which do not have a language version greater than or equal to
+/// the language version in which records are released.
 ///
-/// It is an error for the identifier [Record], denoting the [Record] class from
-/// dart:core, where that import scope name is only imported from platform
-/// libraries, to appear in a library whose language version is less than v.
-///
-/// @description Check that it is a compile-time error if class [Record] from
-/// dart:core is used in a library whose language version is less than v.
+/// @description Check that it is not an error if class [Record] from dart:core
+/// is used in a library whose language version is less than language version in
+/// which records are released.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=records
 
 // @dart = 2.18
 
+import "interaction_with_legacy_A01_lib.dart";
+
 typedef T1 = Record;
-//           ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 
 T? foo<T>(T? t) => t;
 
 main() {
   Record? r = null;
-//^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   foo<Record>(null);
-//    ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }


### PR DESCRIPTION
See https://github.com/dart-lang/language/commit/8c8d93b8b6e776f3f2360cde5039c433f7efaeab