### PR TITLE
#1401. Pattern-for-in statement and element tests

### DIFF
--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t01.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that if `I` implements `Iterable<T>` for some `T` then
+/// `E` is `T`. Test `T` inferred from `<pattern>` to `<expression>` and from
+/// `<expression>` to `<pattern>`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "../../Utils/static_type_helper.dart";
+import "patterns_lib.dart";
+
+main() {
+  var l1 = [
+    0,
+    for (var (num v1) in [1, 2, 3]) v1,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l1);
+  l1.expectStaticType<Exactly<List<num>>>();
+
+  var l2 = [
+    0,
+    for (final (v2) in <num>[1, 2, 3]) v2,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l2);
+  l2.expectStaticType<Exactly<List<num>>>();
+
+  var l3 = [
+    0,
+    for (var <num>[v3] in [[1], [2], [3]]) v3,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l3);
+  l3.expectStaticType<Exactly<List<num>>>();
+
+  var l4 = [
+    0,
+    for (final [v4] in <List<num>>[[1], [2], [3]]) v4,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l4);
+  l4.expectStaticType<Exactly<List<num>>>();
+
+  var l5 = [
+    0,
+    for (var <String, num>{"k1": v5} in [{"k1": 1}]) v5,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l5);
+  l5.expectStaticType<Exactly<List<num>>>();
+
+  var l6 = [
+    0,
+    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}]) v6,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l6);
+  l6.expectStaticType<Exactly<List<num>>>();
+
+  var l7 = [
+    0,
+    for (var (num v7, n: num v8) in [(1, n: 2)]) v7,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l7);
+  l7.expectStaticType<Exactly<List<num>>>();
+
+  var l8 = [
+    1,
+    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)]) v10,
+    3
+  ];
+  Expect.listEquals([1, 2, 3], l8);
+  l8.expectStaticType<Exactly<List<num>>>();
+
+  var l9 = [
+    for (var Square<Centimeter>(area: v11) in [Square(1)]) v11,
+  ];
+  Expect.isTrue(l9[0] == 1);
+  l9.expectStaticType<Exactly<List<Unit<Centimeter>>>>();
+
+  var l10 = [
+    for (final Square(area: v12) in <Square<Centimeter>>[Square<Centimeter>(1)])
+      v12
+  ];
+  Expect.isTrue(l10[0] == 1);
+  l10.expectStaticType<Exactly<List<Unit<Centimeter>>>>();
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t01.dart
@@ -37,81 +37,92 @@ import "../../Utils/expect.dart";
 import "../../Utils/static_type_helper.dart";
 import "patterns_lib.dart";
 
+extension Storing on Object? {
+  static dynamic stored;
+  void get store => stored = this;
+}
+
 main() {
   var l1 = [
     0,
-    for (var (num v1) in [1, 2, 3]) v1,
+    for (var (num v1) in [1, 2, 3]..store) v1,
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l1);
-  l1.expectStaticType<Exactly<List<num>>>();
+  Expect.isTrue(Storing.stored is List<num>);
+  Storing.stored.add(42);
+  Storing.stored.add(3.14);
 
   var l2 = [
     0,
-    for (final (v2) in <num>[1, 2, 3]) v2,
+    for (final (v2) in <num>[1, 2, 3])
+      v2.expectStaticType<Exactly<num>>(),
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l2);
-  l2.expectStaticType<Exactly<List<num>>>();
 
   var l3 = [
     0,
-    for (var <num>[v3] in [[1], [2], [3]]) v3,
+    for (var <num>[v3] in [[1], [2], [3]]..store) v3,
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l3);
-  l3.expectStaticType<Exactly<List<num>>>();
+  Expect.isTrue(Storing.stored is List<List<num>>);
+  Storing.stored.add(42);
+  Storing.stored.add(3.14);
 
   var l4 = [
     0,
-    for (final [v4] in <List<num>>[[1], [2], [3]]) v4,
+    for (final [v4] in <List<num>>[[1], [2], [3]])
+      v4.expectStaticType<Exactly<num>>(),
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l4);
-  l4.expectStaticType<Exactly<List<num>>>();
 
   var l5 = [
     0,
-    for (var <String, num>{"k1": v5} in [{"k1": 1}]) v5,
+    for (var <String, num>{"k1": v5} in [{"k1": 1}]..store) v5,
     2
   ];
   Expect.listEquals([0, 1, 2], l5);
-  l5.expectStaticType<Exactly<List<num>>>();
+  Expect.isTrue(Storing.stored is List<Map<String, num>>);
+  Expect.isTrue(Storing.stored.first is Map<String, num>);
+  Storing.stored.first["answer"] = 42;
+  Storing.stored.first["pi"] = 3.14;
 
   var l6 = [
     0,
-    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}]) v6,
+    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}])
+      v6.expectStaticType<Exactly<num>>(),
     2
   ];
   Expect.listEquals([0, 1, 2], l6);
