### PR TITLE
Update test for the new `CONTINUE_LABEL_INVALID`

### DIFF
--- a/Language/Statements/Continue/label_t07.dart
+++ b/Language/Statements/Continue/label_t07.dart
@@ -22,8 +22,10 @@ main() {
     case 1:
       x = 0;
       continue L;
-//             ^
-// [analyzer] unspecified
+  //  ^^^^^^^^^^^
+  // [analyzer] COMPILE_TIME_ERROR.CONTINUE_LABEL_INVALID
+  //  ^^^^^^^^
+  // [cfe] A 'continue' label must be on a loop or a switch member.
     default:
       x = 2;
   }


### PR DESCRIPTION
There is an incoming change to add a new diagnostic for both the analyzer and the front end.

Related to https://github.com/dart-lang/sdk/issues/49852

I think this should be merged once the [breaking change request](https://github.com/dart-lang/sdk/issues/50902) is accepted.
