### PR TITLE
#1401. Matching tests for list pattern

### DIFF
--- a/LanguageFeatures/Patterns/matching_list_A01_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A01_t01.dart
@@ -60,9 +60,9 @@ import "../../Utils/expect.dart";
 
 String test1(Object o) {
   switch (o) {
-    case <int>[42]:
+    case <int>[]:
       return "match-1";
-    case <num>[42]:
+    case <num>[]:
       return "match-2";
     default:
       return "no match";
@@ -70,10 +70,10 @@ String test1(Object o) {
 }
 
 String test2(Object o) {
-  if (o case <int>[42]) {
+  if (o case <int>[]) {
     return "match-1";
   }
-  if (o case <num>[42]) {
+  if (o case <num>[]) {
     return "match-2";
   }
   return "no match";
@@ -81,54 +81,51 @@ String test2(Object o) {
 
 String test3(Object o) {
   return switch (o) {
-    <int>[42] => "match-1",
-    <num>[42] => "match-2",
+    <int>[] => "match-1",
+    <num>[] => "match-2",
     _ => "no match"
   };
 }
 
 void test4(dynamic o) {
-  var <int>[v] = o;
+  var <int>[] = o;
 }
 
 main() {
-  Expect.equals("match-1", test1(<int>[42]));
-  Expect.equals("match-2", test1(<num>[42]));
-  Expect.equals("match-2", test1(<double>[42.0]));
-  Expect.equals("no match", test1(<dynamic>[42.0]));
-  Expect.equals("no match", test1(<dynamic>[42]));
-  Expect.equals("no match", test1(["42"]));
-  Expect.equals("no match", test1(<int?>[42]));
-  Expect.equals("no match", test1(<num?>[42]));
+  Expect.equals("match-1", test1(<int>[]));
+  Expect.equals("match-2", test1(<num>[]));
+  Expect.equals("match-2", test1(<double>[]));
+  Expect.equals("no match", test1(<dynamic>[]));
+  Expect.equals("no match", test1(<String>[]));
+  Expect.equals("no match", test1(<int?>[]));
+  Expect.equals("no match", test1(<num?>[]));
 
-  Expect.equals("match-1", test2(<int>[42]));
-  Expect.equals("match-2", test2(<num>[42]));
-  Expect.equals("match-2", test2(<double>[42.0]));
-  Expect.equals("no match", test2(<dynamic>[42.0]));
-  Expect.equals("no match", test2(<dynamic>[42]));
-  Expect.equals("no match", test2(["42"]));
-  Expect.equals("no match", test2(<int?>[42]));
-  Expect.equals("no match", test2(<num?>[42]));
+  Expect.equals("match-1", test2(<int>[]));
+  Expect.equals("match-2", test2(<num>[]));
+  Expect.equals("match-2", test2(<double>[]));
+  Expect.equals("no match", test2(<dynamic>[]));
+  Expect.equals("no match", test2(<String>[]));
+  Expect.equals("no match", test2(<int?>[]));
+  Expect.equals("no match", test2(<num?>[]));
 
-  Expect.equals("match-1", test3(<int>[42]));
-  Expect.equals("match-2", test3(<num>[42]));
-  Expect.equals("match-2", test3(<double>[42.0]));
-  Expect.equals("no match", test3(<dynamic>[42.0]));
-  Expect.equals("no match", test3(<dynamic>[42]));
-  Expect.equals("no match", test3(["42"]));
-  Expect.equals("no match", test3(<int?>[42]));
-  Expect.equals("no match", test3(<num?>[42]));
+  Expect.equals("match-1", test3(<int>[]));
+  Expect.equals("match-2", test3(<num>[]));
+  Expect.equals("match-2", test3(<double>[]));
+  Expect.equals("no match", test3(<dynamic>[]));
+  Expect.equals("no match", test3(<String>[]));
+  Expect.equals("no match", test3(<int?>[]));
+  Expect.equals("no match", test3(<num?>[]));
 
   Expect.throws(() {
-    test4(<num>[42]);
+    test4(<num>[]);
   });
   Expect.throws(() {
-    test4(<dynamic>[42]);
+    test4(<dynamic>[]);
   });
   Expect.throws(() {
-    test4(<int?>[42]);
+    test4(<int?>[]);
   });
   Expect.throws(() {
-    test4(["42"]);
+    test4(<String>[]);
   });
 }

--- a/LanguageFeatures/Patterns/matching_list_A01_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A01_t01.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if the runtime type of `v` is not a subtype of the
+/// required type of `p` then the match fails.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+
+String test1(Object o) {
+  switch (o) {
+    case <int>[42]:
+      return "match-1";
+    case <num>[42]:
+      return "match-2";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case <int>[42]) {
+    return "match-1";
+  }
+  if (o case <num>[42]) {
+    return "match-2";
+  }
+  return "no match";
+}
+
+String test3(Object o) {
+  return switch (o) {
+    <int>[42] => "match-1",
+    <num>[42] => "match-2",
+    _ => "no match"
+  };
+}
+
+void test4(dynamic o) {
+  var <int>[v] = o;
+}
+
+main() {
+  Expect.equals("match-1", test1(<int>[42]));
+  Expect.equals("match-2", test1(<num>[42]));
+  Expect.equals("match-2", test1(<double>[42.0]));
+  Expect.equals("no match", test1(<dynamic>[42.0]));
+  Expect.equals("no match", test1(<dynamic>[42]));
+  Expect.equals("no match", test1(["42"]));
+  Expect.equals("no match", test1(<int?>[42]));
+  Expect.equals("no match", test1(<num?>[42]));
+
+  Expect.equals("match-1", test2(<int>[42]));
+  Expect.equals("match-2", test2(<num>[42]));
+  Expect.equals("match-2", test2(<double>[42.0]));
+  Expect.equals("no match", test2(<dynamic>[42.0]));
+  Expect.equals("no match", test2(<dynamic>[42]));
+  Expect.equals("no match", test2(["42"]));
+  Expect.equals("no match", test2(<int?>[42]));
+  Expect.equals("no match", test2(<num?>[42]));
+
+  Expect.equals("match-1", test3(<int>[42]));
+  Expect.equals("match-2", test3(<num>[42]));
+  Expect.equals("match-2", test3(<double>[42.0]));
+  Expect.equals("no match", test3(<dynamic>[42.0]));
+  Expect.equals("no match", test3(<dynamic>[42]));
+  Expect.equals("no match", test3(["42"]));
+  Expect.equals("no match", test3(<int?>[42]));
+  Expect.equals("no match", test3(<num?>[42]));
+
+  Expect.throws(() {
+    test4(<num>[42]);
+  });
+  Expect.throws(() {
+    test4(<dynamic>[42]);
+  });
+  Expect.throws(() {
+    test4(<int?>[42]);
+  });
+  Expect.throws(() {
+    test4(["42"]);
+  });
+}

--- a/LanguageFeatures/Patterns/matching_list_A01_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A01_t02.dart
@@ -1,0 +1,182 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if the runtime type of `v` is not a subtype of the
+/// required type of `p` then the match fails and no any member of `v` is called
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "dart:collection";
+import "../../Utils/expect.dart";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    log += "length;";
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    log += "length=;";
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index];";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    log += "[$index]=$value;";
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log += "sublist($start, $end)";
+    return _inner.sublist(start, end);
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case <int>[42]:
+      return "match-1";
+    case <num>[42]:
+      return "match-2";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case <int>[42]) {
+    return "match-1";
+  }
+  if (o case <num>[42]) {
+    return "match-2";
+  }
+  return "no match";
+}
+
+String test3(Object o) {
+  return switch (o) {
+    <int>[42] => "match-1",
+    <num>[42] => "match-2",
+    _ => "no match"
+  };
+}
+
+void test4(dynamic o) {
+  var <int>[v] = o;
+}
+
+main() {
+  Expect.equals("no match", test1(MyList<dynamic>([42.0])));
+  Expect.equals("", log);
+  Expect.equals("no match", test1(MyList<dynamic>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test1(MyList<String>(["42"])));
+  Expect.equals("", log);
+  Expect.equals("no match", test1(MyList<int?>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test1(MyList<num?>([42])));
+  Expect.equals("", log);
+
+  Expect.equals("no match", test2(MyList<dynamic>([42.0])));
+  Expect.equals("", log);
+  Expect.equals("no match", test2(MyList<dynamic>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test2(MyList<String>(["42"])));
+  Expect.equals("", log);
+  Expect.equals("no match", test2(MyList<int?>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test2(MyList<num?>([42])));
+  Expect.equals("", log);
+
+  Expect.equals("no match", test3(MyList<dynamic>([42.0])));
+  Expect.equals("", log);
+  Expect.equals("no match", test3(MyList<dynamic>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test3(MyList<String>(["42"])));
+  Expect.equals("", log);
+  Expect.equals("no match", test3(MyList<int?>([42])));
+  Expect.equals("", log);
+  Expect.equals("no match", test3(MyList<num?>([42])));
+  Expect.equals("", log);
+
+  Expect.throws(() {
+    test4(MyList<num>([42]));
+  });
+  Expect.equals("", log);
+  Expect.throws(() {
+    test4(MyList<dynamic>([42]));
+  });
+  Expect.equals("", log);
+  Expect.throws(() {
+    test4(MyList<int?>([42]));
+  });
+  Expect.equals("", log);
+  Expect.throws(() {
+    test4(MyList(["42"]));
+  });
+  Expect.equals("", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A01_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A01_t02.dart
@@ -51,50 +51,13 @@
 /// viii. The match succeeds if all subpatterns match.
 ///
 /// @description Checks that if the runtime type of `v` is not a subtype of the
-/// required type of `p` then the match fails and no any member of `v` is called
+/// required type of `p` then the match fails and operator `[]` is never invoked
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
-import "dart:collection";
+import "patterns_collections_lib.dart";
 import "../../Utils/expect.dart";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    log += "length;";
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    log += "length=;";
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log += "[$index];";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    log += "[$index]=$value;";
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    log += "sublist($start, $end)";
-    return _inner.sublist(start, end);
-  }
-}
 
 String test1(Object o) {
   switch (o) {
@@ -130,53 +93,52 @@ void test4(dynamic o) {
 }
 
 main() {
-  Expect.equals("no match", test1(MyList<dynamic>([42.0])));
-  Expect.equals("", log);
-  Expect.equals("no match", test1(MyList<dynamic>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test1(MyList<String>(["42"])));
-  Expect.equals("", log);
-  Expect.equals("no match", test1(MyList<int?>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test1(MyList<num?>([42])));
-  Expect.equals("", log);
+  var ml1 = MyList<dynamic>([42]);
+  var ml2 = MyList<String>(["42"]);
+  var ml3 = MyList<int?>([42]);
+  var ml4 = MyList<num?>([42]);
 
-  Expect.equals("no match", test2(MyList<dynamic>([42.0])));
-  Expect.equals("", log);
-  Expect.equals("no match", test2(MyList<dynamic>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test2(MyList<String>(["42"])));
-  Expect.equals("", log);
-  Expect.equals("no match", test2(MyList<int?>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test2(MyList<num?>([42])));
-  Expect.equals("", log);
+  Expect.equals("no match", test1(ml1));
+  Expect.equals("", ml1.log);
+  Expect.equals("no match", test1(ml2));
+  Expect.equals("", ml2.log);
+  Expect.equals("no match", test1(ml3));
+  Expect.equals("", ml3.log);
+  Expect.equals("no match", test1(ml4));
+  Expect.equals("", ml4.log);
 
-  Expect.equals("no match", test3(MyList<dynamic>([42.0])));
-  Expect.equals("", log);
-  Expect.equals("no match", test3(MyList<dynamic>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test3(MyList<String>(["42"])));
-  Expect.equals("", log);
-  Expect.equals("no match", test3(MyList<int?>([42])));
-  Expect.equals("", log);
-  Expect.equals("no match", test3(MyList<num?>([42])));
-  Expect.equals("", log);
+  Expect.equals("no match", test2(ml1));
+  Expect.equals("", ml1.log);
+  Expect.equals("no match", test2(ml2));
+  Expect.equals("", ml2.log);
+  Expect.equals("no match", test2(ml3));
+  Expect.equals("", ml3.log);
+  Expect.equals("no match", test2(ml4));
+  Expect.equals("", ml4.log);
+
+  Expect.equals("no match", test3(ml1));
+  Expect.equals("", ml1.log);
+  Expect.equals("no match", test3(ml2));
+  Expect.equals("", ml2.log);
+  Expect.equals("no match", test3(ml3));
+  Expect.equals("", ml3.log);
+  Expect.equals("no match", test3(ml4));
+  Expect.equals("", ml4.log);
 
   Expect.throws(() {
-    test4(MyList<num>([42]));
+    test4(ml1);
   });
-  Expect.equals("", log);
+  Expect.equals("", ml1.log);
   Expect.throws(() {
-    test4(MyList<dynamic>([42]));
+    test4(ml2);
   });
-  Expect.equals("", log);
+  Expect.equals("", ml2.log);
   Expect.throws(() {
-    test4(MyList<int?>([42]));
+    test4(ml3);
   });
-  Expect.equals("", log);
+  Expect.equals("", ml3.log);
   Expect.throws(() {
-    test4(MyList(["42"]));
+    test4(ml4);
   });
-  Expect.equals("", log);
+  Expect.equals("", ml4.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A02_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t01.dart
@@ -57,35 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    log = "Length called: ${_inner.length}";
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -111,16 +83,15 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([42]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   Expect.equals("match", test2(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   Expect.equals("match", test3(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
 
   var [...r1] = ml;
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   final [...] = ml;
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A02_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t01.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `p` has a rest element and `h + t == 0` then
+/// length check is not performed and `List.length` getter is not called
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    log = "Length called: ${_inner.length}";
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [...]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [...]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [...] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([42]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test2(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test3(ml));
+  Expect.equals("", log);
+
+  var [...r1] = ml;
+  Expect.equals("", log);
+  final [...] = ml;
+  Expect.equals("", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A02_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t02.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `p` has a rest element and `h + t > 0` then
+/// if `l < h + t` then the match fails.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+
+String test1(Object o) {
+  switch (o) {
+    case [1, 2, ...]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, ..., 2]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+   switch (o) {
+    [..., 1, 2] => "match",
+    _ => "no match"
+  };
+
+main() {
+  Expect.equals("no match", test1([1]));
+  Expect.equals("no match", test2([2]));
+  Expect.equals("no match", test3([1]));
+
+  Expect.throws(() {
+    var [v1, v2, ...r] = [1];
+  });
+  Expect.throws(() {
+    final [v1, v2, ...r] = [1];
+  });
+}

--- a/LanguageFeatures/Patterns/matching_list_A02_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t03.dart
@@ -1,0 +1,97 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `p` has no rest element and `h + t > 0` then
+/// if `l != h + t` then the match fails.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+
+String test1(Object o) {
+  switch (o) {
+    case [1, 2]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, 2]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+   switch (o) {
+    [1, 2] => "match",
+    _ => "no match"
+  };
+
+main() {
+  Expect.equals("no match", test1([1]));
+  Expect.equals("no match", test1([1, 2, 3]));
+  Expect.equals("no match", test2([1]));
+  Expect.equals("no match", test2([1, 2, 3]));
+  Expect.equals("no match", test3([1]));
+  Expect.equals("no match", test3([1, 2, 3]));
+
+  Expect.throws(() {
+    var [v1, v2] = [1];
+  });
+  Expect.throws(() {
+    final [v1, v2] = [1, 2, 3];
+  });
+}

--- a/LanguageFeatures/Patterns/matching_list_A02_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t03.dart
@@ -60,7 +60,7 @@ import "../../Utils/expect.dart";
 
 String test1(Object o) {
   switch (o) {
-    case [1, 2]:
+    case <int>[1, 2]:
       return "match";
     default:
       return "no match";
@@ -68,7 +68,7 @@ String test1(Object o) {
 }
 
 String test2(Object o) {
-  if (o case [1, 2]) {
+  if (o case <int>[1, 2]) {
     return "match";
   }
   return "no match";
@@ -76,22 +76,22 @@ String test2(Object o) {
 
 String test3(Object o) =>
    switch (o) {
-    [1, 2] => "match",
+    <int>[1, 2] => "match",
     _ => "no match"
   };
 
 main() {
-  Expect.equals("no match", test1([1]));
-  Expect.equals("no match", test1([1, 2, 3]));
-  Expect.equals("no match", test2([1]));
-  Expect.equals("no match", test2([1, 2, 3]));
-  Expect.equals("no match", test3([1]));
-  Expect.equals("no match", test3([1, 2, 3]));
+  Expect.equals("no match", test1(<int>[1]));
+  Expect.equals("no match", test1(<int>[1, 2, 3]));
+  Expect.equals("no match", test2(<int>[1]));
+  Expect.equals("no match", test2(<int>[1, 2, 3]));
+  Expect.equals("no match", test3(<int>[1]));
+  Expect.equals("no match", test3(<int>[1, 2, 3]));
 
   Expect.throws(() {
-    var [v1, v2] = [1];
+    var <int>[v1, v2] = <int>[1];
   });
   Expect.throws(() {
-    final [v1, v2] = [1, 2, 3];
+    final <int>[v1, v2] = <int>[1, 2, 3];
   });
 }

--- a/LanguageFeatures/Patterns/matching_list_A02_t04.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t04.dart
@@ -59,7 +59,7 @@ import "../../Utils/expect.dart";
 
 String test1(Object o) {
   switch (o) {
-    case []:
+    case <int?>[]:
       return "match";
     default:
       return "no match";
@@ -67,7 +67,7 @@ String test1(Object o) {
 }
 
 String test2(Object o) {
-  if (o case []) {
+  if (o case <int?>[]) {
     return "match";
   }
   return "no match";
@@ -75,22 +75,22 @@ String test2(Object o) {
 
 String test3(Object o) =>
    switch (o) {
-    [] => "match",
+    <int?>[] => "match",
     _ => "no match"
   };
 
 main() {
-  Expect.equals("no match", test1([1]));
-  Expect.equals("no match", test1([null]));
-  Expect.equals("no match", test2([1]));
-  Expect.equals("no match", test2([null]));
-  Expect.equals("no match", test3([1]));
-  Expect.equals("no match", test3([null]));
+  Expect.equals("no match", test1(<int?>[1]));
+  Expect.equals("no match", test1(<int?>[null]));
+  Expect.equals("no match", test2(<int?>[1]));
+  Expect.equals("no match", test2(<int?>[null]));
+  Expect.equals("no match", test3(<int?>[1]));
+  Expect.equals("no match", test3(<int?>[null]));
 
   Expect.throws(() {
-    var [] = [1];
+    var <int>[] = <int>[1];
     });
   Expect.throws(() {
-    final [] = [null];
+    final <Object?>[] = <Object?>[null];
   });
 }

--- a/LanguageFeatures/Patterns/matching_list_A02_t04.dart
+++ b/LanguageFeatures/Patterns/matching_list_A02_t04.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `p` is empty and `l > 0` then the match fails.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+
+String test1(Object o) {
+  switch (o) {
+    case []:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case []) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+   switch (o) {
+    [] => "match",
+    _ => "no match"
+  };
+
+main() {
+  Expect.equals("no match", test1([1]));
+  Expect.equals("no match", test1([null]));
+  Expect.equals("no match", test2([1]));
+  Expect.equals("no match", test2([null]));
+  Expect.equals("no match", test3([1]));
+  Expect.equals("no match", test3([null]));
+
+  Expect.throws(() {
+    var [] = [1];
+    });
+  Expect.throws(() {
+    final [] = [null];
+  });
+}

--- a/LanguageFeatures/Patterns/matching_list_A03_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t01.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `s` is an identifier pattern whose name is `_`
+/// then `v[i]` is not called for this element
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log = "[$index] called";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [_]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [_]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [_] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([42]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test2(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test3(ml));
+  Expect.equals("", log);
+
+  var [_] = ml;
+  Expect.equals("", log);
+  final [_] = ml;
+  Expect.equals("", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A03_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t01.dart
@@ -57,35 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log = "[$index] called";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -111,16 +83,19 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([42]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("", log);
+  Expect.equals("length;", ml.log);
+  ml.clearLog();
   Expect.equals("match", test2(ml));
-  Expect.equals("", log);
+  Expect.equals("length;", ml.log);
+  ml.clearLog();
   Expect.equals("match", test3(ml));
-  Expect.equals("", log);
+  Expect.equals("length;", ml.log);
+  ml.clearLog();
 
   var [_] = ml;
-  Expect.equals("", log);
+  Expect.equals("length;", ml.log);
+  ml.clearLog();
   final [_] = ml;
-  Expect.equals("", log);
+  Expect.equals("length;", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A03_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t02.dart
@@ -58,35 +58,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log += "[$index] called;";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -111,24 +83,23 @@ String test3(Object o) =>
   };
 
 main() {
-  MyList ml = MyList([1, 2, 3, 4]);
-  log = "";
+  MyList ml = MyList([1, 2, 3, 4], logLength: false);
   Expect.equals("match", test1(ml));
-  Expect.equals("[0] called;[1] called;", log);
-  log = "";
+  Expect.equals("[0];[1];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("[0] called;[1] called;", log);
-  log = "";
+  Expect.equals("[0];[1];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test3(ml));
-  Expect.equals("[0] called;[1] called;", log);
-  log = "";
+  Expect.equals("[0];[1];", ml.log);
+  ml.clearLog();
 
   var [x1, x2, ...] = ml;
-  Expect.equals("[0] called;[1] called;", log);
-  log = "";
+  Expect.equals("[0];[1];", ml.log);
+  ml.clearLog();
 
   final [y1, y2, ...] = ml;
-  Expect.equals("[0] called;[1] called;", log);
+  Expect.equals("[0];[1];", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A03_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t02.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `s` is not an identifier pattern with name `_`
+/// then each element is extracted by calling `v[i]` where `i` is from `0` to
+/// `h-1`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index] called;";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [1, 2, ...]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, 2, ...]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [1, 2, ...] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("[0] called;[1] called;", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("[0] called;[1] called;", log);
+  log = "";
+
+  Expect.equals("match", test3(ml));
+  Expect.equals("[0] called;[1] called;", log);
+  log = "";
+
+  var [x1, x2, ...] = ml;
+  Expect.equals("[0] called;[1] called;", log);
+  log = "";
+
+  final [y1, y2, ...] = ml;
+  Expect.equals("[0] called;[1] called;", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A03_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t03.dart
@@ -58,35 +58,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log += "[$index] called;";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -111,24 +83,23 @@ String test3(Object o) =>
   };
 
 main() {
-  MyList ml = MyList([1, 2, 3, 4, 5]);
-  log = "";
+  MyList ml = MyList([1, 2, 3, 4, 5], logLength: false);
   Expect.equals("match", test1(ml));
-  Expect.equals("[0] called;[2] called;", log);
-  log = "";
+  Expect.equals("[0];[2];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("[0] called;[2] called;", log);
-  log = "";
+  Expect.equals("[0];[2];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test3(ml));
-  Expect.equals("[0] called;[2] called;", log);
-  log = "";
+  Expect.equals("[0];[2];", ml.log);
+  ml.clearLog();
 
   var [x1, _, x3, ...] = ml;
-  Expect.equals("[0] called;[2] called;", log);
-  log = "";
+  Expect.equals("[0];[2];", ml.log);
+  ml.clearLog();
 
   final [y1, _, y3, ...] = ml;
-  Expect.equals("[0] called;[2] called;", log);
+  Expect.equals("[0];[2];", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A03_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A03_t03.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `s` is not an identifier pattern with name `_`
+/// then each element is extracted by calling `v[i]` where `i` is from `0` to
+/// `h-1`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index] called;";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [1, _, 3, ...]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, _, 3, ...]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [1, _, 3, ...] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4, 5]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("[0] called;[2] called;", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("[0] called;[2] called;", log);
+  log = "";
+
+  Expect.equals("match", test3(ml));
+  Expect.equals("[0] called;[2] called;", log);
+  log = "";
+
+  var [x1, _, x3, ...] = ml;
+  Expect.equals("[0] called;[2] called;", log);
+  log = "";
+
+  final [y1, _, y3, ...] = ml;
+  Expect.equals("[0] called;[2] called;", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A04_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t01.dart
@@ -57,40 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    log = "sublist($start, $end)";
-    return _inner.sublist(start, end);
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -117,28 +84,25 @@ String test3(Object o) =>
   };
 
 main() {
-  MyList ml = MyList([1, 2, 3, 4, 5]);
-  log = "";
-  Expect.equals("match", test1(ml));
-  Expect.equals("sublist(2, 4)", log);
-  log = "";
+  MyList ml1 = MyList([1, 2, 3, 4, 5]);
+  Expect.equals("match", test1(ml1));
+  Expect.equals("length;[0];[1];sublist(2, 4);[4];", ml1.log);
 
-  ml = MyList([1, 2, 3]);
-  Expect.equals("match", test2(ml));
-  Expect.equals("sublist(1, 2)", log);
-  log = "";
+  MyList ml2 = MyList([1, 2, 3]);
+  Expect.equals("match", test2(ml2));
+  Expect.equals("length;[0];sublist(1, 2);[2];", ml2.log);
 
-  ml = MyList([1, 2, 3, 4]);
-  Expect.equals("match", test3(ml));
-  Expect.equals("sublist(0, 2)", log);
-  log = "";
+  MyList ml3 = MyList([1, 2, 3, 4]);
+  Expect.equals("match", test3(ml3));
+  Expect.equals("length;sublist(0, 2);[2];[3];", ml3.log);
+  ml3.clearLog();
 
-  var [x1, x2, ...r1, x4] = ml;
-  Expect.equals("sublist(2, 3)", log);
+  var [x1, x2, ...r1, x4] = ml3;
+  Expect.equals("length;[0];[1];sublist(2, 3);[3];", ml3.log);
   Expect.listEquals(r1, [3]);
-  log = "";
+  ml3.clearLog();
 
-  final [... r2, y3, y4] = ml;
-  Expect.equals("sublist(0, 2)", log);
+  final [... r2, y3, y4] = ml3;
+  Expect.equals("length;sublist(0, 2);[2];[3];", ml3.log);
   Expect.listEquals(r2, [1, 2]);
 }

--- a/LanguageFeatures/Patterns/matching_list_A04_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t01.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if there is a matching rest element `r` and `t > 0`
+/// then `r` is the result of `v.sublist(h, l - t)`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log = "sublist($start, $end)";
+    return _inner.sublist(start, end);
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [1, 2, ... var r, 5]:
+      Expect.listEquals([3, 4], r);
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, ... final r, 3]) {
+    Expect.listEquals([2], r);
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [... var r, 3, 4] when r.length == 2 && r[0] == 1 && r[1] == 2 => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4, 5]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("sublist(2, 4)", log);
+  log = "";
+
+  ml = MyList([1, 2, 3]);
+  Expect.equals("match", test2(ml));
+  Expect.equals("sublist(1, 2)", log);
+  log = "";
+
+  ml = MyList([1, 2, 3, 4]);
+  Expect.equals("match", test3(ml));
+  Expect.equals("sublist(0, 2)", log);
+  log = "";
+
+  var [x1, x2, ...r1, x4] = ml;
+  Expect.equals("sublist(2, 3)", log);
+  Expect.listEquals(r1, [3]);
+  log = "";
+
+  final [... r2, y3, y4] = ml;
+  Expect.equals("sublist(0, 2)", log);
+  Expect.listEquals(r2, [1, 2]);
+}

--- a/LanguageFeatures/Patterns/matching_list_A04_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t02.dart
@@ -1,0 +1,146 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if there is a matching rest element `r` and
+/// `t == 0` then `r` is the result of `v.sublist(h)`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log = "sublist($start, $end)";
+    return _inner.sublist(start, end);
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [1, 2, ... var r]:
+    Expect.listEquals([3, 4], r);
+    return "match";
+  default:
+    return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, 2, ... final r]) {
+    Expect.listEquals([3, 4], r);
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+    switch (o) {
+      [1, 2, ... var r] when r.length == 2 && r[0] == 3 && r[1] == 4 => "match",
+      _ => "no match"
+    };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("sublist(2, null)", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("sublist(2, null)", log);
+  log = "";
+
+  Expect.equals("match", test3(ml));
+  Expect.equals("sublist(2, null)", log);
+  log = "";
+
+  var [x1, x2, ...r1] = ml;
+  Expect.equals("sublist(2, null)", log);
+  Expect.listEquals(r1, [3, 4]);
+  Expect.equals(1, x1);
+  Expect.equals(2, x2);
+  log = "";
+
+  final [y1, y2, ...r2] = ml;
+  Expect.equals("sublist(2, null)", log);
+  Expect.listEquals(r2, [3, 4]);
+  Expect.equals(1, y1);
+  Expect.equals(2, y2);
+}

--- a/LanguageFeatures/Patterns/matching_list_A04_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t02.dart
@@ -57,40 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    log = "sublist($start, $end)";
-    return _inner.sublist(start, end);
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -118,28 +85,27 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([1, 2, 3, 4]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("sublist(2, null)", log);
-  log = "";
+  Expect.equals("length;[0];[1];sublist(2, null);", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("sublist(2, null)", log);
-  log = "";
+  Expect.equals("length;[0];[1];sublist(2, null);", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test3(ml));
-  Expect.equals("sublist(2, null)", log);
-  log = "";
+  Expect.equals("length;[0];[1];sublist(2, null);", ml.log);
+  ml.clearLog();
 
   var [x1, x2, ...r1] = ml;
-  Expect.equals("sublist(2, null)", log);
+  Expect.equals("length;[0];[1];sublist(2, null);", ml.log);
   Expect.listEquals(r1, [3, 4]);
   Expect.equals(1, x1);
   Expect.equals(2, x2);
-  log = "";
+  ml.clearLog();
 
   final [y1, y2, ...r2] = ml;
-  Expect.equals("sublist(2, null)", log);
+  Expect.equals("length;[0];[1];sublist(2, null);", ml.log);
   Expect.listEquals(r2, [3, 4]);
   Expect.equals(1, y1);
   Expect.equals(2, y2);

--- a/LanguageFeatures/Patterns/matching_list_A04_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t03.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if there is a matching rest element `r` and
+/// `t == 0` then `r` is the result of `v.sublist(h)`. Test the case when `p`
+/// contains only a rest element
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    log += "length called: ${_inner.length};";
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log += "sublist($start, $end)";
+    return _inner.sublist(start, end);
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [... var r]:
+    Expect.listEquals([1, 2], r);
+    return "match";
+  default:
+    return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [... final r]) {
+    Expect.listEquals([1, 2], r);
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+    switch (o) {
+      [... var r] when r.length == 2 && r[0] == 1 && r[1] == 2 => "match",
+      _ => "no match"
+    };
+
+main() {
+  MyList ml = MyList([1, 2]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("sublist(0, null)", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("sublist(0, null)", log);
+  log = "";
+  
+  Expect.equals("match", test3(ml));
+  Expect.equals("sublist(0, null)", log);
+  log = "";
+
+  var [...r1] = ml;
+  Expect.equals("sublist(0, null)", log);
+  Expect.listEquals(r1, [1, 2]);
+  log = "";
+
+  final [...r2] = ml;
+  Expect.equals("sublist(0, null)", log);
+  Expect.listEquals(r2, [1, 2]);
+}

--- a/LanguageFeatures/Patterns/matching_list_A04_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t03.dart
@@ -51,48 +51,14 @@
 /// viii. The match succeeds if all subpatterns match.
 ///
 /// @description Checks that if there is a matching rest element `r` and
-/// `t == 0` then `r` is the result of `v.sublist(h)`. Test the case when `p`
-/// contains only a rest element
+/// `t == 0` then `r` is the result of `v.sublist(h). Test that if `p` contains
+/// only a rest element then no `length` and operators `[]` invoked
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    log += "length called: ${_inner.length};";
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    log += "sublist($start, $end)";
-    return _inner.sublist(start, end);
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -120,25 +86,24 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([1, 2]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("sublist(0, null)", log);
-  log = "";
+  Expect.equals("sublist(0, null);", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("sublist(0, null)", log);
-  log = "";
+  Expect.equals("sublist(0, null);", ml.log);
+  ml.clearLog();
   
   Expect.equals("match", test3(ml));
-  Expect.equals("sublist(0, null)", log);
-  log = "";
+  Expect.equals("sublist(0, null);", ml.log);
+  ml.clearLog();
 
   var [...r1] = ml;
-  Expect.equals("sublist(0, null)", log);
+  Expect.equals("sublist(0, null);", ml.log);
   Expect.listEquals(r1, [1, 2]);
-  log = "";
+  ml.clearLog();
 
   final [...r2] = ml;
-  Expect.equals("sublist(0, null)", log);
+  Expect.equals("sublist(0, null);", ml.log);
   Expect.listEquals(r2, [1, 2]);
 }

--- a/LanguageFeatures/Patterns/matching_list_A04_t04.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t04.dart
@@ -57,40 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    log += "sublist($start, $end)";
-    return _inner.sublist(start, end);
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -116,23 +83,26 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([1, 2, 3]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("", log);
+  Expect.equals("length;[0];[2];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("", log);
+  Expect.equals("length;[0];[2];", ml.log);
+  ml.clearLog();
   
   Expect.equals("match", test3(ml));
-  Expect.equals("", log);
+  Expect.equals("length;[0];[2];", ml.log);
+  ml.clearLog();
 
   var [x1, ..., x3] = ml;
-  Expect.equals("", log);
+  Expect.equals("length;[0];[2];", ml.log);
   Expect.equals(1, x1);
   Expect.equals(3, x3);
+  ml.clearLog();
 
   final [y1, ..., y3] = ml;
-  Expect.equals("", log);
+  Expect.equals("length;[0];[2];", ml.log);
   Expect.equals(1, y1);
   Expect.equals(3, y3);
 }

--- a/LanguageFeatures/Patterns/matching_list_A04_t04.dart
+++ b/LanguageFeatures/Patterns/matching_list_A04_t04.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if there is a non-matching rest element then
+/// `v.sublist()` is not called
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log += "sublist($start, $end)";
+    return _inner.sublist(start, end);
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [1, ..., 3]:
+    return "match";
+  default:
+    return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [1, ..., 3]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+    switch (o) {
+      [1, ..., 3] => "match",
+      _ => "no match"
+    };
+
+main() {
+  MyList ml = MyList([1, 2, 3]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("", log);
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("", log);
+  
+  Expect.equals("match", test3(ml));
+  Expect.equals("", log);
+
+  var [x1, ..., x3] = ml;
+  Expect.equals("", log);
+  Expect.equals(1, x1);
+  Expect.equals(3, x3);
+
+  final [y1, ..., y3] = ml;
+  Expect.equals("", log);
+  Expect.equals(1, y1);
+  Expect.equals(3, y3);
+}

--- a/LanguageFeatures/Patterns/matching_list_A05_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t01.dart
@@ -57,42 +57,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log = "[$index] called;";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    var res = _inner.sublist(start, end);
-    log = "";
-    return res;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -117,17 +82,16 @@ String test3(Object o) =>
   };
 
 main() {
-  MyList ml = MyList([1, 2, 3]);
-  log = "";
+  MyList ml = MyList([1, 2, 3], logLength: false);
   Expect.equals("match", test1(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   Expect.equals("match", test2(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   Expect.equals("match", test3(ml));
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
 
   var [..., _] = ml;
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
   final [..., _] = ml;
-  Expect.equals("", log);
+  Expect.equals("", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A05_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t01.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that if `s` is an identifier pattern whose name is `_`
+/// then `v[i]` is not called for this element. Test tail elements
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log = "[$index] called;";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    var res = _inner.sublist(start, end);
+    log = "";
+    return res;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [..., _]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [..., _]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [..., _] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test2(ml));
+  Expect.equals("", log);
+  Expect.equals("match", test3(ml));
+  Expect.equals("", log);
+
+  var [..., _] = ml;
+  Expect.equals("", log);
+  final [..., _] = ml;
+  Expect.equals("", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A05_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t02.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that for the each tail element if `s` is not an
+/// identifier pattern with name `_` then each element is extracted by calling
+/// `v[l - t + i]` where `i` is from `0` to `t-1`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index] called;";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    var res = _inner.sublist(start, end);
+    log = "";
+    return res;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [..., 3, 4]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [..., 3, 4]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [..., 3, 4] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("[2] called;[3] called;", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("[2] called;[3] called;", log);
+  log = "";
+
+  Expect.equals("match", test3(ml));
+  Expect.equals("[2] called;[3] called;", log);
+  log = "";
+
+  var [..., x3, x4] = ml;
+  Expect.equals("[2] called;[3] called;", log);
+  log = "";
+
+  final [..., y3, y4] = ml;
+  Expect.equals("[2] called;[3] called;", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A05_t02.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t02.dart
@@ -58,42 +58,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log += "[$index] called;";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    var res = _inner.sublist(start, end);
-    log = "";
-    return res;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -119,23 +84,22 @@ String test3(Object o) =>
 
 main() {
   MyList ml = MyList([1, 2, 3, 4]);
-  log = "";
   Expect.equals("match", test1(ml));
-  Expect.equals("[2] called;[3] called;", log);
-  log = "";
+  Expect.equals("length;[2];[3];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("[2] called;[3] called;", log);
-  log = "";
+  Expect.equals("length;[2];[3];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test3(ml));
-  Expect.equals("[2] called;[3] called;", log);
-  log = "";
+  Expect.equals("length;[2];[3];", ml.log);
+  ml.clearLog();
 
   var [..., x3, x4] = ml;
-  Expect.equals("[2] called;[3] called;", log);
-  log = "";
+  Expect.equals("length;[2];[3];", ml.log);
+  ml.clearLog();
 
   final [..., y3, y4] = ml;
-  Expect.equals("[2] called;[3] called;", log);
+  Expect.equals("length;[2];[3];", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_list_A05_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t03.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion At runtime, a pattern is matched against a value. This determines
+/// whether or not the match fails and the pattern refutes the value. If the
+/// match succeeds, the pattern may also destructure data from the object or
+/// bind variables.
+///
+/// Refutable patterns usually occur in a context where match refutation causes
+/// execution to skip over the body of code where any variables bound by the
+/// pattern are in scope. If a pattern match failure occurs in an irrefutable
+/// context, a runtime error is thrown.
+///
+/// To match a pattern p against a value v:
+/// ...
+/// List:
+/// i. If the runtime type of v is not a subtype of the required type of p then
+///   the match fails.
+/// ii. Let h be the number of non-rest elements preceding the rest element if
+///   there is one, or the number of elements if there is no rest element.
+/// iii. Let t be the number of non-rest elements following the rest element if
+///   there is one, or 0 otherwise.
+/// iv. Check the length:
+///   a. If p has a rest element and h + t == 0, then do nothing for checking
+///     the length.
+///   b. Else let l be the length of the list determined by calling length on v.
+///   c. If p has a rest element (and h + t > 0):
+///     a.  If l < h + t then the match fails.
+///   d. Else if h + t > 0 (and p has no rest element):
+///     a. If l != h + t then the match fails.
+///   e. Else p is empty:
+///     a. If l > 0 then the match fails.
+/// v. Match the head elements. For i from 0 to h - 1, inclusive:
+///   a. Let s be the ith element subpattern.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[i].
+///   d. Match s against e.
+/// vi. If there is a matching rest element:
+///   a. If t > 0 then let r be the result of v.sublist(h, l - t).
+///   b. Else let r be the result of v.sublist(h).
+///   c. Match the rest element subpattern against r.
+/// vii. Match the tail elements. If t > 0, then for i from 0 to t - 1,
+///   inclusive:
+///   a. Let s be the subpattern i elements after the rest element.
+///   b. If s is an identifier pattern whose name is _ then do nothing for this
+///     element.
+///   c. Else extract the element value e by calling v[l - t + i].
+///   d. Match s against e.
+/// viii. The match succeeds if all subpatterns match.
+///
+/// @description Checks that for the each tail element if `s` is not an
+/// identifier pattern with name `_` then each element is extracted by calling
+/// `v[l - t + i]` where `i` is from `0` to `t-1`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../Utils/expect.dart";
+import "dart:collection";
+
+String log = "";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  MyList(this._inner);
+
+  @override
+  int get length {
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index] called;";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    var res = _inner.sublist(start, end);
+    log = "";
+    return res;
+  }
+}
+
+String test1(Object o) {
+  switch (o) {
+    case [..., 3, _, 5]:
+      return "match";
+    default:
+      return "no match";
+  }
+}
+
+String test2(Object o) {
+  if (o case [..., 3, _, 5]) {
+    return "match";
+  }
+  return "no match";
+}
+
+String test3(Object o) =>
+  switch (o) {
+    [..., 3, _, 5] => "match",
+    _ => "no match"
+  };
+
+main() {
+  MyList ml = MyList([1, 2, 3, 4, 5]);
+  log = "";
+  Expect.equals("match", test1(ml));
+  Expect.equals("[2] called;[4] called;", log);
+  log = "";
+
+  Expect.equals("match", test2(ml));
+  Expect.equals("[2] called;[4] called;", log);
+  log = "";
+
+  Expect.equals("match", test3(ml));
+  Expect.equals("[2] called;[4] called;", log);
+  log = "";
+
+  var [..., x3, _, x5] = ml;
+  Expect.equals("[2] called;[4] called;", log);
+  log = "";
+
+  final [..., y3, _, y5] = ml;
+  Expect.equals("[2] called;[4] called;", log);
+}

--- a/LanguageFeatures/Patterns/matching_list_A05_t03.dart
+++ b/LanguageFeatures/Patterns/matching_list_A05_t03.dart
@@ -58,42 +58,7 @@
 // SharedOptions=--enable-experiment=patterns
 
 import "../../Utils/expect.dart";
-import "dart:collection";
-
-String log = "";
-
-class MyList<T> extends ListBase<T> {
-  List<T> _inner = [];
-  MyList(this._inner);
-
-  @override
-  int get length {
-    return _inner.length;
-  }
-
-  @override
-  void set length(int newLength) {
-    _inner.length = newLength;
-  }
-
-  @override
-  T operator [](int index) {
-    log += "[$index] called;";
-    return _inner[index];
-  }
-
-  @override
-  void operator []=(int index, T value) {
-    _inner[index] = value;
-  }
-
-  @override
-  List<T> sublist(int start, [int? end]) {
-    var res = _inner.sublist(start, end);
-    log = "";
-    return res;
-  }
-}
+import "patterns_collections_lib.dart";
 
 String test1(Object o) {
   switch (o) {
@@ -118,24 +83,23 @@ String test3(Object o) =>
   };
 
 main() {
-  MyList ml = MyList([1, 2, 3, 4, 5]);
-  log = "";
+  MyList ml = MyList([1, 2, 3, 4, 5], logLength: false);
   Expect.equals("match", test1(ml));
-  Expect.equals("[2] called;[4] called;", log);
-  log = "";
+  Expect.equals("[2];[4];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test2(ml));
-  Expect.equals("[2] called;[4] called;", log);
-  log = "";
+  Expect.equals("[2];[4];", ml.log);
+  ml.clearLog();
 
   Expect.equals("match", test3(ml));
-  Expect.equals("[2] called;[4] called;", log);
-  log = "";
+  Expect.equals("[2];[4];", ml.log);
+  ml.clearLog();
 
   var [..., x3, _, x5] = ml;
-  Expect.equals("[2] called;[4] called;", log);
-  log = "";
+  Expect.equals("[2];[4];", ml.log);
+  ml.clearLog();
 
   final [..., y3, _, y5] = ml;
-  Expect.equals("[2] called;[4] called;", log);
+  Expect.equals("[2];[4];", ml.log);
 }

--- a/LanguageFeatures/Patterns/matching_parenthesized_A01_t01.dart
+++ b/LanguageFeatures/Patterns/matching_parenthesized_A01_t01.dart
@@ -16,8 +16,8 @@
 /// ...
 /// Parenthesized: Match the subpattern against v and succeed if it matches.
 ///
-/// @description Checks that if subpattern of a parenthesized pattern matches,
-/// then pattern itself matches
+/// @description Checks that if the subpattern of a parenthesized pattern
+/// matches, then the pattern itself matches
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns

--- a/LanguageFeatures/Patterns/matching_parenthesized_A02_t01.dart
+++ b/LanguageFeatures/Patterns/matching_parenthesized_A02_t01.dart
@@ -16,8 +16,8 @@
 /// ...
 /// Parenthesized: Match the subpattern against v and succeed if it matches.
 ///
-/// @description Checks that if subpattern of a parenthesized pattern doesn't
-/// match, then pattern itself doesn't match too
+/// @description Checks that if the subpattern of a parenthesized pattern
+/// doesn't match, then the pattern itself doesn't match too
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=patterns

--- a/LanguageFeatures/Patterns/patterns_collections_lib.dart
+++ b/LanguageFeatures/Patterns/patterns_collections_lib.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @description Defines collections used by Patterns tests
+/// @author sgrekhov22@gmail.com
+
+library patterns_collections_lib;
+
+import "dart:collection";
+
+class MyList<T> extends ListBase<T> {
+  List<T> _inner = [];
+  String log = "";
+  bool _logLength;
+  MyList(this._inner, {logLength = true}) : this._logLength = logLength;
+
+  @override
+  int get length {
+    if (_logLength) {
+      log += "length;";
+    }
+    return _inner.length;
+  }
+
+  @override
+  void set length(int newLength) {
+    log += "length=;";
+    _inner.length = newLength;
+  }
+
+  @override
+  T operator [](int index) {
+    log += "[$index];";
+    return _inner[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    log += "[$index]=$value;";
+    _inner[index] = value;
+  }
+
+  @override
+  List<T> sublist(int start, [int? end]) {
+    log += "sublist($start, $end);";
+    return _inner.sublist(start, end);
+  }
+
+  void clearLog() {
+    log = "";
+  }
+}


### PR DESCRIPTION
Please note `matching_list_A04_t04.dart`. It checks the following [informal statement](https://github.com/dart-lang/language/blob/master/accepted/future-releases/0546-patterns/feature-specification.md#matching-refuting-and-destructuring:~:text=If%20there%20is%20a%20non%2Dmatching%20rest%20element%2C%20the%20unneeded%20list%20elements%20are%20completely%20skipped%20and%20we%20don%27t%20even%20call%20sublist()%20to%20access%20them.)

> If there is a non-matching rest element, the unneeded list elements are completely skipped and we don't even call sublist() to access them.

Probably it's too strong to test that `sublist()` is not called in this case. "We don't call" doesn't necessary mean "we shouldn't call". Probably, it's not an error for some implementations to call `sublist()` for some reason. I tested it on `dartk` only and it works there (`sublist()` is not called for non-matching rest element). But if you believe that it's better not to have this test I'll remove it