### PR TITLE
#1401. Exhaustiveness algorithm tests

### DIFF
--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t01.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with enum as a matched type are
+/// always exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is an enum and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+enum E<T> {
+  a<int>(),
+  b<String>(),
+  c<double>(),
+}
+
+String test1(E<num> e) {
+  switch (e) {
+    case E.a:
+    case E.c:
+      return "ok";
+  }
+}
+
+String test2(E<num> e) =>
+  switch (e) {
+    E.a => "a",
+    E.c => "c"
+  };
+
+main() {
+  Expect.equals("ok", test1(E.a));
+  Expect.equals("ok", test1(E.c));
+  Expect.equals("a", test2(E.a));
+  Expect.equals("c", test2(E.c));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t02.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with enum as a matched type are
+/// always exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is an enum and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+enum E<T> {
+  a<int>(),
+  b<String>(),
+  c<double>(),
+}
+
+String test1<T extends num>(E<T> e) {
+  switch (e) {
+    case E.a:
+    case E.c:
+      return "ok";
+  }
+}
+
+String test2<T extends num>(E<T> e) =>
+  switch (e) {
+    E.a => "a",
+    E.c => "c"
+  };
+
+main() {
+  Expect.equals("ok", test1(E.a));
+  Expect.equals("ok", test1(E.c));
+  Expect.equals("ok", test1<int>(E.a));
+  Expect.equals("ok", test1<double>(E.c));
+  Expect.equals("a", test2(E.a));
+  Expect.equals("c", test2(E.c));
+  Expect.equals("a", test2<int>(E.a));
+  Expect.equals("c", test2<double>(E.c));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t03.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A01_t03.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with enum as a matched type are
+/// always exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is an enum and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+enum E<T> {
+  a<int>(),
+  b<String>(),
+  c<double>(),
+}
+
+String test1<T extends num>(E<T> e) {
+  switch (e) {
+    case E.a || E.c:
+      return "ok";
+  }
+}
+
+String test2<T extends num>(E<T> e) =>
+  switch (e) {
+    E.a || E.c => "ok"
+  };
+
+main() {
+  Expect.equals("ok", test1(E.a));
+  Expect.equals("ok", test1(E.c));
+  Expect.equals("ok", test1<int>(E.a));
+  Expect.equals("ok", test1<double>(E.c));
+  Expect.equals("ok", test2(E.a));
+  Expect.equals("ok", test2(E.c));
+  Expect.equals("ok", test2<int>(E.a));
+  Expect.equals("ok", test2<double>(E.c));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A02_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_enum_A02_t01.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with enum as a matched type are
+/// always exhaustive
+///
+/// @description Check that it is a compile-time error if a matched type of a
+/// switch expression is an enum and not all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+enum E<T> {
+  a<int>(),
+  b<String>(),
+  c<double>(),
+}
+
+String test1<T extends num>(E<T> e) {
+  switch (e) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case E.a:
+      return "a";
+    case E.b:
+      return "b";
+  }
+}
+
+String test2<T extends num>(E<T> e) =>
+  switch (e) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      E.a => "a",
+      E.b => "b"
+    };
+
+String test3(E<num> e) {
+  switch (e) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case E.a:
+      return "ok";
+  }
+}
+
+String test4(E<num> e) =>
+  switch (e) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    E.a => "a"
+  };
+
+main() {
+  test1(E.a);
+  test2(E.c);
+  test3(E.a);
+  test4(E.a);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_lib.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_lib.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @description Library containing common classes for exhaustiveness tests
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+library exhaustiveness_lib;
+
+enum Suit { club, diamond, heart, spade }
+
+sealed class Card<T> {
+  final Suit suit;
+
+  Card(this.suit);
+}
+
+class Pip<T> extends Card<T> {
+  final int pips;
+
+  Pip(this.pips, super.suit);
+}
+
+sealed class Face<T> extends Card<T> {
+  Face(super.suit);
+}
+
+class Jack<T> extends Face<T> {
+  final bool oneEyed;
+
+  Jack(super.suit, {this.oneEyed = false});
+}
+
+class Queen<T> extends Face<T> {
+  Queen(super.suit);
+}
+
+class King<T> extends Face<T> {
+  King(super.suit);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t01.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is a list and all cases are exhaustive. Test rest element
+/// at the end of the list pattern
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(List<int> l) =>
+  switch (l) {
+    <int?>[] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, _, ...] => "2+"
+  };
+
+String test2(List<bool> l) =>
+  switch (l) {
+    [] => "0",
+    [true] => "1_1",
+    [false] => "1_2",
+    [_, true] => "2_1",
+    [_, false] => "2_2",
+    [_, true, ...var r1] => "3_1",
+    [_, false, ...final r2] => "3_2"
+  };
+
+main() {
+  Expect.equals("0", test1([]));
+  Expect.equals("1", test1([1]));
+  Expect.equals("2", test1([1, 2]));
+  Expect.equals("2+", test1([1, 2, 3]));
+
+  Expect.equals("0", test2([]));
+  Expect.equals("1_1", test2([true]));
+  Expect.equals("1_2", test2([false]));
+  Expect.equals("2_1", test2([true, true]));
+  Expect.equals("2_2", test2([true, false]));
+  Expect.equals("3_1", test2([true, true, false]));
+  Expect.equals("3_2", test2([true, false, false]));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t02.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is a list and all cases are exhaustive. Test rest element
+/// at the middle of the list pattern
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(List<int> l) =>
+  switch (l) {
+    [] => "0",
+    <int?>[_] => "1",
+    [_, _] => "2",
+    [_, ..., _] => "2+"
+  };
+
+String test2(List<bool> l) =>
+  switch (l) {
+    [] => "0",
+    [true] => "1_1",
+    [false] => "1_2",
+    [_, true] => "2_1",
+    [_, false] => "2_2",
+    [_, ... var r1, true] => "3_1",
+    [_, ... final r2, false] => "3_2"
+  };
+
+main() {
+  Expect.equals("0", test1([]));
+  Expect.equals("1", test1([1]));
+  Expect.equals("2", test1([1, 2]));
+  Expect.equals("2+", test1([1, 2, 3]));
+
+  Expect.equals("0", test2([]));
+  Expect.equals("1_1", test2([true]));
+  Expect.equals("1_2", test2([false]));
+  Expect.equals("2_1", test2([true, true]));
+  Expect.equals("2_2", test2([true, false]));
+  Expect.equals("3_1", test2([true, true, true]));
+  Expect.equals("3_2", test2([true, false, false]));
+
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t03.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A01_t03.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is no compile-time error if a matched type of a
+/// switch expression is a list and all cases are exhaustive. Test rest element
+/// at the beginning of the list pattern
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(List<int> l) =>
+  switch (l) {
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    <int?>[..., _, _] => "2+"
+  };
+
+String test2(List<bool> l) =>
+  switch (l) {
+    [] => "0",
+    [true] => "1_1",
+    [false] => "1_2",
+    [_, true] => "2_1",
+    [_, false] => "2_2",
+    [... var r1, true] => "3_1",
+    [... final r2, false] => "3_2"
+  };
+
+main() {
+  Expect.equals("0", test1([]));
+  Expect.equals("1", test1([1]));
+  Expect.equals("2", test1([1, 2]));
+  Expect.equals("2+", test1([1, 2, 3]));
+
+  Expect.equals("0", test2([]));
+  Expect.equals("1_1", test2([true]));
+  Expect.equals("1_2", test2([false]));
+  Expect.equals("2_1", test2([true, true]));
+  Expect.equals("2_2", test2([true, false]));
+  Expect.equals("3_1", test2([true, true, true]));
+  Expect.equals("3_2", test2([true, false, false]));
+
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A02_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A02_t01.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements with a list as a matched type can never be
+/// exhaustive
+///
+/// @description Check that exhaustiveness check is not performed for a switch
+/// statement with a list as a matched type
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test(List<bool> l) {
+//     ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  switch (l) {
+    case []:
+    case [_]:
+    case [_, _]:
+    case [_, _, ...]:
+      return "ok";
+  }
+}
+
+main() {
+  test([]);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t01.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is a compile-time error if a matched type of a
+/// switch expression is a list and cases are not exhaustive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    <String>[] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, _, ...] => "2+"
+  };
+
+String test2(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    <String>[_] => "1",
+    [_, _] => "2",
+    [_, ..., _] => "2+"
+  };
+
+String test3(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    <String>[..., _, _] => "2+"
+  };
+
+main() {
+  test1([]);
+  test2([]);
+  test3([]);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t02.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is a compile-time error if a matched type of a
+/// switch expression is a list and cases are not exhaustive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, ..., _, _, _] => "2+"
+  };
+
+String test2(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_, _] => "2",
+    [_, ..., _] => "2+"
+  };
+
+String test3(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [_] => "1",
+    [..., _, _] => "2+"
+  };
+
+main() {
+  test1([]);
+  test2([]);
+  test3([]);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t03.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_list_A03_t03.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch expression with a list as a matched type can be exhaustive
+///
+/// @description Check that it is a compile-time error if a matched type of a
+/// switch expression is a list and cases are not exhaustive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, _, _] => "3"
+  };
+
+String test2(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, _, _] => "3",
+    [...[_]] => "-"
+  };
+
+String test3(List<int> l) =>
+  switch (l) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    [] => "0",
+    [_] => "1",
+    [_, _] => "2",
+    [_, _, ... List<String> r] => "2+"
+  };
+
+main() {
+  test1([]);
+  test2([]);
+  test3([]);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_map_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_map_A01_t01.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with map as a matched type can
+/// never be exhaustive
+///
+/// @description Check that map pattern cannot be exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(Map<bool, bool> m) =>
+  switch (m) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    {true: true} => "case-1",
+    {true: false} => "case-2",
+    {false: true} => "case-3",
+    {false: false} => "case-4",
+  };
+
+String test2(Map<bool, bool> m) {
+//     ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  switch (m) {
+    case {true: true}:
+      return "case-1";
+    case {true: false}:
+      return "case-2";
+    case {false: true}:
+      return "case-3";
+    case {false: false}:
+      return "case-4";
+  }
+}
+
+main() {
+  print(test1({true: false}));
+  print(test2({true: false}));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t01.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is no compile-time error if matched type of a
+/// switch expression is a sealed class and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "../../../Utils/expect.dart";
+
+sealed class A<T> {}
+
+class B<T> extends A<T> {}
+
+class C extends A<int> {}
+
+test1(A<String> a) => switch (a) { B _ => 'B'};
+
+test2(A<String> a) => switch (a) { B _ => 'B', C _ => 'C'};
+
+main() {
+  Expect.equals("B", test1(B<String>()));
+  Expect.equals("B", test2(B<String>()));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t02.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is no compile-time error if matched type of a
+/// switch expression is a sealed class and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+import "../../../Utils/expect.dart";
+
+String test1(Face face) =>
+    switch (face) { Jack _ => 'Jack', Queen _ => 'Queen', King _ => 'King' };
+
+String test2(Face<int> face) => switch (face) {
+      Jack<num> _ => 'Jack',
+      Queen<int> _ => 'Queen',
+      King<int> _ => 'King'
+    };
+
+String test3<T extends num>(Face<T> face) => switch (face) {
+      Jack<num> _ => 'Jack',
+      Queen<num> _ => 'Queen',
+      King<T> _ => 'King'
+    };
+
+main() {
+  Expect.equals("King", test1(King(Suit.club)));
+  Expect.equals("King", test2(King(Suit.club)));
+  Expect.equals("King", test3<int>(King(Suit.club)));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t03.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t03.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is no compile-time error if matched type of a
+/// switch expression is a sealed class and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+import "../../../Utils/expect.dart";
+
+String test1(Face face) => switch (face) {
+      Jack _ => 'Jack',
+      Queen _ => 'Queen',
+      King(suit: _) => 'King'
+    };
+
+String test2(Face<int> face) => switch (face) {
+      Jack<num> _ => 'Jack',
+      Queen<int> _ => 'Queen',
+      King<int>(suit: Suit.club || Suit.diamond || Suit.heart || Suit.spade) =>
+        'King'
+    };
+
+String test3<T extends num>(Face<T> face) => switch (face) {
+      Jack<num>() && Jack<T>(oneEyed: _) => 'Jack',
+      Queen<num> _ => 'Queen',
+      King<T>() => 'King'
+    };
+
+main() {
+  Expect.equals("King", test1(King(Suit.club)));
+  Expect.equals("King", test2(King(Suit.club)));
+  Expect.equals("King", test3<int>(King(Suit.club)));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t04.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A01_t04.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is no compile-time error if matched type of a
+/// switch expression is a sealed class and all cases are exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+import "../../../Utils/expect.dart";
+
+String test1(Face face) => switch (face) {
+      Jack _ || Queen _ => 'Jack or Queen',
+      King(suit: _) => 'King'
+    };
+
+String test2(Face<int> face) => switch (face) {
+      Jack<num> _ || Queen<int> _ => 'Jack or Queen',
+      King<int>(suit: Suit.club || Suit.diamond || Suit.heart || Suit.spade) =>
+        'King'
+    };
+
+String test3<T extends num>(Face<T> face) => switch (face) {
+      Jack<num>() && Jack<T>(oneEyed: _) => 'Jack',
+      Queen<num> _ => 'Queen',
+      King<T>() => 'King'
+    };
+
+main() {
+  Expect.equals("Jack or Queen", test1(Jack(Suit.club)));
+  Expect.equals("Jack or Queen", test2(Jack(Suit.club)));
+  Expect.equals("King", test3<int>(King(Suit.club)));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t01.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is a compile-time error if matched type of a
+/// switch expression is a sealed class and cases are not exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+
+String test1(Face face) => switch (face) {
+//                         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack _ => 'Jack',
+  Queen _ => 'Queen'
+};
+
+String test2(Face<num> face) => switch (face) {
+//                              ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack<num> _ => 'Jack',
+  Queen<int> _ => 'Queen',
+  King<double> _ => 'King'
+};
+
+String test3<T extends num>(Face<T> face) => switch (face) {
+//                                           ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack<num> _ => 'Jack',
+  Queen<int> _ => 'Queen',
+  King<T> _ => 'King'
+};
+
+main() {
+  test1(King(Suit.club));
+  test2(King(Suit.club));
+  test3<int>(King(Suit.club));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t02.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Switch statements and expressions with a sealed class as a
+/// matched type are always exhaustive
+///
+/// @description Check that it is a compile-time error if matched type of a
+/// switch expression is a sealed class and cases are not exhaustive
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+
+String test1(Face face) => switch (face) {
+//                         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack _ => 'Jack',
+  Queen _ => 'Queen',
+  King(suit: Suit.club) => 'King'
+};
+
+String test2(Face<num> face) => switch (face) {
+//                              ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack<num> _ => 'Jack',
+  Queen<int> _ => 'Queen',
+  King<int>(suit: Suit.club)  => 'King'
+};
+
+String test3<T extends num>(Face<T> face) => switch (face) {
+//                                           ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  Jack<num>(oneEyed: false) && Jack<T>(oneEyed: true) => 'Jack',
+  Queen<num> _ => 'Queen',
+  King<T>(suit: _) => 'King'
+};
+
+main() {
+  test1(King(Suit.club));
+  test2(King(Suit.club));
+  test3<int>(King(Suit.club));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/guard_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/guard_A01_t01.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion To tell if the set of cases in a switch statement or expression
+/// are exhaustive over the matched value type:
+/// 1. Lift the matched value type to a space union value.
+/// 2. Discard any cases that have guards. Since static analysis can't tell when
+///   a guard might evaluate to false, any case with a guard doesn't reliably
+///   match values and so can't help prove exhaustiveness.
+/// 3. Lift the remaining case patterns to a set of space unions cases.
+/// 4. The switch is exhaustive if is-exhaustive with value and cases is true
+///   and false otherwise.
+///
+/// @description Check that any cases with guards are ignored when calculating
+/// an exhaustiveness
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+
+String testBool1(bool b) {
+  switch (b) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case true:
+      return "true";
+    case false when b == false:
+      return "false";
+  }
+}
+
+String testBool2(bool b) => switch (b) {
+//                          ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      true when b == true => "true",
+      false => "false"
+    };
+
+String testEnum1(Suit suit) {
+  switch (suit) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case Suit.club:
+    case Suit.diamond:
+    case Suit.heart when suit == Suit.heart:
+    case Suit.spade:
+      return "exhaustive";
+  }
+}
+
+String testEnum2(Suit suit) => switch (suit) {
+//                             ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      Suit.club => "club",
+      Suit.diamond => "diamond",
+      Suit.heart when suit == Suit.heart => "heart",
+      Suit.spade => "spade"
+    };
+
+String testSealed1(Card card) {
+  switch (card) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case Pip _ when true:
+      return "Pip";
+    case Face _:
+      return "Face";
+  }
+}
+
+String testSealed2(Card card) => switch (card) {
+//                               ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      Pip _ => "Pip",
+      Face _ when true => "Face"
+    };
+
+main() {
+  testBool1(true);
+  testBool2(false);
+  testEnum1(Suit.club);
+  testEnum2(Suit.club);
+  testSealed1(Jack(Suit.club));
+  testSealed2(Jack(Suit.club));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/guard_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/guard_A01_t02.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion To tell if the set of cases in a switch statement or expression
+/// are exhaustive over the matched value type:
+/// 1. Lift the matched value type to a space union value.
+/// 2. Discard any cases that have guards. Since static analysis can't tell when
+///   a guard might evaluate to false, any case with a guard doesn't reliably
+///   match values and so can't help prove exhaustiveness.
+/// 3. Lift the remaining case patterns to a set of space unions cases.
+/// 4. The switch is exhaustive if is-exhaustive with value and cases is true
+///   and false otherwise.
+///
+/// @description Check that any cases with guards are ignored when calculating
+/// an exhaustiveness
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "exhaustiveness_lib.dart";
+import "../../../Utils/expect.dart";
+
+String testBool1(bool b) {
+  switch (b) {
+    case true:
+      return "true";
+    case false when b == false:
+      return "false1";
+    case false:
+      return "false2";
+  }
+}
+
+String testBool2(bool b) =>
+  switch (b) {
+    true when b == true => "true1",
+    true => "true2",
+    false =>  "false"
+  };
+
+String testEnum1(Suit suit) {
+  switch (suit) {
+    case Suit.club:
+    case Suit.diamond:
+    case Suit.heart when suit == Suit.heart:
+    case Suit.heart:
+    case Suit.spade:
+      return "exhaustive";
+  }
+}
+
+String testEnum2(Suit suit) =>
+  switch (suit) {
+    Suit.club => "club",
+    Suit.diamond => "diamond",
+    Suit.heart when suit == Suit.heart => "heart1",
+    Suit.heart => "heart2",
+    Suit.spade => "spade"
+  };
+
+String testSealed1(Card card) {
+  switch (card) {
+    case Pip _ when true:
+      return "Pip1";
+    case Pip _:
+      return "Pip2";
+    case Face _:
+      return "Face";
+  }
+}
+
+String testSealed2(Card card) =>
+  switch (card) {
+    Pip _ => "Pip",
+    Face _ when true => "Face1",
+    Face _ => "Face2"
+  };
+
+main() {
+  Expect.equals("false1", testBool1(false));
+  Expect.equals("false", testBool2(false));
+  Expect.equals("exhaustive", testEnum1(Suit.club));
+  Expect.equals("heart1", testEnum2(Suit.heart));
+  Expect.equals("Face", testSealed1(Jack(Suit.club)));
+  Expect.equals("Face1", testSealed2(Jack(Suit.club)));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_cast_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_cast_pattern_A01_t01.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Cast pattern:
+/// The space union spaces for a cast pattern with cast type C is a union of:
+/// - The lifted space union of the cast's subpattern in context C.
+/// - For each space E in the expanded spaces of M:
+///   a. If E is not a subset of C and C is not a subset of M, then the lifted
+///     space union of E.
+///
+/// @description Check a lifted space of a cast pattern in case of not sealed
+/// type
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+int test1(Object obj) {
+//  ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  switch (obj) {
+    case int(isEven: true) as int:
+      return 1;
+    case int _:
+      return 2;
+  }
+}
+
+int test2(Object obj) => switch (obj) {
+//                       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    int(isEven: true) as int => 1,
+    int _ => 2
+  };
+
+main() {
+  test1(1);
+  test2(2);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_cast_pattern_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_cast_pattern_A01_t02.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Cast pattern:
+/// The space union spaces for a cast pattern with cast type C is a union of:
+/// - The lifted space union of the cast's subpattern in context C.
+/// - For each space E in the expanded spaces of M:
+///   a. If E is not a subset of C and C is not a subset of M, then the lifted
+///   space union of E.
+///
+/// @description Check a lifted space of a cast pattern in case of a sealed type
+/// @author sgrekhov22@gmail.com
+/// @issue 51877
+
+// SharedOptions=--enable-experiment=patterns,class-modifiers
+
+import "../../../Utils/expect.dart";
+
+sealed class A {
+  final int field;
+  A(this.field);
+}
+class B extends A {
+  B(int field) : super(field);
+}
+class C extends A {
+  C(int field) : super(field);
+}
+
+test1(A a) {
+  switch (a) {
+    case C(field: 0) as C:
+      return 0;
+    case C _:
+      return 1;
+  }
+}
+
+test2(A a) => switch (a) {
+  C(field: 0) as C => 0,
+  C _ => 1
+};
+
+main() {
+  Expect.equals(0, test1(C(0)));
+  Expect.equals(1, test1(C(1)));
+  Expect.throws(() {
+    test1(B(0));
+  });
+  Expect.equals(0, test2(C(0)));
+  Expect.equals(1, test2(C(1)));
+  Expect.throws(() {
+    test2(B(0));
+  });
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A01_t01.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Constant pattern:
+/// i. If the constant has primitive equality, then a space whose type is the
+///   type of the constant and with a constant restriction for the given
+///   constant value.
+/// ii. Else the empty space union.
+///
+/// @description Check that if a constant has primitive equality, then a lifted
+/// space is a space whose type is the type of the constant and with a constant
+/// restriction for the given constant value.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(bool o) {
+  switch (o) {
+    case true:
+      return "true";
+    case false:
+      return "false";
+  }
+}
+
+String test2(bool o) => switch (o) {
+      true => "true",
+      false => "false"
+    };
+
+main() {
+  Expect.equals("true", test1(true));
+  Expect.equals("false", test1(false));
+  Expect.equals("true", test2(true));
+  Expect.equals("false", test2(false));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A02_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A02_t01.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Constant pattern:
+/// i. If the constant has primitive equality, then a space whose type is the
+///   type of the constant and with a constant restriction for the given
+///   constant value.
+/// ii. Else the empty space union.
+///
+/// @description Check that if a constant have no primitive equality then its
+/// lifted space is an empty space
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+class C {
+  final bool v;
+  const C(this.v);
+
+  bool operator ==(covariant bool other) => v == other;
+}
+
+const True = C(true);
+const False = C(false);
+
+String test1(bool b) {
+  switch (b) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case True:
+      return "true";
+    case False:
+      return "false";
+  }
+}
+
+String test2(bool b) => switch (b) {
+//                      ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      True => "true",
+      False => "false"
+    };
+
+main() {
+  test1(true);
+  test2(false);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A02_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_constant_pattern_A02_t02.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Constant pattern:
+/// i. If the constant has primitive equality, then a space whose type is the
+///   type of the constant and with a constant restriction for the given
+///   constant value.
+/// ii. Else the empty space union.
+///
+/// @description Check that if a constant have no primitive equality then its
+/// lifted space is an empty space
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+class C {
+  final bool v;
+  const C(this.v);
+
+  bool operator ==(covariant bool other) => v == other;
+}
+
+const True = C(true);
+const False = C(false);
+
+String test1(bool b) {
+  switch (b) {
+    case True:
+      return "True";
+    case False:
+      return "False";
+    case true:
+      return "true";
+    case false:
+      return "false";
+  }
+}
+
+String test2(bool b) => switch (b) {
+      True => "True",
+      False => "False",
+      true => "true",
+      false => "false"
+    };
+
+main() {
+  Expect.equals("True", test1(true));
+  Expect.equals("False", test1(false));
+  Expect.equals("True", test2(true));
+  Expect.equals("False", test2(false));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_identifier_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_identifier_pattern_A01_t01.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Variable pattern or identifier pattern: The lifted space union of the static
+/// type of the corresponding variable.
+///
+/// @description Check that a lifted space for an identifier pattern is a union
+/// of the static type of the corresponding variable.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+const _true = true;
+const _false = false;
+
+String test1(bool o) {
+  switch (o) {
+    case _true:
+      return "true";
+    case _false:
+      return "false";
+  }
+}
+
+String test2(bool o) => switch (o) {
+      _true => "true",
+      _false => "false"
+    };
+
+main() {
+  Expect.equals("true", test1(true));
+  Expect.equals("false", test1(false));
+  Expect.equals("true", test2(true));
+  Expect.equals("false", test2(false));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_assert_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_assert_pattern_A01_t01.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Null-assert pattern: A union of the lifted space union of the subpattern and
+/// a space with type Null.
+///
+/// @description Check that a null-assert's pattern space is a union of the
+/// lifted space union of the subpattern and a space with type `Null`.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(Object? o) {
+  switch (o) {
+    case Object _!:
+      return "exhaustive";
+  }
+}
+
+String test2(Object? o) => switch (o) {
+      Object _! => "exhaustive"
+    };
+
+main() {
+  Expect.equals("exhaustive" ,test1(42));
+  Expect.equals("exhaustive" ,test2(42));
+  Expect.throws(() {
+    test1(null);
+  });
+  Expect.throws(() {
+    test2(null);
+  });
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_check_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_check_pattern_A01_t01.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Null-check pattern:
+/// i. Let S be the expanded spaces of the lifted space union of the subpattern.
+/// ii. Remove any unions in S that have type Null. A null-check pattern
+///   specifically does not match null, so even if the subpattern would handle
+///   it, it will never see it.
+/// iii. The result is S.
+///
+/// @description Check that a null-check pattern removes any unions in `S` that
+/// have type `Null`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(Object? o) {
+  switch (o) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case Object _?:
+      return "not exhaustive";
+  }
+}
+
+String test2(Object? o) => switch (o) {
+//                         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      Object _? => "not exhaustive"
+    };
+
+main() {
+  test1(null);
+  test2(null);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_check_pattern_A01_t02.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_null_check_pattern_A01_t02.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Null-check pattern:
+/// i. Let S be the expanded spaces of the lifted space union of the subpattern.
+/// ii. Remove any unions in S that have type Null. A null-check pattern
+///   specifically does not match null, so even if the subpattern would handle
+///   it, it will never see it.
+/// iii. The result is S.
+///
+/// @description Check that a null-check pattern removes any unions in `S` that
+/// have type `Null`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "exhaustiveness_lib.dart";
+import "../../../Utils/expect.dart";
+
+String test1(Card? c) {
+  switch (c) {
+    case Pip _?:
+      return "Pipe";
+    case Face _?:
+      return "Face";
+    case Null _:
+      return "null";
+  }
+}
+
+String test2(Card? c) => switch (c) {
+      Pip _? => "Pipe",
+      Face _? => "Face",
+      Null _ => "null"
+    };
+
+main() {
+  Expect.equals("Pipe", test1(Pip(2, Suit.club)));
+  Expect.equals("null", test1(null));
+  Expect.equals("Face", test2(Jack(Suit.club)));
+  Expect.equals("null", test2(null));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_parenthesized_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_parenthesized_pattern_A01_t01.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Parenthesized pattern: The lifted space union of the subpattern.
+///
+/// @description Check that a lifted space for a parenthesized pattern is a
+/// lifted space union of the subpattern.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+const _true = true;
+const _false = false;
+
+String test1(bool o) {
+  switch (o) {
+    case (_true):
+      return "true";
+    case (_false):
+      return "false";
+  }
+}
+
+String test2(bool o) => switch (o) {
+      (_true) => "true",
+      (_false) => "false"
+    };
+
+main() {
+  Expect.equals("true", test1(true));
+  Expect.equals("false", test1(false));
+  Expect.equals("true", test2(true));
+  Expect.equals("false", test2(false));
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_relational_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_relational_pattern_A01_t01.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Relational pattern:
+/// The empty space union. Relational patterns
+/// don't reliably match any values, so don't help with exhaustiveness.
+///
+/// @description Check that relational pattern doesn't take part in the
+/// calculating of the exhaustiveness
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+String test1(bool b) {
+  switch (b) {
+//^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    case == true:
+      return "true";
+    case == false:
+      return "false";
+  }
+}
+
+String test2(bool b) => switch (b) {
+//                      ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      == true => "true",
+      == false => "false"
+    };
+
+main() {
+  test1(true);
+  test2(false);
+}

--- a/LanguageFeatures/Patterns/Exhaustiveness/lifting_variable_pattern_A01_t01.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/lifting_variable_pattern_A01_t01.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The lifted space union for a pattern with matched value type M is
+/// ...
+/// Variable pattern or identifier pattern: The lifted space union of the static
+/// type of the corresponding variable.
+///
+/// @description Check that a lifted space for a variable pattern is a union of
+/// the static type of the corresponding variable.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=patterns
+
+import "../../../Utils/expect.dart";
+
+String test1(bool o) {
+  switch (o) {
+    case bool _b:
+      return "exhaustive";
+  }
+}
+
+String test2(bool o) => switch (o) {
+      var v => "exhaustive"
+    };
+
+main() {
+  Expect.equals("exhaustive", test1(true));
+  Expect.equals("exhaustive", test1(false));
+  Expect.equals("exhaustive", test2(true));
+  Expect.equals("exhaustive", test2(false));
+}


### PR DESCRIPTION
@eernstg this PR needs some comments. First, exhaustiveness algorithm described there is complicated and not all of its parts/steps can be tested. So, I tried to test what it is possible to test. Some trivial cases are not tested because they are already covered by `Patterns/exhaustiveness_A*`. 

Tests in this PR can be separated in two groups. Test whose names names started with `lifting_*` are testing [Lifting types and patterns to space unions](https://github.com/dart-lang/language/blob/master/accepted/future-releases/0546-patterns/exhaustiveness.md#lifting-types-and-patterns-to-space-unions) where possible. I was not able to invent tests for some cases. 

Tests with names `exhaustiveness_*` are testing algorithm itself. Again, not all patterns checked, partially to avoid duplication, partially because I didn't find anything that can be added to already existing checks in  `Patterns/exhaustiveness_A*`. Assertion text in this group of tests is not copied from spec, as usual, but written by me to clarify what we are testing here. So, if we need more detailed assertion, please let me know.

Waiting for your review/suggestions
