### PR TITLE
Fixes #2059. Don't expect an error in a weak mode

### DIFF
--- a/LanguageFeatures/nnbd/weak/const_evaluation_A06_t01.dart
+++ b/LanguageFeatures/nnbd/weak/const_evaluation_A06_t01.dart
@@ -11,6 +11,7 @@
 
 // Requirements=nnbd-weak
 
+import "../../../Utils/expect.dart";
 import '../const_evaluation_lib.dart';
 import 'const_evaluation_legacy_lib.dart';
 
@@ -18,12 +19,7 @@ const dynamic d = null;
 
 main() {
   const c1 = C.t(null, cLegacyInt);
-//           ^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
   const c2 = C.t(d, cLegacyInt);
-//           ^^^^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  Expect.isNull(c1.x);
+  Expect.isNull(c2.x);
 }


### PR DESCRIPTION
This test used to test a strong mode. Now in a weak mode it fails. As far as I understand here we have class
```dart
class C<T> {
  final T x;
  const C.t(Object? o, T t) : x = o as T;
}
```
When we call
```dart
const c1 = C.t(null, cLegacyInt);
```
`T` is inferred as `int*`. `int*` became `int` and `x = o as int;` failed. But now in a weak mode is doesn't throw, so we should expect no error