### PR TITLE
Fixes #1937. Add `@dart=2.19` to class implementing `LinkedHashSet`

### DIFF
--- a/LanguageFeatures/Set-literals/exact_types_of_literals_A01_t01.dart
+++ b/LanguageFeatures/Set-literals/exact_types_of_literals_A01_t01.dart
@@ -13,6 +13,8 @@
 /// LinkedHashSet<T>
 /// @author sgrekhov@unipro.ru
 
+// @dart=2.19
+
 import "dart:collection";
 
 class C<T> with SetMixin<T> implements LinkedHashSet<T> {


### PR DESCRIPTION
I don't see any other ways how to fix this