### PR TITLE
Fix year in header

### DIFF
--- a/LanguageFeatures/Constant-update-2018/ShortCircuitOperators_A01_t08.dart
+++ b/LanguageFeatures/Constant-update-2018/ShortCircuitOperators_A01_t08.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/LanguageFeatures/nnbd/weak/null_aware_operator_A02_t01.dart
+++ b/LanguageFeatures/nnbd/weak/null_aware_operator_A02_t01.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 20120 the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/LanguageFeatures/nnbd/weak/null_aware_operator_A05_t02.dart
+++ b/LanguageFeatures/nnbd/weak/null_aware_operator_A05_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 20120 the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/LanguageFeatures/nnbd/weak/type-normalization/equations_A05_t01.dart
+++ b/LanguageFeatures/nnbd/weak/type-normalization/equations_A05_t01.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 20201 the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Another point, sometimes the year is `2020` and sometimes is it `2011-2017`, I guess it should be unified to have a single year instead of a range, as this is the majority of cases.