-  l6.expectStaticType<Exactly<List<num>>>();
 
   var l7 = [
     0,
-    for (var (num v7, n: num v8) in [(1, n: 2)]) v7,
+    for (var (num v7, n: num v8) in [(1, n: 2)]..store) v7,
     2
   ];
   Expect.listEquals([0, 1, 2], l7);
-  l7.expectStaticType<Exactly<List<num>>>();
+  Expect.isTrue(Storing.stored is List<(num, {num n})>);
 
   var l8 = [
     1,
-    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)]) v10,
+    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)])
+      v10.expectStaticType<Exactly<num>>(),
     3
   ];
   Expect.listEquals([1, 2, 3], l8);
-  l8.expectStaticType<Exactly<List<num>>>();
 
   var l9 = [
-    for (var Square<Centimeter>(area: v11) in [Square(1)]) v11,
+    for (var Square<Centimeter>(area: v11) in [Square(1)]..store) v11,
   ];
-  Expect.isTrue(l9[0] == 1);
-  l9.expectStaticType<Exactly<List<Unit<Centimeter>>>>();
+  Expect.listEquals([Unit<Centimeter>(1)], l9);
+  Expect.isTrue(Storing.stored is List<Square<Centimeter>>);
 
   var l10 = [
     for (final Square(area: v12) in <Square<Centimeter>>[Square<Centimeter>(1)])
-      v12
+      v12.expectStaticType<Exactly<Unit<Centimeter>>>()
   ];
