### PR TITLE
Fixes #2061. Add expected analyzer error to const_evaluation_A06_t01.dart

### DIFF
--- a/LanguageFeatures/nnbd/weak/const_evaluation_A06_t01.dart
+++ b/LanguageFeatures/nnbd/weak/const_evaluation_A06_t01.dart
@@ -19,7 +19,12 @@ const dynamic d = null;
 
 main() {
   const c1 = C.t(null, cLegacyInt);
+//           ^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
   const c2 = C.t(d, cLegacyInt);
+//           ^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+
   Expect.isNull(c1.x);
   Expect.isNull(c2.x);
 }


### PR DESCRIPTION
I'm not sure if it makes sense to preserve `Expect.isNull()` here. But, probably, there are some VM configurations can be run if there is no expected CFE error