### PR TITLE
Fixes #2087. Add subtyping tests for tearoffs of methods with covariant arguments

### DIFF
--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t01.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/arguments_binding_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+
+void baz(num n, [Object o = ""]) {}
+const t1Default = baz;
+
+namedArgumentsFunc1(void Function(num n, [Object o]) t1, {void Function(num n, [Object o]) t2 = t1Default}) {}
+positionalArgumentsFunc1(void Function(num n, [Object o]) t1, [void Function(num n, [Object o]) t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(void Function(num n, [Object o]) t1) {}
+
+  ArgumentsBindingClass.named(void Function(num n, [Object o]) t1, {void Function(num n, [Object o]) t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(void Function(num n, [Object o]) t1, [void Function(num n, [Object o]) t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(void Function(num n, [Object o]) t1, {void Function(num n, [Object o]) t2  = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(void Function(num n, [Object o]) t1, [void Function(num n, [Object o]) t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(void Function(num n, [Object o]) t1, {void Function(num n, [Object o]) t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(void Function(num n, [Object o]) t1, [void Function(num n, [Object o]) t2 = t1Default]) {}
+
+  namedArgumentsMethod(void Function(num n, [Object o]) t1, {void Function(num n, [Object o]) t2 = t1Default}) {}
+  positionalArgumentsMethod(void Function(num n, [Object o]) t1, [void Function(num n, [Object o]) t2 = t1Default]) {}
+
+  set testSetter(void Function(num n, [Object o]) val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(forgetType(t0Instance), t2: forgetType(t0Instance));
+  positionalArgumentsFunc1(forgetType(t0Instance), forgetType(t0Instance));
+
+  // test class constructors
+  ArgumentsBindingClass instance1 =
+      new ArgumentsBindingClass(forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.positional(forgetType(t0Instance),
+      forgetType(t0Instance));
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1.positionalArgumentsMethod(forgetType(t0Instance),
+      forgetType(t0Instance));
+  instance1.testSetter = forgetType(t0Instance);
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(
+      forgetType(t0Instance), forgetType(t0Instance));
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<void Function(num n, [Object o])>(forgetType(t0Instance), t2: forgetType(t0Instance));
+
+  // test generic class constructors
+  ArgumentsBindingGen<void Function(num n, [Object o])> instance2 =
+      new ArgumentsBindingGen<void Function(num n, [Object o])>(forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<void Function(num n, [Object o])>.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<void Function(num n, [Object o])>.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2.testSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t02.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/arguments_binding_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+void Function(num n, [Object o]) t1Instance = a.foo;
+
+void baz(num n, [Object o = ""]) {}
+const t1Default = baz;
+
+class ArgumentsBindingSuper1_t02 {
+  void Function(num n, [Object o]) m;
+
+  ArgumentsBindingSuper1_t02(void Function(num n, [Object o]) value): m = value {}
+  ArgumentsBindingSuper1_t02.named(void Function(num n, [Object o]) value, {void Function(num n, [Object o]) val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(void Function(num n, [Object o]) value, [void Function(num n, [Object o]) val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(void Function(num n, [Object o]) val) {}
+  void superTestPositioned(void Function(num n, [Object o]) val, [void Function(num n, [Object o]) val2 = t1Default]) {}
+  void superTestNamed(void Function(num n, [Object o]) val, {void Function(num n, [Object o]) val2 = t1Default}) {}
+  void Function(num n, [Object o]) get superGetter => m;
+  void set superSetter(void Function(num n, [Object o]) val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value) : m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}) : m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+
+  ArgumentsBinding2_t02<void Function(num n, [Object o])> c2 =
+    new ArgumentsBinding2_t02<void Function(num n, [Object o])>(forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<void Function(num n, [Object o])>.c2(t1Instance, forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<void Function(num n, [Object o])>.c5(forgetType(t0Instance));
+
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+  c2.superGetter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A01_t03.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/arguments_binding_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+void Function(num n, [Object o]) t1Instance = a.foo;
+
+void baz(num n, [Object o = ""]) {}
+const t1Default = baz;
+
+mixin class ArgumentsBindingMixin1_t03 {
+  void Function(num n, [Object o]) m = t1Default;
+
+  void superTest(void Function(num n, [Object o]) val) {}
+  void superTestPositioned(void Function(num n, [Object o]) val, [void Function(num n, [Object o]) val2 = t1Default]) {}
+  void superTestNamed(void Function(num n, [Object o]) val, {void Function(num n, [Object o]) val2 = t1Default}) {}
+  void Function(num n, [Object o]) get superGetter => m;
+  void set superSetter(void Function(num n, [Object o]) val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin class ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(forgetType(t0Instance), t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<void Function(num n, [Object o])> c2 = new ArgumentsBinding2_t03<void Function(num n, [Object o])>();
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t01.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/arguments_binding_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+
+void baz({required num n, Object o = ""}) {}
+const t1Default = baz;
+
+namedArgumentsFunc1(void Function({required num n, Object o}) t1, {void Function({required num n, Object o}) t2 = t1Default}) {}
+positionalArgumentsFunc1(void Function({required num n, Object o}) t1, [void Function({required num n, Object o}) t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(void Function({required num n, Object o}) t1) {}
+
+  ArgumentsBindingClass.named(void Function({required num n, Object o}) t1, {void Function({required num n, Object o}) t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(void Function({required num n, Object o}) t1, [void Function({required num n, Object o}) t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(void Function({required num n, Object o}) t1, {void Function({required num n, Object o}) t2  = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(void Function({required num n, Object o}) t1, [void Function({required num n, Object o}) t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(void Function({required num n, Object o}) t1, {void Function({required num n, Object o}) t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(void Function({required num n, Object o}) t1, [void Function({required num n, Object o}) t2 = t1Default]) {}
+
+  namedArgumentsMethod(void Function({required num n, Object o}) t1, {void Function({required num n, Object o}) t2 = t1Default}) {}
+  positionalArgumentsMethod(void Function({required num n, Object o}) t1, [void Function({required num n, Object o}) t2 = t1Default]) {}
+
+  set testSetter(void Function({required num n, Object o}) val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(forgetType(t0Instance), t2: forgetType(t0Instance));
+  positionalArgumentsFunc1(forgetType(t0Instance), forgetType(t0Instance));
+
+  // test class constructors
+  ArgumentsBindingClass instance1 =
+      new ArgumentsBindingClass(forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.positional(forgetType(t0Instance),
+      forgetType(t0Instance));
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1.positionalArgumentsMethod(forgetType(t0Instance),
+      forgetType(t0Instance));
+  instance1.testSetter = forgetType(t0Instance);
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(
+      forgetType(t0Instance), forgetType(t0Instance));
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<void Function({required num n, Object o})>(forgetType(t0Instance), t2: forgetType(t0Instance));
+
+  // test generic class constructors
+  ArgumentsBindingGen<void Function({required num n, Object o})> instance2 =
+      new ArgumentsBindingGen<void Function({required num n, Object o})>(forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<void Function({required num n, Object o})>.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<void Function({required num n, Object o})>.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2.testSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t02.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/arguments_binding_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+void Function({required num n, Object o}) t1Instance = a.foo;
+
+void baz({required num n, Object o = ""}) {}
+const t1Default = baz;
+
+class ArgumentsBindingSuper1_t02 {
+  void Function({required num n, Object o}) m;
+
+  ArgumentsBindingSuper1_t02(void Function({required num n, Object o}) value): m = value {}
+  ArgumentsBindingSuper1_t02.named(void Function({required num n, Object o}) value, {void Function({required num n, Object o}) val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(void Function({required num n, Object o}) value, [void Function({required num n, Object o}) val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(void Function({required num n, Object o}) val) {}
+  void superTestPositioned(void Function({required num n, Object o}) val, [void Function({required num n, Object o}) val2 = t1Default]) {}
+  void superTestNamed(void Function({required num n, Object o}) val, {void Function({required num n, Object o}) val2 = t1Default}) {}
+  void Function({required num n, Object o}) get superGetter => m;
+  void set superSetter(void Function({required num n, Object o}) val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value) : m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}) : m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+
+  ArgumentsBinding2_t02<void Function({required num n, Object o})> c2 =
+    new ArgumentsBinding2_t02<void Function({required num n, Object o})>(forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<void Function({required num n, Object o})>.c2(t1Instance, forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<void Function({required num n, Object o})>.c5(forgetType(t0Instance));
+
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+  c2.superGetter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_arguments_binding_A02_t03.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/arguments_binding_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+void Function({required num n, Object o}) t1Instance = a.foo;
+
+void baz({required num n, Object o = ""}) {}
+const t1Default = baz;
+
+mixin class ArgumentsBindingMixin1_t03 {
+  void Function({required num n, Object o}) m = t1Default;
+
+  void superTest(void Function({required num n, Object o}) val) {}
+  void superTestPositioned(void Function({required num n, Object o}) val, [void Function({required num n, Object o}) val2 = t1Default]) {}
+  void superTestNamed(void Function({required num n, Object o}) val, {void Function({required num n, Object o}) val2 = t1Default}) {}
+  void Function({required num n, Object o}) get superGetter => m;
+  void set superSetter(void Function({required num n, Object o}) val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin class ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(forgetType(t0Instance), t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<void Function({required num n, Object o})> c2 = new ArgumentsBinding2_t03<void Function({required num n, Object o})>();
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t01.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/class_member_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+
+void baz(num n, [Object o = ""]) {}
+
+class ClassMember1_t01 {
+  static void Function(num n, [Object o]) s = forgetType(t0Instance);
+  void Function(num n, [Object o]) m = forgetType(t0Instance);
+  void Function(num n, [Object o]) _p = forgetType(t0Instance);
+
+  ClassMember1_t01() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  ClassMember1_t01.named(void Function(num n, [Object o]) value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  set setter(void Function(num n, [Object o]) val) {
+    _p = val;
+  }
+
+  void Function(num n, [Object o]) get getter => forgetType(_p);
+
+  static staticTest() {
+    s = forgetType(t0Instance);
+  }
+
+  static set staticSetter(void Function(num n, [Object o]) val) {
+    s = val;
+  }
+
+  static void Function(num n, [Object o]) get staticGetter => forgetType(t0Instance);
+}
+
+class ClassMember2_t01<X> {
+  X m;
+  X _p;
+
+  ClassMember2_t01():  m = forgetType(t0Instance), _p = forgetType(t0Instance) {
+  }
+
+  ClassMember2_t01.named(X value): m = value, _p = value {
+  }
+
+  ClassMember2_t01.short(this.m, this._p);
+
+  test(X v) {
+    m = v;
+    _p = v;
+  }
+
+  set setter(X val) {
+    _p = val;
+  }
+
+  void Function(num n, [Object o]) get getter => forgetType(_p);
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(forgetType(t0Instance),
+      forgetType(t0Instance));
+  c1 = new ClassMember1_t01.named(forgetType(t0Instance));
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.setter = forgetType(t0Instance);
+  c1.getter;
+
+  ClassMember1_t01.s = forgetType(t0Instance);
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = forgetType(t0Instance);
+  ClassMember1_t01.staticGetter;
+
+  // Test type parameters
+
+  ClassMember2_t01<void Function(num n, [Object o])> c2 = new ClassMember2_t01<void Function(num n, [Object o])>();
+  c2 = new ClassMember2_t01<void Function(num n, [Object o])>.short(forgetType(t0Instance),
+  forgetType(t0Instance));
+  c2 = new ClassMember2_t01<void Function(num n, [Object o])>.named(forgetType(t0Instance));
+  c2.m = forgetType(t0Instance);
+  c2.test(forgetType(t0Instance));
+  c2.getter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t02.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/class_member_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+
+void baz(num n, [Object o = ""]) {}
+
+class ClassMemberSuper1_t02 {
+  void Function(num n, [Object o]) m;
+
+  ClassMemberSuper1_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(void Function(num n, [Object o]) val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t02<X> {
+  X m;
+
+  ClassMemberSuper2_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t02<void Function(num n, [Object o])> c2 = new ClassMember2_t02<void Function(num n, [Object o])>();
+  c2 = new ClassMember2_t02<void Function(num n, [Object o])>.short();
+  c2 = new ClassMember2_t02<void Function(num n, [Object o])>.named();
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A01_t03.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/class_member_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+void Function(num n, [Object o]) t1Instance = a.foo;
+
+void baz(num n, [Object o = ""]) {}
+const t1Default = baz;
+
+mixin class ClassMemberMixin1_t03 {
+  void Function(num n, [Object o]) m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+mixin class ClassMemberMixin2_t03<X> {
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember2_t03<X> extends Object with ClassMemberMixin2_t03<X> {
+  X m;
+  ClassMember2_t03(X x): m = x {  }
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t03<void Function(num n, [Object o])> c2 = new ClassMember2_t03<void Function(num n, [Object o])>(t1Instance);
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t01.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/class_member_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+
+void baz({required num n, Object o = ""}) {}
+
+class ClassMember1_t01 {
+  static void Function({required num n, Object o}) s = forgetType(t0Instance);
+  void Function({required num n, Object o}) m = forgetType(t0Instance);
+  void Function({required num n, Object o}) _p = forgetType(t0Instance);
+
+  ClassMember1_t01() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  ClassMember1_t01.named(void Function({required num n, Object o}) value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  set setter(void Function({required num n, Object o}) val) {
+    _p = val;
+  }
+
+  void Function({required num n, Object o}) get getter => forgetType(_p);
+
+  static staticTest() {
+    s = forgetType(t0Instance);
+  }
+
+  static set staticSetter(void Function({required num n, Object o}) val) {
+    s = val;
+  }
+
+  static void Function({required num n, Object o}) get staticGetter => forgetType(t0Instance);
+}
+
+class ClassMember2_t01<X> {
+  X m;
+  X _p;
+
+  ClassMember2_t01():  m = forgetType(t0Instance), _p = forgetType(t0Instance) {
+  }
+
+  ClassMember2_t01.named(X value): m = value, _p = value {
+  }
+
+  ClassMember2_t01.short(this.m, this._p);
+
+  test(X v) {
+    m = v;
+    _p = v;
+  }
+
+  set setter(X val) {
+    _p = val;
+  }
+
+  void Function({required num n, Object o}) get getter => forgetType(_p);
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(forgetType(t0Instance),
+      forgetType(t0Instance));
+  c1 = new ClassMember1_t01.named(forgetType(t0Instance));
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.setter = forgetType(t0Instance);
+  c1.getter;
+
+  ClassMember1_t01.s = forgetType(t0Instance);
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = forgetType(t0Instance);
+  ClassMember1_t01.staticGetter;
+
+  // Test type parameters
+
+  ClassMember2_t01<void Function({required num n, Object o})> c2 = new ClassMember2_t01<void Function({required num n, Object o})>();
+  c2 = new ClassMember2_t01<void Function({required num n, Object o})>.short(forgetType(t0Instance),
+  forgetType(t0Instance));
+  c2 = new ClassMember2_t01<void Function({required num n, Object o})>.named(forgetType(t0Instance));
+  c2.m = forgetType(t0Instance);
+  c2.test(forgetType(t0Instance));
+  c2.getter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t02.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/class_member_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+
+void baz({required num n, Object o = ""}) {}
+
+class ClassMemberSuper1_t02 {
+  void Function({required num n, Object o}) m;
+
+  ClassMemberSuper1_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(void Function({required num n, Object o}) val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t02<X> {
+  X m;
+
+  ClassMemberSuper2_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t02<void Function({required num n, Object o})> c2 = new ClassMember2_t02<void Function({required num n, Object o})>();
+  c2 = new ClassMember2_t02<void Function({required num n, Object o})>.short();
+  c2 = new ClassMember2_t02<void Function({required num n, Object o})>.named();
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_class_member_A02_t03.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/class_member_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+void Function({required num n, Object o}) t1Instance = a.foo;
+
+void baz({required num n, Object o = ""}) {}
+const t1Default = baz;
+
+mixin class ClassMemberMixin1_t03 {
+  void Function({required num n, Object o}) m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+mixin class ClassMemberMixin2_t03<X> {
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember2_t03<X> extends Object with ClassMemberMixin2_t03<X> {
+  X m;
+  ClassMember2_t03(X x): m = x {  }
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t03<void Function({required num n, Object o})> c2 = new ClassMember2_t03<void Function({required num n, Object o})>(t1Instance);
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_global_variable_A01_t01.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/global_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+void Function(num n, [Object o]) t1Instance = a.foo;
+
+void baz(num n, [Object o = ""]) {}
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  foo() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  static test() {
+    t1Instance = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  t1Instance = forgetType(t0Instance);
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_global_variable_A02_t01.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/global_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+void Function({required num n, Object o}) t1Instance = a.foo;
+
+void baz({required num n, Object o = ""}) {}
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  foo() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  static test() {
+    t1Instance = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  t1Instance = forgetType(t0Instance);
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_local_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_local_variable_A01_t01.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/local_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+
+void baz(num n, [Object o = ""]) {}
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    void Function(num n, [Object o]) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  static staticTest() {
+    void Function(num n, [Object o]) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  test() {
+    void Function(num n, [Object o]) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+}
+
+main() {
+  foo() {
+    void Function(num n, [Object o]) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  void Function(num n, [Object o]) t1 = forgetType(t0Instance);
+  t1 = forgetType(t0Instance);
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_local_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_local_variable_A02_t01.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/local_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+
+void baz({required num n, Object o = ""}) {}
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    void Function({required num n, Object o}) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  static staticTest() {
+    void Function({required num n, Object o}) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  test() {
+    void Function({required num n, Object o}) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+}
+
+main() {
+  foo() {
+    void Function({required num n, Object o}) t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  void Function({required num n, Object o}) t1 = forgetType(t0Instance);
+  t1 = forgetType(t0Instance);
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_return_value_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_return_value_A01_t01.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A01.dart and 
+/// test_cases/return_value_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+
+void baz(num n, [Object o = ""]) {}
+
+void Function(num n, [Object o]) returnValueFunc() => forgetType(t0Instance);
+
+class ReturnValueTest {
+  static void Function(num n, [Object o]) staticTestMethod() => forgetType(t0Instance);
+
+  void Function(num n, [Object o]) testMethod() => forgetType(t0Instance);
+
+  void Function(num n, [Object o]) get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
+}
+
+main() {
+  void Function(num n, [Object o]) returnValueLocalFunc() => forgetType(t0Instance);
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+
+  // Test type parameters
+
+  new ReturnValueGen<void Function(num n, [Object o])>().testMethod();
+  new ReturnValueGen<void Function(num n, [Object o])>().testGetter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_return_value_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/function_type_covariant_arg_return_value_A02_t01.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_A02.dart and 
+/// test_cases/return_value_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+
+void baz({required num n, Object o = ""}) {}
+
+void Function({required num n, Object o}) returnValueFunc() => forgetType(t0Instance);
+
+class ReturnValueTest {
+  static void Function({required num n, Object o}) staticTestMethod() => forgetType(t0Instance);
+
+  void Function({required num n, Object o}) testMethod() => forgetType(t0Instance);
+
+  void Function({required num n, Object o}) get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
+}
+
+main() {
+  void Function({required num n, Object o}) returnValueLocalFunc() => forgetType(t0Instance);
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+
+  // Test type parameters
+
+  new ReturnValueGen<void Function({required num n, Object o})>().testMethod();
+  new ReturnValueGen<void Function({required num n, Object o})>().testGetter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/test_types/function_type_covariant_arg_A01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_types/function_type_covariant_arg_A01.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+
+class A {
+  void foo(num n, [Object o = "A"]) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n, [covariant String c = "C"]) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function(num n, [Object o]) t0Instance = c.foo;
+void Function(num n, [Object o]) t1Instance = a.foo;
+
+void baz(num n, [Object o = ""]) {}
+const t1Default = baz;
+
+//# @T0 = void Function(num n, [Object o])
+//# @T1 = void Function(num n, [Object o])

--- a/LanguageFeatures/Subtyping/dynamic/test_types/function_type_covariant_arg_A02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/test_types/function_type_covariant_arg_A02.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+
+class A {
+  void foo({required num n, Object o = "A"}) => print("A");
+}
+
+class C implements A {
+  void foo({required covariant int n, covariant String o = "C"}) => print("C");
+}
+
+A a = A();
+A c = C();
+void Function({required num n, Object o}) t0Instance = c.foo;
+void Function({required num n, Object o}) t1Instance = a.foo;
+
+void baz({required num n, Object o = ""}) {}
+const t1Default = baz;
+
+//# @T0 = void Function({required num n, Object o})
+//# @T1 = void Function({required num n, Object o})

--- a/LanguageFeatures/Subtyping/dynamic/tests/function_type_covariant_arg_fail_A02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/tests/function_type_covariant_arg_fail_A02.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that if type `T0` is a function type with a covariant
+/// arguments and `T1` is a function type with arguments that are supertypes of
+/// `T0` arguments, then `T0` is a subtype of `T1`. But runtime invocation of
+/// `T0` with argument of `T1`'s type fails
+/// @author sgrekhov22@gmail.com
+
+import '../../../../Utils/expect.dart';
+
+class A {
+  void foo(num n) {
+    print("A");
+  }
+}
+
+class C implements A {
+  void foo(covariant int n) {
+    print("C");
+  }
+}
+
+main() {
+  A a = C();
+  void Function(num n) f = a.foo;
+  Expect.throws(() {
+    f(3.14);
+  });
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_fail_A01_t01.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Global function required argument is
+/// tested.
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/arguments_binding_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+void Function(num n) t1Instance = (num n) {};
+
+void baz(num n) {}
+const t1Default = baz;
+
+namedArgumentsFunc1(void Function(num n) t1, {void Function(num n) t2 = t1Default}) {}
+positionalArgumentsFunc1(void Function(num n) t1, [void Function(num n) t2 = t1Default]) {}
+
+class ArgumentsBindingClass {
+    ArgumentsBindingClass(void Function(num n) t1) {}
+
+    ArgumentsBindingClass.named(void Function(num n) t1, {void Function(num n) t2 = t1Default}) {}
+    ArgumentsBindingClass.positional(void Function(num n) t1, [void Function(num n) t2 = t1Default]) {}
+
+    factory ArgumentsBindingClass.fNamed(void Function(num n) t1, {void Function(num n) t2 = t1Default}) {
+        return new ArgumentsBindingClass.named(t1, t2: t2);
+    }
+    factory ArgumentsBindingClass.fPositional(void Function(num n) t1, [void Function(num n) t2 = t1Default]) {
+        return new ArgumentsBindingClass.positional(t1, t2);
+    }
+
+    static namedArgumentsStaticMethod(void Function(num n) t1, {void Function(num n) t2 = t1Default}) {}
+    static positionalArgumentsStaticMethod(void Function(num n) t1, [void Function(num n) t2 = t1Default]) {}
+
+    namedArgumentsMethod(void Function(num n) t1, {void Function(num n) t2 = t1Default}) {}
+    positionalArgumentsMethod(void Function(num n) t1, [void Function(num n) t2 = t1Default]) {}
+
+    set testSetter(void Function(num n) val) {}
+}
+
+class ArgumentsBindingClassSuper {
+  ArgumentsBindingClassSuper(void Function(num n) t1) {}
+}
+
+class ArgumentsBindingDesc extends ArgumentsBindingClassSuper {
+  ArgumentsBindingDesc(void Function(int n) t0) : super (t0) {}
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  namedArgumentsFunc1(t0Instance);
+//                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  namedArgumentsFunc1(t1Instance, t2: t0Instance);
+//                                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  positionalArgumentsFunc1(t0Instance);
+//                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  positionalArgumentsFunc1(t1Instance, t0Instance);
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t0Instance);
+//                          ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t0Instance);
+//                                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance, t2: t0Instance);
+//                                                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t0Instance);
+//                                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance, t0Instance);
+//                                                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).testSetter = t0Instance;
+//                                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance, t2: t0Instance);
+//                                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t0Instance);
+//                                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance, t0Instance);
+//                                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.named(t0Instance);
+//                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.named(t1Instance, t2: t0Instance);
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.positional(t0Instance);
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.positional(t1Instance, t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fNamed(t0Instance);
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fNamed(t1Instance, t2: t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fPositional(t0Instance);
+//                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fPositional(t1Instance, t0Instance);
+//                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_mixin_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_mixin_fail_A01_t01.dart
@@ -1,0 +1,174 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test mixin members. Super method required
+/// argument is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/arguments_binding_mixin_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+void Function(num n) t1Instance = (num n) {};
+
+void baz(num n) {}
+const t1Default = baz;
+
+mixin ArgumentsBindingSuper1_t03 {
+  void superTest(void Function(num n) val) {}
+  void superTestPositioned(void Function(num n) val, [void Function(num n) val2 = t1Default]) {}
+  void superTestNamed(void Function(num n) val, {void Function(num n) val2 = t1Default}) {}
+  void Function(num n) get superGetter => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set superSetter(void Function(num n) val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
+
+  test() {
+    superTest(t0Instance);
+//            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTest(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTest(t0Instance);
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t0Instance);
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t0Instance);
+//                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t1Instance, t0Instance);
+//                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t1Instance, t0Instance);
+//                                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t1Instance, t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t0Instance);
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t1Instance, val2: t0Instance);
+//                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t1Instance, val2: t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t1Instance, val2: t0Instance);
+//                                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superSetter = t0Instance;
+//                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superSetter = t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ArgumentsBinding1_t03().superTest(t0Instance);
+//                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestPositioned(t0Instance);
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestPositioned(t1Instance, t0Instance);
+//                                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestNamed(t0Instance);
+//                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: t0Instance);
+//                                                             ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superSetter = t0Instance;
+//                                          ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().test();
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_super_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_arguments_binding_super_fail_A01_t01.dart
@@ -1,0 +1,207 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test superclass members. Super constructor
+/// required argument is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/arguments_binding_super_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+void Function(num n) t1Instance = (num n) {};
+
+void baz(num n) {}
+const t1Default = baz;
+
+class ArgumentsBindingSuper1_t02 {
+  void Function(num n) m = t1Default;
+
+  ArgumentsBindingSuper1_t02(void Function(num n) value): m = value {}
+  ArgumentsBindingSuper1_t02.named(void Function(num n) value, {void Function(num n) val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(void Function(num n) value, [void Function(num n) val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(void Function(num n) val) {}
+  void superTestPositioned(void Function(num n) val, [void Function(num n) val2 = t1Default]) {}
+  void superTestNamed(void Function(num n) val, {void Function(num n) val2 = t1Default}) {}
+  void Function(num n) get superGetter => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set superSetter(void Function(num n) val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(void Function(int n) t0) : super(t0) {}
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c1(void Function(int n) t0) : super.named(t0) {}
+//                                               ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c2(void Function(num n) t1, void Function(int n) t2) : super.named(t1, val2: t2) {}
+//                                                       ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c3(void Function(int n) t0) : super.positional(t0) {}
+//                                                    ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c4(void Function(num n) t1, void Function(int n) t2) : super.positional(t1, t2) {}
+//                                                                ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c5(void Function(int n) t1) : super.short(t1) {}
+//                                               ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  ArgumentsBinding1_t02.valid() : super(t1Default) {}
+
+  test() {
+    superTest(t0Instance);
+//            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTest(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTest(t0Instance);
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t0Instance);
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t0Instance);
+//                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t1Instance, t0Instance);
+//                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t1Instance, t0Instance);
+//                                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t1Instance, t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t0Instance);
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t1Instance, val2: t0Instance);
+//                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t1Instance, val2: t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t1Instance, val2: t0Instance);
+//                                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superSetter = t0Instance;
+//                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superSetter = t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ArgumentsBinding1_t02.valid().superTest(t0Instance);
+//                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestPositioned(t0Instance);
+//                                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestPositioned(t1Instance, t0Instance);
+//                                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestNamed(t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestNamed(t1Instance, val2: t0Instance);
+//                                                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superSetter = t0Instance;
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().test();
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_fail_A01_t01.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as a class member of type T1. Assignment to static and instance class
+/// variables is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/class_member_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+
+void baz(num n) {}
+const t1Default = baz;
+
+class ClassMemberTestStatic {
+  static void Function(num n) s = t1Default;
+
+  ClassMemberTestStatic(void Function(int n) val) {
+    s = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static staticTest() {
+    s = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static set staticSetter(void Function(int n) val) {
+    s = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static void Function(num n) get staticGetter => t0Instance;
+//                               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+class ClassMemberTestPublic {
+  void Function(num n) m = t1Default;
+
+  ClassMemberTestPublic(void Function(int n) val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  ClassMemberTestPublic.short(this.m);
+
+  ClassMemberTestPublic.validConstructor() {}
+
+  test(void Function(int n) val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  set setter(void Function(int n) val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  void Function(num n) get getter => t0Instance;
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+class ClassMemberTestPrivate {
+  void Function(num n) _m = t1Default;
+
+  ClassMemberTestPrivate(void Function(int n) val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  ClassMemberTestPrivate.short(this._m);
+
+  ClassMemberTestPrivate.validConstructor() {}
+
+  test(void Function(int n) val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  set setter(void Function(int n) val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+class ClassMemberTestInitFail {
+  static void Function(num n) s = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void Function(num n) m = t0Instance;
+//        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  new ClassMemberTestPublic.validConstructor().m = t0Instance;
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_mixin_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_mixin_fail_A01_t01.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the mixin member of type T1.
+/// Assignment to instance variable of super class is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/class_member_mixin_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+
+void baz(num n) {}
+const t1Default = baz;
+
+mixin class ClassMemberSuper1_t03 {
+  void Function(num n) m = t1Default;
+  void set superSetter(void Function(num n) val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ClassMember1_t03().m = t0Instance;
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t03().superSetter = t0Instance;
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_super_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_class_member_super_fail_A01_t01.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the superclass member of type T1.
+/// Assignment to variable of super class is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/class_member_super_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+
+void baz(num n) {}
+const t1Default = baz;
+
+class ClassMemberSuper1_t02 {
+  void Function(num n) m = t1Default;
+
+  ClassMemberSuper1_t02(void Function(int n) value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.named(void Function(int n) value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.valid(void Function(num n) value) {
+    m = value;
+  }
+  void set superSetter(void Function(num n) val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+  ClassMember1_t02() : super(t0Instance) {}
+  ClassMember1_t02.named() : super.named(t0Instance) {}
+  ClassMember1_t02.valid() : super.valid(t1Default);
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ClassMember1_t02.valid().m = t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t02.valid().superSetter = t0Instance;
+//                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_global_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_global_variable_fail_A01_t01.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to global variable of type T1.
+/// Assignment to global variable is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/global_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+void Function(num n) t1Instance = (num n) {};
+
+void baz(num n) {}
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  foo() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  static test() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  t1Instance = t0Instance;
+//             ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  bar () {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_local_variable_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_local_variable_fail_A01_t01.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to local variable of type T1.
+/// Assignment to local variable is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+
+void baz(num n) {}
+
+class LocalVariableTest {
+  LocalVariableTest() {
+    void Function(num n) t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  test() {
+    void Function(num n) t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static staticTest() {
+    void Function(num n) t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  void Function(num n) t1 = t0Instance;
+//         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  bar () {
+    void Function(num n) t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_return_value_fail_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/function_type_covariant_arg_fail_return_value_fail_A01_t01.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then instance
+/// of T0 cannot be used as a return value of type T1. Return value is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/function_type_covariant_arg_fail_A01.dart and 
+/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+
+void baz(num n) {}
+
+void Function(num n) returnValueFunc() => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+class ReturnValueTest {
+  static void Function(num n) staticTestMethod() => t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void Function(num n) testMethod() => t0Instance;
+//                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void Function(num n) get testGetter => t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  void Function(num n) returnValueLocalFunc() => t0Instance;
+//                              ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/test_types/function_type_covariant_arg_fail_A01.dart
+++ b/LanguageFeatures/Subtyping/static/test_types/function_type_covariant_arg_fail_A01.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Function Type/Function: T0 is a function type and T1 is Function
+///
+/// @description Check that tearing-off a method with covariant arguments strips
+/// these arguments. Therefore, if `T0` is a function type with covariant
+/// arguments and `T0` is a valid override of function type `T1`, but without
+/// `covariant` keyword `T0` is not a valid override of `T1`, then `T0` is not a
+/// subtype of `T1`
+/// @author sgrekhov22@gmail.com
+
+class A {
+  void foo(num n) => print("A");
+}
+
+class C implements A {
+  void foo(covariant int n) => print("C");
+}
+
+C c = C();
+void Function(int n) t0Instance = c.foo;
+void Function(num n) t1Instance = (num n) {};
+
+void baz(num n) {}
+const t1Default = baz;
+
+//# @T0 = void Function(int n)
+//# @T1 = void Function(num n)


### PR DESCRIPTION
Subtyping tests are generated. So it makes sense to review the files outside of `generated` folders. Other tests are generated using those ones