-  Expect.isTrue(l10[0] == 1);
-  l10.expectStaticType<Exactly<List<Unit<Centimeter>>>>();
+  Expect.listEquals([Unit<Centimeter>(1)], l10);
 }

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t02.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t02.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that if `I` is `dynamic` and runtime type of `I` is
+/// `Iterable<T>` where `T` is assignable to `<pattern>` required type then
+/// for-in element works as expected
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "../../Utils/static_type_helper.dart";
+import "patterns_lib.dart";
+
+main() {
+  var l1 = [
+    0,
+    for (var (num v1) in [1, 2, 3] as dynamic) v1,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l1);
+  l1.expectStaticType<Exactly<List<num>>>();
+
+  var l2 = [
+    0,
+    for (final (v2) in <num>[1, 2, 3] as dynamic) v2,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l2);
+  l2.expectStaticType<Exactly<List<dynamic>>>();
+
+  var l3 = [
+    0,
+    for (var <num>[v3] in [[1], [2], [3]] as dynamic) v3,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l3);
+  l3.expectStaticType<Exactly<List<num>>>();
+
+  var l4 = [
+    0,
+    for (final [v4] in <List<num>>[[1], [2], [3]] as dynamic) v4,
+    4
+  ];
+  Expect.listEquals([0, 1, 2, 3, 4], l4);
+  l4.expectStaticType<Exactly<List<dynamic>>>();
+
+  var l5 = [
+    0,
+    for (var <String, num>{"k1": v5} in [{"k1": 1}] as dynamic) v5,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l5);
+  l5.expectStaticType<Exactly<List<num>>>();
+
+  var l6 = [
+    0,
+    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}] as dynamic) v6,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l6);
+  l6.expectStaticType<Exactly<List<dynamic>>>();
+
+  var l7 = [
+    0,
+    for (var (num v7, n: num v8) in [(1, n: 2)] as dynamic) v7,
+    2
+  ];
+  Expect.listEquals([0, 1, 2], l7);
+  l7.expectStaticType<Exactly<List<num>>>();
+
+  var l8 = [
+    1,
+    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)] as dynamic) v10,
+    3
+  ];
+  Expect.listEquals([1, 2, 3], l8);
+  l8.expectStaticType<Exactly<List<dynamic>>>();
+
+  var l9 = [
+    for (var Square<Centimeter>(area: v11) in [Square(1)] as dynamic) v11,
+  ];
+  Expect.isTrue(l9[0] == 1);
+  l9.expectStaticType<Exactly<List<Unit<Centimeter>>>>();
+
+  var l10 = [
+    for (final Square(area: v12) in
+      <Square<Centimeter>>[Square<Centimeter>(1)] as dynamic) v12
+  ];
+  Expect.isTrue(l10[0] == 1);
+  l10.expectStaticType<Exactly<List<Unit<MetricUnits>>>>();
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t02.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t02.dart
@@ -48,7 +48,8 @@ main() {
 
   var l2 = [
     0,
-    for (final (v2) in <num>[1, 2, 3] as dynamic) v2,
+    for (final (v2) in <num>[1, 2, 3] as dynamic)
+      (1 > 2 ? v2.whatever : null, v2).$2,
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l2);
@@ -64,7 +65,8 @@ main() {
 
   var l4 = [
     0,
-    for (final [v4] in <List<num>>[[1], [2], [3]] as dynamic) v4,
+    for (final [v4] in <List<num>>[[1], [2], [3]] as dynamic)
+      (1 > 2 ? v4.whatever : null, v4).$2,
     4
   ];
   Expect.listEquals([0, 1, 2, 3, 4], l4);
@@ -80,7 +82,8 @@ main() {
 
   var l6 = [
     0,
-    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}] as dynamic) v6,
+    for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}] as dynamic)
+      (1 > 2 ? v6.whatever : null, v6).$2,
     2
   ];
   Expect.listEquals([0, 1, 2], l6);
@@ -96,7 +99,8 @@ main() {
 
   var l8 = [
     1,
-    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)] as dynamic) v10,
+    for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)] as dynamic)
+      (1 > 2 ? v10.whatever : null, v10).$2,
     3
   ];
   Expect.listEquals([1, 2, 3], l8);

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t03.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t03.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that if `I` is `dynamic` and runtime type of `I` is
+/// `Iterable<T>` where `T` is not assignable to `<pattern>` required type then
+/// a run-time error occurs
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "patterns_lib.dart";
+
+main() {
+  Expect.throws(() {
+    [
+      for (var (int v1) in <num>[1, 2, 3] as dynamic) v1
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (final <int>[v2] in <List<num>>[[1], [2], [3]] as dynamic) v2
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (var <String, int>{"k1": v3} in
+          <Map<String, num>>[{"k1": 1}] as dynamic) v3
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (final (int v4,) in <(num,)>[(1,)] as dynamic) v4
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (var (n: int v5) in <({num n})>[(n: 2)] as dynamic) v5
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (var Square<Centimeter>(area: v6) in [Circle(1)] as dynamic) v6
+    ];
+  });
+
+  Expect.throws(() {
+    [
+      for (final Square<Meter>(area: v7) in
+          <Square<Centimeter>>[Square<Centimeter>(1)] as dynamic) v7
+    ];
+  });
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t04.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A01_t04.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if `I` doesn't implement
+/// `Iterable<T>` and in not `dynamic`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  [
+    for (var (int v1) in 42) v1
+//                       ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final <int>[v2] in "42") v2
+//                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (var <String, int>{"k1": v3} in 42) v3
+//                                      ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final (int v4,) in "42") v4
+//                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (var (n: v5) in 42) v5
+//                      ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final Square(area: v6) in "42") v6
+//                                 ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A02_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A02_t01.dart
@@ -48,7 +48,7 @@ main() {
 // [cfe] unspecified
   ];
   [
-    for (var <String, int>{"k1": v3} in <String, num>[{"k1": 1}]) v3
+    for (var <String, int>{"k1": v3} in <Map<String, num>>[{"k1": 1}]) v3
 //                                      ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A02_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A02_t01.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if type check ot the
+/// `<pattern>` with matched value `E` fails
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  [
+    for (var (int v1) in <num>[1, 2, 3]) v1
+//                       ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final <int>[v2] in <List<num>>[[1], [2], [3]]) v2
+//                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (var <String, int>{"k1": v3} in <String, num>[{"k1": 1}]) v3
+//                                      ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final (int v4,) in <(num,)>[(1,)]) v4
+//                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (var (n: int v5) in <({num n})>[(n: 2)]) v5
+//                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (var Square<Centimeter>(area: v) in <Square<Meter>>[Square<Meter>(1)]) v
+//                                          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A03_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A03_t01.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if final variable
+/// declared by the pattern is assigned in a for-in element
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  [
+    for (final (int v1) in [1, 2, 3]) v1++
+//                                    ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final <int>[v2] in [[1], [2], [3]]) v2++
+//                                           ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final <String, int>{"k1": v3} in [{"k1": 1}]) v3++
+//                                                     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final (int v4,) in [(1,)]) v4++
+//                                  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final (n: int v5) in [(n: 2)]) v5++
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  [
+    for (final Square(area: v6) in [Square(1)]) v6++
+//                                              ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A03_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A03_t01.dart
@@ -26,7 +26,7 @@
 ///   append(<element>);
 /// }
 /// ```
-/// @description Checks that it is a compile-time error if final variable
+/// @description Checks that it is a compile-time error if a final variable
 /// declared by the pattern is assigned in a for-in element
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_element_A04_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_element_A04_t01.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A collection element of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <element>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///     i. If I implements Iterable<T> for some T then E is T.
+///     ii. Else if I is dynamic then E is dynamic.
+///     iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers and append() is
+///   an operation to add an element to the surrounding collection being built:
+/// ```dart
+/// I id1 = <expression>;
+/// Iterator<E> id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   append(<element>);
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if type of for-in
+/// element is not assignable to the type of the collection
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  <String>[
+    for (var (int v1) in [1, 2, 3]) v1
+//                                  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  <String>[
+    for (final <int>[v2] in [[1], [2], [3]]) v2
+//                                           ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  <String>[
+    for (final <String, int>{"k1": v3} in [{"k1": 1}]) v3
+//                                                     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  <String>[
+    for (final (int v4,) in [(1,)]) v4
+//                                  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  <String>[
+    for (final (n: int v5) in [(n: 2)]) v5
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+  <String>[
+    for (final Square(area: v6) in [Square(1)]) v6
+//                                              ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ];
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t01.dart
@@ -36,13 +36,21 @@ import "../../Utils/expect.dart";
 import "../../Utils/static_type_helper.dart";
 import "patterns_lib.dart";
 
+extension Storing on Object? {
+  static dynamic stored;
+  void get store => stored = this;
+}
+
 main() {
   String log = "";
-  for (var (num v1) in [1, 2, 3]) {
+  for (var (num v1) in [1, 2, 3]..store) {
     v1.expectStaticType<Exactly<num>>();
     log += "$v1;";
   }
   Expect.equals("1;2;3;", log);
+  Expect.isTrue(Storing.stored is List<num>);
+  Storing.stored.add(42);
+  Storing.stored.add(3.14);
 
   log = "";
   for (final (v2) in <num>[1, 2, 3]) {
@@ -53,11 +61,14 @@ main() {
   log = "";
 
   log = "";
-  for (var <num>[v3] in [[1], [2], [3]]) {
+  for (var <num>[v3] in [[1], [2], [3]]..store) {
     v3.expectStaticType<Exactly<num>>();
     log += "$v3;";
   }
   Expect.equals("1;2;3;", log);
+  Expect.isTrue(Storing.stored is List<num>);
+  Storing.stored.add(42);
+  Storing.stored.add(3.14);
 
   log = "";
   for (final [v4] in <List<num>>[[1], [2], [3]]) {
@@ -67,11 +78,15 @@ main() {
   Expect.equals("1;2;3;", log);
 
   log = "";
-  for (var <String, num>{"k1": v5} in [{"k1": 1}]) {
+  for (var <String, num>{"k1": v5} in [{"k1": 1}]..store) {
     v5.expectStaticType<Exactly<num>>();
     log += "$v5;";
   }
   Expect.equals("1;", log);
+  Expect.isTrue(Storing.stored is List<Map<String, num>>);
+  Expect.isTrue(Storing.stored.first is Map<String, num>);
+  Storing.stored.first["answer"] = 42;
+  Storing.stored.first["pi"] = 3.14;
 
   log = "";
   for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}]) {
@@ -81,12 +96,13 @@ main() {
   Expect.equals("1;", log);
 
   log = "";
-  for (var (num v7, n: num v8) in [(1, n: 2)]) {
+  for (var (num v7, n: num v8) in [(1, n: 2)]..store) {
     v7.expectStaticType<Exactly<num>>();
     v8.expectStaticType<Exactly<num>>();
     log += "$v7;$v8;";
   }
   Expect.equals("1;2;", log);
+  Expect.isTrue(Storing.stored is List<(num, {num n})>);
 
   log = "";
   for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)]) {
@@ -102,6 +118,7 @@ main() {
     log += "$v11;";
   }
   Expect.equals("1;", log);
+  Expect.isTrue(Storing.stored is List<Square<Centimeter>>);
 
   log = "";
   for (final Square(area: v12) in <Square<Centimeter>>[Square<Centimeter>(1)]) {
@@ -109,5 +126,4 @@ main() {
     log += "$v12;";
   }
   Expect.equals("1;", log);
-
 }

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t01.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that if `I` implements `Iterable<T>` for some `T` then
+/// `E` is `T`. Test `T` inferred from `<pattern>` to `<expression>` and from
+/// `<expression>` to `<pattern>`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "../../Utils/static_type_helper.dart";
+import "patterns_lib.dart";
+
+main() {
+  String log = "";
+  for (var (num v1) in [1, 2, 3]) {
+    v1.expectStaticType<Exactly<num>>();
+    log += "$v1;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (final (v2) in <num>[1, 2, 3]) {
+    v2.expectStaticType<Exactly<num>>();
+    log += "$v2;";
+  }
+  Expect.equals("1;2;3;", log);
+  log = "";
+
+  log = "";
+  for (var <num>[v3] in [[1], [2], [3]]) {
+    v3.expectStaticType<Exactly<num>>();
+    log += "$v3;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (final [v4] in <List<num>>[[1], [2], [3]]) {
+    v4.expectStaticType<Exactly<num>>();
+    log += "$v4;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (var <String, num>{"k1": v5} in [{"k1": 1}]) {
+    v5.expectStaticType<Exactly<num>>();
+    log += "$v5;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}]) {
+    v6.expectStaticType<Exactly<num>>();
+    log += "$v6;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (var (num v7, n: num v8) in [(1, n: 2)]) {
+    v7.expectStaticType<Exactly<num>>();
+    v8.expectStaticType<Exactly<num>>();
+    log += "$v7;$v8;";
+  }
+  Expect.equals("1;2;", log);
+
+  log = "";
+  for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)]) {
+    v9.expectStaticType<Exactly<num>>();
+    v10.expectStaticType<Exactly<num>>();
+    log += "$v9;$v10;";
+  }
+  Expect.equals("1;2;", log);
+
+  log = "";
+  for (var Square<Centimeter>(area: v11) in [Square(1)]) {
+    v11.expectStaticType<Exactly<Unit<Centimeter>>>();
+    log += "$v11;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (final Square(area: v12) in <Square<Centimeter>>[Square<Centimeter>(1)]) {
+    v12.expectStaticType<Exactly<Unit<Centimeter>>>();
+    log += "$v12;";
+  }
+  Expect.equals("1;", log);
+
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t02.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t02.dart
@@ -27,7 +27,8 @@
 /// ```
 /// @description Checks that if `I` is `dynamic` and runtime type of `I` is
 /// `Iterable<T>` where `T` is assignable to `<pattern>` required type then
-/// for-in statement works as expected
+/// for-in statement works as expected. In particular, if `I` is `dynamic` then
+/// element type is `dynamic` and execution of the body does take place
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns,records

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t02.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t02.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that if `I` is `dynamic` and runtime type of `I` is
+/// `Iterable<T>` where `T` is assignable to `<pattern>` required type then
+/// for-in statement works as expected
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "../../Utils/static_type_helper.dart";
+import "patterns_lib.dart";
+
+main() {
+  String log = "";
+  for (var (num v1) in [1, 2, 3] as dynamic) {
+    v1.expectStaticType<Exactly<num>>();
+    log += "$v1;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (final (v2) in <num>[1, 2, 3] as dynamic) {
+    Expect.throws(() {v2.whatever;}); // v2 is dynamic
+    log += "$v2;";
+  }
+  Expect.equals("1;2;3;", log);
+  log = "";
+
+  log = "";
+  for (var <num>[v3] in [[1], [2], [3]] as dynamic) {
+    v3.expectStaticType<Exactly<num>>();
+    log += "$v3;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (final [v4] in <List<num>>[[1], [2], [3]] as dynamic) {
+    Expect.throws(() {v4.whatever;});
+    log += "$v4;";
+  }
+  Expect.equals("1;2;3;", log);
+
+  log = "";
+  for (var <String, num>{"k1": v5} in [{"k1": 1}] as dynamic) {
+    v5.expectStaticType<Exactly<num>>();
+    log += "$v5;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (final {"k1": v6} in <Map<String, num>>[{"k1": 1}] as dynamic) {
+    Expect.throws(() {v6.whatever;});
+    log += "$v6;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (var (num v7, n: num v8) in [(1, n: 2)] as dynamic) {
+    v7.expectStaticType<Exactly<num>>();
+    v8.expectStaticType<Exactly<num>>();
+    log += "$v7;$v8;";
+  }
+  Expect.equals("1;2;", log);
+
+  log = "";
+  for (final (v9, n: v10) in <(num, {num n})>[(1, n: 2)] as dynamic) {
+    Expect.throws(() {v9.whatever;});
+    Expect.throws(() {v10.whatever;});
+    log += "$v9;$v10;";
+  }
+  Expect.equals("1;2;", log);
+
+  log = "";
+  for (var Square<Centimeter>(area: v11) in [Square(1)] as dynamic) {
+    v11.expectStaticType<Exactly<Unit<Centimeter>>>();
+    log += "$v11;";
+  }
+  Expect.equals("1;", log);
+
+  log = "";
+  for (final Square(area: v12) in
+      <Square<Centimeter>>[Square<Centimeter>(1)] as dynamic) {
+    v12.expectStaticType<Exactly<Unit<MetricUnits>>>();
+    log += "$v12;";
+  }
+  Expect.equals("1;", log);
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t03.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t03.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that if `I` is `dynamic` and runtime type of `I` is
+/// `Iterable<T>` where `T` is not assignable to `<pattern>` required type then
+/// a run-time error occurs
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "../../Utils/expect.dart";
+import "patterns_lib.dart";
+
+main() {
+  Expect.throws(() {
+    for (var (int v1) in <num>[1, 2, 3] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (final <int>[v2] in <List<num>>[[1], [2], [3]] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (var <String, int>{"k1": v3} in
+        <Map<String, num>>[{"k1": 1}] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (final (int v4,) in <(num,)>[(1,)] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (var (n: int v5) in <({num n})>[(n: 2)] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (var Square<Centimeter>(area: v6 in [Circle(1)] as dynamic) {}
+  });
+
+  Expect.throws(() {
+    for (final Square<Meter>(area: v7) in
+        <Square<Centimeter>>[Square<Centimeter>(1)] as dynamic) {}
+  });
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t03.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t03.dart
@@ -58,7 +58,7 @@ main() {
   });
 
   Expect.throws(() {
-    for (var Square<Centimeter>(area: v6 in [Circle(1)] as dynamic) {}
+    for (var Square<Centimeter>(area: v6) in [Circle(1)] as dynamic) {}
   });
 
   Expect.throws(() {

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t04.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A01_t04.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if `I` doesn't implement
+/// `Iterable<T>` and in not `dynamic`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  for (var (int v1) in 42) {}
+//                     ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (final <int>[v2] in "42") {}
+//                        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (var <String, int>{"k1": v3} in 42) {}
+//                                    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (final (int v4,) in "42") {}
+//                      ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (var (n: v5) in 42) {}
+//                    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (final Square(area: v6) in "42") {}
+//                               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A02_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A02_t01.dart
@@ -44,7 +44,7 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
 
-  for (var <String, int>{"k1": v3} in <String, num>[{"k1": 1}]) {}
+  for (var <String, int>{"k1": v3} in <Map<String, num>>[{"k1": 1}]) {}
 //                                    ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A02_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A02_t01.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if type check ot the
+/// `<pattern>` with matched value `E` fails
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  for (var (int v1) in <num>[1, 2, 3]) {}
+//                     ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (final <int>[v2] in <List<num>>[[1], [2], [3]]) {}
+//                        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (var <String, int>{"k1": v3} in <String, num>[{"k1": 1}]) {}
+//                                    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (final (int v4,) in <(num,)>[(1,)]) {}
+//                        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (var (n: int v5) in <({num n})>[(n: 2)]) {}
+//                        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  for (var Square<Centimeter>(area: v6) in <Square<Meter>>[Square<Meter>(1)]) {}
+//                                         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A03_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A03_t01.dart
@@ -25,7 +25,7 @@
 ///   { <statement> }
 /// }
 /// ```
-/// @description Checks that it is a compile-time error if final variable
+/// @description Checks that it is a compile-time error if a final variable
 /// declared by the pattern is assigned in a for-in statement
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A03_t01.dart
+++ b/LanguageFeatures/Patterns/execution_pattern_for_in_statement_A03_t01.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion
+/// A statement of the form:
+///
+/// for (<keyword> <pattern> in <expression>) <statement>
+///
+/// Where <keyword> is var or final is treated like so:
+/// 1. Let I be the static type of <expression>, inferred using context type
+///   schema Iterable<P> where P is the context type schema of <pattern>.
+/// 2. Calculate the element type of I:
+///   i. If I implements Iterable<T> for some T then E is T.
+///   ii. Else if I is dynamic then E is dynamic.
+///   iii. Else it is a compile-time error.
+/// 3. Type check <pattern> with matched value type E.
+/// 4. If there are no compile-time errors, then execution proceeds as the
+///   following code, where id1 and id2 are fresh identifiers:
+/// ```dart
+/// var id1 = <expression>;
+/// var id2 = id1.iterator;
+/// while (id2.moveNext()) {
+///   <keyword> <pattern> = id2.current;
+///   { <statement> }
+/// }
+/// ```
+/// @description Checks that it is a compile-time error if final variable
+/// declared by the pattern is assigned in a for-in statement
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,records
+
+import "patterns_lib.dart";
+
+main() {
+  for (final (int v1) in [1, 2, 3]) {
+    v1++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  for (final <int>[v2] in [[1], [2], [3]]) {
+    v2++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  for (final <String, int>{"k1": v3} in [{"k1": 1}]) {
+    v3++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  for (final (int v4,) in [(1,)]) {
+    v4++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  for (final (n: int v5) in [(n: 2)]) {
+    v5++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  for (final Square(area: v6) in [Square(1)]) {
+    v6++;
+//  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}


### PR DESCRIPTION
Please note the following.
1. Tests for for-in-element are written for `List` only. Please review them first and I'll then add the similar tests for `Map` and `Set`
2. Some tests check both static and dynamic semantic. I believe it's Ok if type check is part of the runtime semantics and it uses inferred types. 
3. We also need tests for async for-in loop. I'll add them in a separate PR. Again, let's review this one first
