### PR TITLE
Fixes #2099. Add subtyping tests for function type with required named arguments

### DIFF
--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A01_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A02_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A03_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A04_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A05_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t01.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+namedArgumentsFunc1(F1 t1, {F1 t2 = t1Default}) {}
+positionalArgumentsFunc1(F1 t1, [F1 t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(F1 t1) {}
+
+  ArgumentsBindingClass.named(F1 t1, {F1 t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(F1 t1, [F1 t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(F1 t1, {F1 t2  = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(F1 t1, [F1 t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(F1 t1, {F1 t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  namedArgumentsMethod(F1 t1, {F1 t2 = t1Default}) {}
+  positionalArgumentsMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  set testSetter(F1 val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(forgetType(t0Instance), t2: forgetType(t0Instance));
+  positionalArgumentsFunc1(forgetType(t0Instance), forgetType(t0Instance));
+
+  // test class constructors
+  ArgumentsBindingClass instance1 =
+      new ArgumentsBindingClass(forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.positional(forgetType(t0Instance),
+      forgetType(t0Instance));
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1.positionalArgumentsMethod(forgetType(t0Instance),
+      forgetType(t0Instance));
+  instance1.testSetter = forgetType(t0Instance);
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(
+      forgetType(t0Instance), forgetType(t0Instance));
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<F1>(forgetType(t0Instance), t2: forgetType(t0Instance));
+
+  // test generic class constructors
+  ArgumentsBindingGen<F1> instance2 =
+      new ArgumentsBindingGen<F1>(forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<F1>.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<F1>.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2.testSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t02.dart
@@ -1,0 +1,137 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+class ArgumentsBindingSuper1_t02 {
+  F1 m;
+
+  ArgumentsBindingSuper1_t02(F1 value): m = value {}
+  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => m;
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value) : m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}) : m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+
+  ArgumentsBinding2_t02<F1> c2 =
+    new ArgumentsBinding2_t02<F1>(forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<F1>.c2(t1Instance, forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<F1>.c5(forgetType(t0Instance));
+
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+  c2.superGetter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_arguments_binding_A06_t03.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin class ArgumentsBindingMixin1_t03 {
+  F1 m = t1Default;
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => m;
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin class ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(forgetType(t0Instance), t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<F1> c2 = new ArgumentsBinding2_t03<F1>();
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A01_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A02_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A03_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A04_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A05_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t01.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+class ClassMember1_t01 {
+  static F1 s = forgetType(t0Instance);
+  F1 m = forgetType(t0Instance);
+  F1 _p = forgetType(t0Instance);
+
+  ClassMember1_t01() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  ClassMember1_t01.named(F1 value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  set setter(F1 val) {
+    _p = val;
+  }
+
+  F1 get getter => forgetType(_p);
+
+  static staticTest() {
+    s = forgetType(t0Instance);
+  }
+
+  static set staticSetter(F1 val) {
+    s = val;
+  }
+
+  static F1 get staticGetter => forgetType(t0Instance);
+}
+
+class ClassMember2_t01<X> {
+  X m;
+  X _p;
+
+  ClassMember2_t01():  m = forgetType(t0Instance), _p = forgetType(t0Instance) {
+  }
+
+  ClassMember2_t01.named(X value): m = value, _p = value {
+  }
+
+  ClassMember2_t01.short(this.m, this._p);
+
+  test(X v) {
+    m = v;
+    _p = v;
+  }
+
+  set setter(X val) {
+    _p = val;
+  }
+
+  F1 get getter => forgetType(_p);
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(forgetType(t0Instance),
+      forgetType(t0Instance));
+  c1 = new ClassMember1_t01.named(forgetType(t0Instance));
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.setter = forgetType(t0Instance);
+  c1.getter;
+
+  ClassMember1_t01.s = forgetType(t0Instance);
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = forgetType(t0Instance);
+  ClassMember1_t01.staticGetter;
+
+  // Test type parameters
+
+  ClassMember2_t01<F1> c2 = new ClassMember2_t01<F1>();
+  c2 = new ClassMember2_t01<F1>.short(forgetType(t0Instance),
+  forgetType(t0Instance));
+  c2 = new ClassMember2_t01<F1>.named(forgetType(t0Instance));
+  c2.m = forgetType(t0Instance);
+  c2.test(forgetType(t0Instance));
+  c2.getter;
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t02.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+class ClassMemberSuper1_t02 {
+  F1 m;
+
+  ClassMemberSuper1_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t02<X> {
+  X m;
+
+  ClassMemberSuper2_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t02<F1> c2 = new ClassMember2_t02<F1>();
+  c2 = new ClassMember2_t02<F1>.short();
+  c2 = new ClassMember2_t02<F1>.named();
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_class_member_A06_t03.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin class ClassMemberMixin1_t03 {
+  F1 m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+mixin class ClassMemberMixin2_t03<X> {
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember2_t03<X> extends Object with ClassMemberMixin2_t03<X> {
+  X m;
+  ClassMember2_t03(X x): m = x {  }
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t03<F1> c2 = new ClassMember2_t03<F1>(t1Instance);
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t01.dart
@@ -1,0 +1,224 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+namedArgumentsFunc1(F1 t1, {F1 t2 = t1Default}) {}
+positionalArgumentsFunc1(F1 t1, [F1 t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(F1 t1) {}
+
+  ArgumentsBindingClass.named(F1 t1, {F1 t2 = t1Default}) {}
+
+  factory ArgumentsBindingClass.fNamed(F1 t1, {F1 t2 = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(F1 t1, [F1 t2 = t1Default]) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+
+  static namedArgumentsStaticMethod(F1 t1, {F1 t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  namedArgumentsMethod(F1 t1, {F1 t2 = t1Default}) {}
+  positionalArgumentsMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  set testSetter(F1 val) {}
+}
+
+class ArgumentsBindingClassGen<X> {
+  ArgumentsBindingClassGen(X t1) {}
+
+  ArgumentsBindingClassGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingClassGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingClassGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+class ArgumentsBindingClassSuper {
+  ArgumentsBindingClassSuper(F1 t1) {}
+}
+
+class ArgumentsBindingDesc extends ArgumentsBindingClassSuper {
+  ArgumentsBindingDesc(F0 t0) : super (forgetType(t0)) {}
+}
+
+main() {
+  // Test functions
+  Expect.throws(() {
+    namedArgumentsFunc1(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    namedArgumentsFunc1(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    positionalArgumentsFunc1(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    positionalArgumentsFunc1(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test constructors
+  Expect.throws(() {
+    new ArgumentsBindingClass(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.named(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.named(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.fNamed(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.fNamed(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.fPositional(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass.fPositional(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test instance methods and setters
+  Expect.throws(() {
+    new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(
+        forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance,
+        t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(
+        forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance,
+        forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClass(t1Instance).testSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test static methods
+  Expect.throws(() {
+    ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance,
+        t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ArgumentsBindingClass.positionalArgumentsStaticMethod(
+        forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance,
+        forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test type parameters
+
+  // Test generic functions
+  Expect.throws(() {
+    namedArgumentsFunc2<F1>(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test constructors
+  Expect.throws(() {
+    new ArgumentsBindingClassGen<F1>(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClassGen<F1>.named(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClassGen<F1>.fNamed(t1Instance, t2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test instance methods and setters
+  Expect.throws(() {
+    new ArgumentsBindingClassGen<F1>(t1Instance).namedArgumentsMethod(t1Instance,
+    t2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBindingClassGen<F1>(t1Instance).testSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test superclass constructor call
+  Expect.throws(() {
+    new ArgumentsBindingDesc(t0Instance);
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t02.dart
@@ -1,0 +1,315 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_fail_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+class ArgumentsBindingSuper1_t02 {
+  F1 m;
+
+  ArgumentsBindingSuper1_t02(F1 value): m = value {}
+  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => forgetType(t0Instance);
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c1(dynamic t1) : super.named(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test() {
+    Expect.throws(() {
+      superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superGetter;
+    }, (e) => e is TypeError);
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value): m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}): m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => forgetType(t0Instance);
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test() {
+    Expect.throws(() {
+      superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superGetter;
+    }, (e) => e is TypeError);
+  }
+}
+
+main() {
+  // test constructors
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // test class members
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(t1Instance).superGetter;
+  }, (e) => e is TypeError);
+
+  new ArgumentsBinding1_t02(t1Instance).test();
+
+  // Test type parameters
+
+  // test generic class constructors
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>.c2(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>.c5(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // test generic class members
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(t1Instance).superTest(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(t1Instance).superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(t1Instance).superGetter;
+  }, (e) => e is TypeError);
+
+  new ArgumentsBinding2_t02<F1>(t1Instance).test();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A06_t03.dart
@@ -1,0 +1,278 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_fail_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin class ArgumentsBindingSuper1_t03 {
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => forgetType(t0Instance);
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
+  test() {
+    Expect.throws(() {
+      superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestPositioned(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestPositioned(forgetType(t1Instance), forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superGetter;
+    }, (e) => e is TypeError);
+  }
+}
+
+mixin class ArgumentsBindingSuper2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => forgetType(t0Instance);
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X> {
+
+  test() {
+    Expect.throws(() {
+      superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTest(forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superSetter = forgetType(t0Instance);
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superGetter;
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superGetter;
+    }, (e) => e is TypeError);
+  }
+}
+
+main() {
+  // test class members
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t03().superGetter;
+  }, (e) => e is TypeError);
+
+  new ArgumentsBinding1_t03().test();
+
+  // Test type parameters
+
+  // test generic class members
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superGetter;
+  }, (e) => e is TypeError);
+
+  new ArgumentsBinding2_t03<F1>().test();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A11_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A12_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A21_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A22_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A23_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A31_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A32_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A33_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A41_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A42_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A43_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A51_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A52_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A53_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t01.dart
@@ -20,15 +20,15 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
 /// be used as an argument of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/arguments_binding_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t02.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
-/// be used as an argument of type T1. Test mixin members
+/// be used as an argument of type T1. Test superclass members
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/arguments_binding_fail_x03.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/arguments_binding_fail_x02.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -47,7 +47,14 @@ F1 t1Instance = f1Instance;
 
 const t1Default = f1Instance;
 
-mixin class ArgumentsBindingSuper1_t03 {
+class ArgumentsBindingSuper1_t02 {
+  F1 m;
+
+  ArgumentsBindingSuper1_t02(F1 value): m = value {}
+  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
   void superTest(F1 val) {}
   void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
   void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
@@ -55,7 +62,14 @@ mixin class ArgumentsBindingSuper1_t03 {
   void set superSetter(F1 val) {}
 }
 
-class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c1(dynamic t1) : super.named(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
@@ -143,14 +157,23 @@ class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   }
 }
 
-mixin class ArgumentsBindingSuper2_t03<X> {
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value): m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}): m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
   void superTest(X val) {}
   void superTestNamed(X val, {required X val2}) {}
   X get superGetter => forgetType(t0Instance);
   void set superSetter(X val) {}
 }
 
-class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X> {
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(dynamic t1) : super.short(t1) {}
 
   test() {
     Expect.throws(() {
@@ -166,27 +189,11 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
     }, (e) => e is TypeError);
 
     Expect.throws(() {
-      superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError);
-
-    Expect.throws(() {
-      this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError);
-
-    Expect.throws(() {
-      super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
-    }, (e) => e is TypeError);
-
-    Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
     }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
-    }, (e) => e is TypeError);
-
-    Expect.throws(() {
-      super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
     }, (e) => e is TypeError);
 
     Expect.throws(() {
@@ -216,63 +223,93 @@ class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X>
 }
 
 main() {
+  // test constructors
+  Expect.throws(() {
+    new ArgumentsBinding1_t02(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
   // test class members
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
+    new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
+    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
+    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
+    new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
+    new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
+    new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t03().superGetter;
+    new ArgumentsBinding1_t02(t1Instance).superGetter;
   }, (e) => e is TypeError);
 
-  new ArgumentsBinding1_t03().test();
+  new ArgumentsBinding1_t02(t1Instance).test();
 
   // Test type parameters
 
+  // test generic class constructors
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>.c2(t1Instance, forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t02<F1>.c5(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
   // test generic class members
   Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
+    new ArgumentsBinding2_t02<F1>(t1Instance).superTest(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
+    new ArgumentsBinding2_t02<F1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    new ArgumentsBinding2_t02<F1>(t1Instance).superSetter = forgetType(t0Instance);
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    new ArgumentsBinding2_t02<F1>(t1Instance).superGetter;
   }, (e) => e is TypeError);
 
-  Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding2_t03<F1>().superGetter;
-  }, (e) => e is TypeError);
-
-  new ArgumentsBinding2_t03<F1>().test();
+  new ArgumentsBinding2_t02<F1>(t1Instance).test();
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_arguments_binding_fail_A61_t03.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
-/// be used as an argument of type T1. Test superclass members
+/// be used as an argument of type T1. Test mixin members
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/arguments_binding_fail_x02.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/arguments_binding_fail_x03.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -47,14 +47,7 @@ F1 t1Instance = f1Instance;
 
 const t1Default = f1Instance;
 
-class ArgumentsBindingSuper1_t02 {
-  F1 m;
-
-  ArgumentsBindingSuper1_t02(F1 value): m = value {}
-  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
-  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
-  ArgumentsBindingSuper1_t02.short(this.m);
-
+mixin class ArgumentsBindingSuper1_t03 {
   void superTest(F1 val) {}
   void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
   void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
@@ -62,14 +55,7 @@ class ArgumentsBindingSuper1_t02 {
   void set superSetter(F1 val) {}
 }
 
-class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
-  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
-  ArgumentsBinding1_t02.c1(dynamic t1) : super.named(t1) {}
-  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
-  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
-  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
-  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
-
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
   test() {
     Expect.throws(() {
       superTest(forgetType(t0Instance));
@@ -157,23 +143,14 @@ class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
   }
 }
 
-class ArgumentsBindingSuper2_t02<X> {
-  X m;
-
-  ArgumentsBindingSuper2_t02(X value): m = value {}
-  ArgumentsBindingSuper2_t02.named(X value, {required X val2}): m = value {}
-  ArgumentsBindingSuper2_t02.short(this.m);
-
+mixin class ArgumentsBindingSuper2_t03<X> {
   void superTest(X val) {}
   void superTestNamed(X val, {required X val2}) {}
   X get superGetter => forgetType(t0Instance);
   void set superSetter(X val) {}
 }
 
-class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
-  ArgumentsBinding2_t02(dynamic t1) : super(t1) {}
-  ArgumentsBinding2_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
-  ArgumentsBinding2_t02.c5(dynamic t1) : super.short(t1) {}
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingSuper2_t03<X> {
 
   test() {
     Expect.throws(() {
@@ -189,11 +166,27 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
     }, (e) => e is TypeError);
 
     Expect.throws(() {
+      superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      this.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
       superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
     }, (e) => e is TypeError);
 
     Expect.throws(() {
       this.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    }, (e) => e is TypeError);
+
+    Expect.throws(() {
+      super.superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
     }, (e) => e is TypeError);
 
     Expect.throws(() {
@@ -223,93 +216,63 @@ class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
 }
 
 main() {
-  // test constructors
-  Expect.throws(() {
-    new ArgumentsBinding1_t02(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding1_t02.c1(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding1_t02.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding1_t02.c3(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding1_t02.c4(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding1_t02.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
   // test class members
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superTest(forgetType(t0Instance));
+    new ArgumentsBinding1_t03().superTest(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(forgetType(t0Instance));
+    new ArgumentsBinding1_t03().superTestPositioned(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superTestPositioned(t1Instance, forgetType(t0Instance));
+    new ArgumentsBinding1_t03().superTestPositioned(t1Instance, forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superTestNamed(forgetType(t0Instance));
+    new ArgumentsBinding1_t03().superTestNamed(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superTestNamed(t1Instance, val2: forgetType(t0Instance));
+    new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superSetter = forgetType(t0Instance);
+    new ArgumentsBinding1_t03().superSetter = forgetType(t0Instance);
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding1_t02(t1Instance).superGetter;
+    new ArgumentsBinding1_t03().superGetter;
   }, (e) => e is TypeError);
 
-  new ArgumentsBinding1_t02(t1Instance).test();
+  new ArgumentsBinding1_t03().test();
 
   // Test type parameters
 
-  // test generic class constructors
-  Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>.c2(t1Instance, forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>.c5(forgetType(t0Instance));
-  }, (e) => e is TypeError);
-
   // test generic class members
   Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>(t1Instance).superTest(forgetType(t0Instance));
+    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>(t1Instance).superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
+    new ArgumentsBinding2_t03<F1>().superTest(forgetType(t0Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>(t1Instance).superSetter = forgetType(t0Instance);
+    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t0Instance), val2: forgetType(t1Instance));
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new ArgumentsBinding2_t02<F1>(t1Instance).superGetter;
+    new ArgumentsBinding2_t03<F1>().superTestNamed(forgetType(t1Instance), val2: forgetType(t0Instance));
   }, (e) => e is TypeError);
 
-  new ArgumentsBinding2_t02<F1>(t1Instance).test();
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ArgumentsBinding2_t03<F1>().superGetter;
+  }, (e) => e is TypeError);
+
+  new ArgumentsBinding2_t03<F1>().test();
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t01.dart
@@ -1,0 +1,264 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as a class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+class ClassMemberTestStatic {
+  static F1 s = t1Default;
+
+  ClassMemberTestStatic(dynamic val) {
+    s = val;
+  }
+
+  static staticTest() {
+    s = forgetType(t0Instance);
+  }
+
+  static set staticSetter(dynamic val) {
+    s = val;
+  }
+
+  static F1 get staticGetter => forgetType(t0Instance);
+}
+
+class ClassMemberTestPublic {
+  F1 m = t1Default;
+
+  ClassMemberTestPublic(dynamic val) {
+    m = val;
+  }
+
+  ClassMemberTestPublic.short(this.m);
+
+  ClassMemberTestPublic.validConstructor() {}
+
+  test(dynamic val) {
+    m = val;
+  }
+
+  set setter(dynamic val) {
+    m = val;
+  }
+
+  F1 get getter => forgetType(t0Instance);
+}
+
+class ClassMemberTestPrivate {
+  F1 _m = t1Default;
+
+  ClassMemberTestPrivate(dynamic val) {
+    _m = val;
+  }
+
+  ClassMemberTestPrivate.short(this._m);
+
+  ClassMemberTestPrivate.validConstructor() {}
+
+  test(dynamic val) {
+    _m = val;
+  }
+
+  set setter(dynamic val) {
+    _m = val;
+  }
+}
+
+class ClassMemberTestInitFail {
+  static F1 s = forgetType(t0Instance);
+  F1 m = forgetType(t0Instance);
+}
+
+class ClassMemberTestGenericPublic<X> {
+  X m;
+
+  ClassMemberTestGenericPublic(dynamic val): m = val {
+  }
+
+  ClassMemberTestGenericPublic.short(this.m);
+
+  test(dynamic val) {
+    m = val;
+  }
+
+  set setter(dynamic val) {
+    m = val;
+  }
+
+  X get getter => forgetType(t0Instance);
+}
+
+class ClassMemberTestGenericPrivate<X> {
+  X _m;
+
+  ClassMemberTestGenericPrivate(dynamic val): _m = val {
+  }
+
+  ClassMemberTestGenericPrivate.short(this._m);
+
+  test(dynamic val) {
+    _m = val;
+  }
+
+  set setter(dynamic val) {
+    _m = val;
+  }
+}
+
+main() {
+  // Test initialization
+  Expect.throws(() {ClassMemberTestInitFail.s;}, (e) => e is TypeError);
+  Expect.throws(() {new ClassMemberTestInitFail();}, (e) => e is TypeError);
+
+  // Test constructors
+  Expect.throws(() {
+    new ClassMemberTestPublic(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestPublic.short(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestPrivate(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestPrivate.short(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  // Test class variables
+  Expect.throws(() {
+    new ClassMemberTestPublic(t1Instance).m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test setters
+  Expect.throws(() {
+    new ClassMemberTestPublic(t1Instance).setter = t0Instance;
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestPrivate(t1Instance).setter = t0Instance;
+  }, (e) => e is TypeError);
+
+  // Test methods
+  Expect.throws(() {
+    new ClassMemberTestPublic(t1Instance).test(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestPrivate(t1Instance).test(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test getters
+  Expect.throws(() {
+    new ClassMemberTestPublic(t1Instance).getter;
+  }, (e) => e is TypeError);
+
+  // Test static stuff
+  Expect.throws(() {
+    new ClassMemberTestStatic(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ClassMemberTestStatic.staticSetter = t0Instance;
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ClassMemberTestStatic.staticGetter;
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    ClassMemberTestStatic.staticTest();
+  }, (e) => e is TypeError);
+
+  // Test type parameters
+
+  // Test getters
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>(t1Instance).getter;
+  }, (e) => e is TypeError);
+
+  // Test methods
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>(t1Instance).test(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestGenericPrivate<F1>(t1Instance).test(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test setters
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>(t1Instance).setter = t0Instance;
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestGenericPrivate<F1>(t1Instance).setter = t0Instance;
+  }, (e) => e is TypeError);
+
+  // Test class variables
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>(t1Instance).m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  // Test constructors
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestGenericPublic<F1>.short(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestGenericPrivate<F1>(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ClassMemberTestGenericPrivate<F1>.short(forgetType(t0Instance));
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t02.dart
@@ -1,0 +1,161 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_fail_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+class ClassMemberSuper1_t02 {
+  F1 m = t1Default;
+
+  ClassMemberSuper1_t02(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  ClassMember1_t02.valid() : super(null);
+
+  test1() {
+    m = forgetType(t0Instance);
+  }
+
+  test2() {
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t02<X> {
+  X m;
+
+  ClassMemberSuper2_t02(X value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(X value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+
+  test1() {
+    m = forgetType(t0Instance);
+  }
+
+  test2() {
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  Expect.throws(() {
+    new ClassMember1_t02();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02.short();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02.named();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().test2();
+  }, (e) => e is TypeError);
+
+  // Test type parameters
+
+  Expect.throws(() {
+    new ClassMember2_t02<F1>();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>.short();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>.named();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().test2();
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A06_t03.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_fail_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin class ClassMemberSuper1_t03 {
+  F1 m = t1Default;
+
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
+
+  test1() {
+    m = forgetType(t0Instance);
+  }
+
+  test2() {
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t03<X> {
+  X m;
+
+  ClassMemberSuper2_t03(X x) : m = x {}
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
+
+  ClassMember2_t03(X x): super(x) {}
+
+  test1() {
+    m = forgetType(t0Instance);
+  }
+
+  test2() {
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  Expect.throws(() {
+    new ClassMember1_t03().m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t03().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t03().test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t03().test2();
+  }, (e) => e is TypeError);
+
+  // Test type parameters
+
+  Expect.throws(() {
+    new ClassMember2_t03<F1>(t1Instance).m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t03<F1>(t1Instance).superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t03<F1>(t1Instance).test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t03<F1>(t1Instance).test2();
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A11_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A12_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A21_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A22_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A23_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A31_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A32_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A33_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A41_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A42_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A43_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A51_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A52_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A53_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t01.dart
@@ -20,15 +20,15 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
 /// be used as a class member of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/class_member_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t02.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the mixin member of type T1
+/// instance of T0 cannot be assigned to the superclass member of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/class_member_fail_x03.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/class_member_fail_x02.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -43,17 +43,34 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
-F1 t1Instance = f1Instance;
 
 const t1Default = f1Instance;
 
-mixin class ClassMemberSuper1_t03 {
+class ClassMemberSuper1_t02 {
   F1 m = t1Default;
+
+  ClassMemberSuper1_t02(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
 
   void set superSetter(F1 val) {}
 }
 
-class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  ClassMember1_t02.valid() : super(null);
 
   test1() {
     m = forgetType(t0Instance);
@@ -64,17 +81,27 @@ class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
   }
 }
 
-class ClassMemberSuper2_t03<X> {
+class ClassMemberSuper2_t02<X> {
   X m;
 
-  ClassMemberSuper2_t03(X x) : m = x {}
+  ClassMemberSuper2_t02(X value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(X value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
 
   void set superSetter(X val) {}
 }
 
-class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 
-  ClassMember2_t03(X x): super(x) {}
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
 
   test1() {
     m = forgetType(t0Instance);
@@ -87,30 +114,48 @@ class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 
 main() {
   Expect.throws(() {
-    new ClassMember1_t03().m = forgetType(t0Instance);
+    new ClassMember1_t02();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t03().superSetter = forgetType(t0Instance);
+    new ClassMember1_t02.short();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t03().test1();
+    new ClassMember1_t02.named();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t03().test2();
+    new ClassMember1_t02().m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember1_t02().test2();
   }, (e) => e is TypeError);
 
   // Test type parameters
 
   Expect.throws(() {
-    new ClassMember2_t03<F1>(t1Instance).m = forgetType(t0Instance);
+    new ClassMember2_t02<F1>();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t03<F1>(t1Instance).superSetter = forgetType(t0Instance);
+    new ClassMember2_t02<F1>.short();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t03<F1>(t1Instance).test1();
+    new ClassMember2_t02<F1>.named();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t03<F1>(t1Instance).test2();
+    new ClassMember2_t02<F1>().m = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().superSetter = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().test1();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ClassMember2_t02<F1>().test2();
   }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_class_member_fail_A61_t03.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the superclass member of type T1
+/// instance of T0 cannot be assigned to the mixin member of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/class_member_fail_x02.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/class_member_fail_x03.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -43,34 +43,17 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
 
 const t1Default = f1Instance;
 
-class ClassMemberSuper1_t02 {
+mixin class ClassMemberSuper1_t03 {
   F1 m = t1Default;
-
-  ClassMemberSuper1_t02(dynamic value) {
-    m = value;
-  }
-
-  ClassMemberSuper1_t02.named(dynamic value) {
-    m = value;
-  }
-
-  ClassMemberSuper1_t02.short(this.m);
 
   void set superSetter(F1 val) {}
 }
 
-class ClassMember1_t02 extends ClassMemberSuper1_t02 {
-
-  ClassMember1_t02() : super(forgetType(t0Instance)) {}
-
-  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
-
-  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
-
-  ClassMember1_t02.valid() : super(null);
+class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
 
   test1() {
     m = forgetType(t0Instance);
@@ -81,27 +64,17 @@ class ClassMember1_t02 extends ClassMemberSuper1_t02 {
   }
 }
 
-class ClassMemberSuper2_t02<X> {
+class ClassMemberSuper2_t03<X> {
   X m;
 
-  ClassMemberSuper2_t02(X value): m = value {
-  }
-
-  ClassMemberSuper2_t02.named(X value): m = value {
-  }
-
-  ClassMemberSuper2_t02.short(this.m);
+  ClassMemberSuper2_t03(X x) : m = x {}
 
   void set superSetter(X val) {}
 }
 
-class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+class ClassMember2_t03<X> extends ClassMemberSuper2_t03<X> {
 
-  ClassMember2_t02() : super(forgetType(t0Instance)) {}
-
-  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
-
-  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+  ClassMember2_t03(X x): super(x) {}
 
   test1() {
     m = forgetType(t0Instance);
@@ -114,48 +87,30 @@ class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
 
 main() {
   Expect.throws(() {
-    new ClassMember1_t02();
+    new ClassMember1_t03().m = forgetType(t0Instance);
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t02.short();
+    new ClassMember1_t03().superSetter = forgetType(t0Instance);
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t02.named();
+    new ClassMember1_t03().test1();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember1_t02().m = forgetType(t0Instance);
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember1_t02().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember1_t02().test1();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember1_t02().test2();
+    new ClassMember1_t03().test2();
   }, (e) => e is TypeError);
 
   // Test type parameters
 
   Expect.throws(() {
-    new ClassMember2_t02<F1>();
+    new ClassMember2_t03<F1>(t1Instance).m = forgetType(t0Instance);
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t02<F1>.short();
+    new ClassMember2_t03<F1>(t1Instance).superSetter = forgetType(t0Instance);
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t02<F1>.named();
+    new ClassMember2_t03<F1>(t1Instance).test1();
   }, (e) => e is TypeError);
   Expect.throws(() {
-    new ClassMember2_t02<F1>().m = forgetType(t0Instance);
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember2_t02<F1>().superSetter = forgetType(t0Instance);
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember2_t02<F1>().test1();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ClassMember2_t02<F1>().test2();
+    new ClassMember2_t03<F1>(t1Instance).test2();
   }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A06_t01.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/global_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  GlobalVariableTest.valid() {}
+
+  foo() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  static test() {
+    t1Instance = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  Expect.throws(() {
+    t1Instance = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    bar();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new GlobalVariableTest();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new GlobalVariableTest.valid().foo();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    GlobalVariableTest.test();
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_global_variable_fail_A61_t01.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the to local variable of type T1
+/// instance of T0 cannot be assigned to the to global variable of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/global_variable_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -43,31 +43,31 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
 
-class LocalVariableTest {
-
-  LocalVariableTest() {
-    F1 t1 = forgetType(t0Instance);
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
   }
 
-  LocalVariableTest.valid() {}
+  GlobalVariableTest.valid() {}
 
-  static staticTest() {
-    F1 t1 = forgetType(t0Instance);
+  foo() {
+    t1Instance = forgetType(t0Instance);
   }
 
-  test() {
-    F1 t1 = forgetType(t0Instance);
+  static test() {
+    t1Instance = forgetType(t0Instance);
   }
 }
 
 main() {
   bar () {
-    F1 t1 = forgetType(t0Instance);
+    t1Instance = forgetType(t0Instance);
   }
 
   Expect.throws(() {
-    F1 t1 = forgetType(t0Instance);
+    t1Instance = forgetType(t0Instance);
   }, (e) => e is TypeError);
 
   Expect.throws(() {
@@ -75,14 +75,14 @@ main() {
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new LocalVariableTest();
+    new GlobalVariableTest();
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    new LocalVariableTest.valid().test();
+    new GlobalVariableTest.valid().foo();
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    LocalVariableTest.staticTest();
+    GlobalVariableTest.test();
   }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A06_t01.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    F1 t1 = forgetType(t0Instance);
+  }
+
+  LocalVariableTest.valid() {}
+
+  static staticTest() {
+    F1 t1 = forgetType(t0Instance);
+  }
+
+  test() {
+    F1 t1 = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    F1 t1 = forgetType(t0Instance);
+  }
+
+  Expect.throws(() {
+    F1 t1 = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    bar();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new LocalVariableTest();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new LocalVariableTest.valid().test();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    LocalVariableTest.staticTest();
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_local_variable_fail_A61_t01.dart
@@ -20,20 +20,21 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the superclass member of type T1.
-/// Assignment to variable of super class is tested.
+/// instance of T0 cannot be assigned to the to local variable of type T1
 /// @author sgrekhov@unipro.ru
-/// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/class_member_super_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
 
 typedef void F0({required int i});
 typedef void F1({int i});
@@ -43,54 +44,45 @@ void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
 
-const t1Default = f1Instance;
+class LocalVariableTest {
 
-class ClassMemberSuper1_t02 {
-  F1 m = t1Default;
+  LocalVariableTest() {
+    F1 t1 = forgetType(t0Instance);
+  }
 
-  ClassMemberSuper1_t02(F0 value) {
-    m = value;
-//      ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-  ClassMemberSuper1_t02.named(F0 value) {
-    m = value;
-//      ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-  ClassMemberSuper1_t02.valid(F1 value) {
-    m = value;
-  }
-  void set superSetter(F1 val) {}
-}
+  LocalVariableTest.valid() {}
 
-class ClassMember1_t02 extends ClassMemberSuper1_t02 {
-  ClassMember1_t02() : super(t0Instance) {}
-  ClassMember1_t02.named() : super.named(t0Instance) {}
-  ClassMember1_t02.valid() : super.valid(t1Default);
-  test1() {
-    m = t0Instance;
-//      ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  static staticTest() {
+    F1 t1 = forgetType(t0Instance);
   }
-  test2() {
-    superSetter = t0Instance;
-//                ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+
+  test() {
+    F1 t1 = forgetType(t0Instance);
   }
 }
 
 main() {
-  new ClassMember1_t02.valid().m = t0Instance;
-//                                 ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  new ClassMember1_t02.valid().superSetter = t0Instance;
-//                                           ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  bar () {
+    F1 t1 = forgetType(t0Instance);
+  }
+
+  Expect.throws(() {
+    F1 t1 = forgetType(t0Instance);
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    bar();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new LocalVariableTest();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new LocalVariableTest.valid().test();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    LocalVariableTest.staticTest();
+  }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A06_t01.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then instance
+/// of T0 cannot be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+import '../../../../Utils/expect.dart';
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+F1 returnValueFunc() => forgetType(t0Instance);
+
+class ReturnValueTest {
+  static F1 staticTestMethod() => forgetType(t0Instance);
+
+  F1 testMethod() => forgetType(t0Instance);
+
+  F1 get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
+}
+
+main() {
+  F1 returnValueLocalFunc() => forgetType(t0Instance);
+
+  Expect.throws(() {
+    returnValueFunc();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    returnValueLocalFunc();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    ReturnValueTest.staticTestMethod();
+  }, (e) => e is TypeError);
+
+  Expect.throws(() {
+    new ReturnValueTest().testMethod();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ReturnValueTest().testGetter;
+  }, (e) => e is TypeError);
+
+  // Test type parameters
+
+  Expect.throws(() {
+    new ReturnValueGen<F1>().testMethod();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ReturnValueGen<F1>().testGetter;
+  }, (e) => e is TypeError);
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_fail_return_value_fail_A61_t01.dart
@@ -20,16 +20,16 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
-/// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the to global variable of type T1
+/// @description Check that if type T0 not a subtype of a type T1, then instance
+/// of T0 cannot be used as a return value of type T1
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/global_variable_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/return_value_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -43,46 +43,48 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
-F1 t1Instance = f1Instance;
 
-class GlobalVariableTest {
-  GlobalVariableTest() {
-    t1Instance = forgetType(t0Instance);
-  }
+F1 returnValueFunc() => forgetType(t0Instance);
 
-  GlobalVariableTest.valid() {}
+class ReturnValueTest {
+  static F1 staticTestMethod() => forgetType(t0Instance);
 
-  foo() {
-    t1Instance = forgetType(t0Instance);
-  }
+  F1 testMethod() => forgetType(t0Instance);
 
-  static test() {
-    t1Instance = forgetType(t0Instance);
-  }
+  F1 get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
 }
 
 main() {
-  bar () {
-    t1Instance = forgetType(t0Instance);
-  }
+  F1 returnValueLocalFunc() => forgetType(t0Instance);
 
   Expect.throws(() {
-    t1Instance = forgetType(t0Instance);
+    returnValueFunc();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    returnValueLocalFunc();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    ReturnValueTest.staticTestMethod();
   }, (e) => e is TypeError);
 
   Expect.throws(() {
-    bar();
+    new ReturnValueTest().testMethod();
+  }, (e) => e is TypeError);
+  Expect.throws(() {
+    new ReturnValueTest().testGetter;
   }, (e) => e is TypeError);
 
-  Expect.throws(() {
-    new GlobalVariableTest();
-  }, (e) => e is TypeError);
+  // Test type parameters
 
   Expect.throws(() {
-    new GlobalVariableTest.valid().foo();
+    new ReturnValueGen<F1>().testMethod();
   }, (e) => e is TypeError);
-
   Expect.throws(() {
-    GlobalVariableTest.test();
+    new ReturnValueGen<F1>().testGetter;
   }, (e) => e is TypeError);
 }

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_global_variable_A06_t01.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/global_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  foo() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  static test() {
+    t1Instance = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  t1Instance = forgetType(t0Instance);
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_local_variable_A06_t01.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/local_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    F1 t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  static staticTest() {
+    F1 t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  test() {
+    F1 t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+}
+
+main() {
+  foo() {
+    F1 t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  F1 t1 = forgetType(t0Instance);
+  t1 = forgetType(t0Instance);
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/named_function_types_return_value_A06_t01.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/return_value_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+F1 returnValueFunc() => forgetType(t0Instance);
+
+class ReturnValueTest {
+  static F1 staticTestMethod() => forgetType(t0Instance);
+
+  F1 testMethod() => forgetType(t0Instance);
+
+  F1 get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
+}
+
+main() {
+  F1 returnValueLocalFunc() => forgetType(t0Instance);
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+
+  // Test type parameters
+
+  new ReturnValueGen<F1>().testMethod();
+  new ReturnValueGen<F1>().testGetter;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A01_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A02_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A03_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A04_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A05_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t01.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+namedArgumentsFunc1(F1 t1, {F1 t2 = t1Default}) {}
+positionalArgumentsFunc1(F1 t1, [F1 t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(F1 t1) {}
+
+  ArgumentsBindingClass.named(F1 t1, {F1 t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(F1 t1, [F1 t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(F1 t1, {F1 t2 = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(F1 t1, [F1 t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(F1 t1, {F1 t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  namedArgumentsMethod(F1 t1, {F1 t2 = t1Default}) {}
+  positionalArgumentsMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+  set testSetter(F1 val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(t0Instance, t2: t0Instance);
+  positionalArgumentsFunc1(t0Instance, t0Instance);
+
+  // test class constructors
+  ArgumentsBindingClass instance1 = new ArgumentsBindingClass(t0Instance);
+  instance1 = new ArgumentsBindingClass.fNamed(t0Instance, t2: t0Instance);
+  instance1 = new ArgumentsBindingClass.fPositional(t0Instance, t0Instance);
+  instance1 = new ArgumentsBindingClass.named(t0Instance, t2: t0Instance);
+  instance1 = new ArgumentsBindingClass.positional(t0Instance, t0Instance);
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(t0Instance, t2: t0Instance);
+  instance1.positionalArgumentsMethod(t0Instance, t0Instance);
+  instance1.testSetter = t0Instance;
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t0Instance, t2: t0Instance);
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t0Instance, t0Instance);
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<F1>(t0Instance, t2: t0Instance);
+
+  // test generic class constructors
+  ArgumentsBindingGen<F1> instance2 = new ArgumentsBindingGen<F1>(t0Instance);
+  instance2 = new ArgumentsBindingGen<F1>.fNamed(t0Instance, t2: t0Instance);
+  instance2 = new ArgumentsBindingGen<F1>.named(t0Instance, t2: t0Instance);
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(t0Instance, t2: t0Instance);
+  instance2.testSetter = t0Instance;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t02.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+class ArgumentsBindingSuper1_t02 {
+  F1 m = t1Default;
+
+  ArgumentsBindingSuper1_t02(F1 value): m = value {}
+  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => m;
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c1(dynamic t1) : super.named(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value): m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}): m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c1(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(t0Instance);
+  c1.superTestPositioned(t0Instance);
+  c1.superTestPositioned(t1Instance, t0Instance);
+  c1.superTestNamed(t0Instance);
+  c1.superTestNamed(t1Instance, val2: t0Instance);
+  c1.superSetter = t0Instance;
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t02<F1> c2 =
+    new ArgumentsBinding2_t02<F1>(t0Instance);
+  c2 = new ArgumentsBinding2_t02<F1>.c2(t1Instance, t0Instance);
+  c2 = new ArgumentsBinding2_t02<F1>.c5(t0Instance);
+
+  c2.test(t0Instance, t1Instance);
+  c2.superTest(t0Instance);
+  c2.superTestNamed(t1Instance, val2: t0Instance);
+  c2.superSetter = t0Instance;
+  c2.superGetter;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_arguments_binding_A06_t03.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/arguments_binding_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin ArgumentsBindingMixin1_t03 {
+  F1 m = t1Default;
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => m;
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(t0Instance);
+  c1.superTestPositioned(t0Instance);
+  c1.superTestPositioned(t1Instance, t0Instance);
+  c1.superTestNamed(t0Instance);
+  c1.superTestNamed(t1Instance, val2: t0Instance);
+  c1.superSetter = t0Instance;
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<F1> c2 = new ArgumentsBinding2_t03<F1>();
+  c2.test(t0Instance, t1Instance);
+  c2.superTest(t0Instance);
+  c2.superTestNamed(t1Instance, val2: t0Instance);
+  c2.superSetter = t0Instance;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A01_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A02_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A03_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A04_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A05_t03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t01.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+class ClassMember1_t01 {
+  static F1 s = t0Instance;
+  F1 m = t0Instance;
+  F1 _p = t0Instance;
+
+  ClassMember1_t01() {
+    s = t0Instance;
+    m = t0Instance;
+    _p = t0Instance;
+  }
+
+  ClassMember1_t01.named(F1 value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = t0Instance;
+    m = t0Instance;
+    _p = t0Instance;
+  }
+
+  set setter(F1 val) {
+    _p = val;
+  }
+
+  F1 get getter => _p;
+
+  static staticTest() {
+    s = t0Instance;
+  }
+
+  static set staticSetter(F1 val) {
+    s = val;
+  }
+
+  static F1 get staticGetter => t0Instance;
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(t0Instance,
+      t0Instance);
+  c1 = new ClassMember1_t01.named(t0Instance);
+  c1.m = t0Instance;
+  c1.test();
+  c1.setter = t0Instance;
+  c1.getter;
+
+  ClassMember1_t01.s = t0Instance;
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = t0Instance;
+  ClassMember1_t01.staticGetter;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t02.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x02.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+class ClassMemberSuper1_t02 {
+  F1 m = t1Default;
+
+  ClassMemberSuper1_t02(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(t0Instance) {}
+
+  ClassMember1_t02.named() : super.named(t0Instance) {}
+
+  ClassMember1_t02.short() : super.short(t0Instance);
+
+  test() {
+    m = t0Instance;
+    superSetter = t0Instance;
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = t0Instance;
+  c1.test();
+  c1.superSetter = t0Instance;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_class_member_A06_t03.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/class_member_x03.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+mixin class ClassMemberMixin1_t03 {
+  F1 m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = t0Instance;
+    superSetter = t0Instance;
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = t0Instance;
+  c1.test();
+  c1.superSetter = t0Instance;
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A06_t01.dart
@@ -1,0 +1,173 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Global function required argument is
+/// tested.
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+namedArgumentsFunc1(F1 t1, {F1 t2 = t1Default}) {}
+positionalArgumentsFunc1(F1 t1, [F1 t2 = t1Default]) {}
+
+class ArgumentsBindingClass {
+    ArgumentsBindingClass(F1 t1) {}
+
+    ArgumentsBindingClass.named(F1 t1, {F1 t2 = t1Default}) {}
+    ArgumentsBindingClass.positional(F1 t1, [F1 t2 = t1Default]) {}
+
+    factory ArgumentsBindingClass.fNamed(F1 t1, {F1 t2 = t1Default}) {
+        return new ArgumentsBindingClass.named(t1, t2: t2);
+    }
+    factory ArgumentsBindingClass.fPositional(F1 t1, [F1 t2 = t1Default]) {
+        return new ArgumentsBindingClass.positional(t1, t2);
+    }
+
+    static namedArgumentsStaticMethod(F1 t1, {F1 t2 = t1Default}) {}
+    static positionalArgumentsStaticMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+    namedArgumentsMethod(F1 t1, {F1 t2 = t1Default}) {}
+    positionalArgumentsMethod(F1 t1, [F1 t2 = t1Default]) {}
+
+    set testSetter(F1 val) {}
+}
+
+class ArgumentsBindingClassSuper {
+  ArgumentsBindingClassSuper(F1 t1) {}
+}
+
+class ArgumentsBindingDesc extends ArgumentsBindingClassSuper {
+  ArgumentsBindingDesc(F0 t0) : super (t0) {}
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  namedArgumentsFunc1(t0Instance);
+//                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  namedArgumentsFunc1(t1Instance, t2: t0Instance);
+//                                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  positionalArgumentsFunc1(t0Instance);
+//                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  positionalArgumentsFunc1(t1Instance, t0Instance);
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t0Instance);
+//                          ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t0Instance);
+//                                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).namedArgumentsMethod(t1Instance, t2: t0Instance);
+//                                                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t0Instance);
+//                                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).positionalArgumentsMethod(t1Instance, t0Instance);
+//                                                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass(t1Instance).testSetter = t0Instance;
+//                                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t1Instance, t2: t0Instance);
+//                                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t0Instance);
+//                                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t1Instance, t0Instance);
+//                                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.named(t0Instance);
+//                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.named(t1Instance, t2: t0Instance);
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.positional(t0Instance);
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.positional(t1Instance, t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fNamed(t0Instance);
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fNamed(t1Instance, t2: t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fPositional(t0Instance);
+//                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBindingClass.fPositional(t1Instance, t0Instance);
+//                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_fail_A61_t01.dart
@@ -20,8 +20,8 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
@@ -29,7 +29,7 @@
 /// tested.
 /// @author sgrekhov@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/arguments_binding_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A06_t01.dart
@@ -1,0 +1,181 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test mixin members. Super method required
+/// argument is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_mixin_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+mixin ArgumentsBindingSuper1_t03 {
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingSuper1_t03 {
+
+  test() {
+    superTest(t0Instance);
+//            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTest(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTest(t0Instance);
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t0Instance);
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t0Instance);
+//                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t1Instance, t0Instance);
+//                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t1Instance, t0Instance);
+//                                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t1Instance, t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t0Instance);
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t1Instance, val2: t0Instance);
+//                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t1Instance, val2: t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t1Instance, val2: t0Instance);
+//                                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superSetter = t0Instance;
+//                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superSetter = t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ArgumentsBinding1_t03().superTest(t0Instance);
+//                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestPositioned(t0Instance);
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestPositioned(t1Instance, t0Instance);
+//                                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestNamed(t0Instance);
+//                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superTestNamed(t1Instance, val2: t0Instance);
+//                                                             ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().superSetter = t0Instance;
+//                                          ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t03().test();
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_mixin_fail_A61_t01.dart
@@ -20,8 +20,8 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
@@ -30,7 +30,7 @@
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/arguments_binding_mixin_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A06_t01.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as an argument of type T1. Test superclass members. Super constructor
+/// required argument is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/arguments_binding_super_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+class ArgumentsBindingSuper1_t02 {
+  F1 m = t1Default;
+
+  ArgumentsBindingSuper1_t02(F1 value): m = value {}
+  ArgumentsBindingSuper1_t02.named(F1 value, {F1 val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(F1 value, [F1 val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(F1 val) {}
+  void superTestPositioned(F1 val, [F1 val2 = t1Default]) {}
+  void superTestNamed(F1 val, {F1 val2 = t1Default}) {}
+  F1 get superGetter => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set superSetter(F1 val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(F0 t0) : super(t0) {}
+//                                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c1(F0 t0) : super.named(t0) {}
+//                                               ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c2(F1 t1, F0 t2) : super.named(t1, val2: t2) {}
+//                                                       ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c3(F0 t0) : super.positional(t0) {}
+//                                                    ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c4(F1 t1, F0 t2) : super.positional(t1, t2) {}
+//                                                                ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  ArgumentsBinding1_t02.c5(F0 t1) : super.short(t1) {}
+//                                               ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  ArgumentsBinding1_t02.valid() : super(t1Default) {}
+
+  test() {
+    superTest(t0Instance);
+//            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTest(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTest(t0Instance);
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t0Instance);
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t0Instance);
+//                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestPositioned(t1Instance, t0Instance);
+//                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestPositioned(t1Instance, t0Instance);
+//                                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestPositioned(t1Instance, t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t0Instance);
+//                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t0Instance);
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t0Instance);
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superTestNamed(t1Instance, val2: t0Instance);
+//                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superTestNamed(t1Instance, val2: t0Instance);
+//                                        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superTestNamed(t1Instance, val2: t0Instance);
+//                                         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    this.superSetter = t0Instance;
+//                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+    super.superSetter = t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ArgumentsBinding1_t02.valid().superTest(t0Instance);
+//                                            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestPositioned(t0Instance);
+//                                                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestPositioned(t1Instance, t0Instance);
+//                                                                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestNamed(t0Instance);
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superTestNamed(t1Instance, val2: t0Instance);
+//                                                                   ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().superSetter = t0Instance;
+//                                                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ArgumentsBinding1_t02.valid().test();
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_arguments_binding_super_fail_A61_t01.dart
@@ -20,8 +20,8 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
@@ -30,7 +30,7 @@
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/arguments_binding_super_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A06_t01.dart
@@ -1,0 +1,157 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then it cannot
+/// be used as a class member of type T1. Assignment to static and instance class
+/// variables is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+class ClassMemberTestStatic {
+  static F1 s = t1Default;
+
+  ClassMemberTestStatic(F0 val) {
+    s = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static staticTest() {
+    s = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static set staticSetter(F0 val) {
+    s = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static F1 get staticGetter => t0Instance;
+//                               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+class ClassMemberTestPublic {
+  F1 m = t1Default;
+
+  ClassMemberTestPublic(F0 val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  ClassMemberTestPublic.short(this.m);
+
+  ClassMemberTestPublic.validConstructor() {}
+
+  test(F0 val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  set setter(F0 val) {
+    m = val;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  F1 get getter => t0Instance;
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+class ClassMemberTestPrivate {
+  F1 _m = t1Default;
+
+  ClassMemberTestPrivate(F0 val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  ClassMemberTestPrivate.short(this._m);
+
+  ClassMemberTestPrivate.validConstructor() {}
+
+  test(F0 val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  set setter(F0 val) {
+    _m = val;
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+class ClassMemberTestInitFail {
+  static F1 s = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  F1 m = t0Instance;
+//        ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  new ClassMemberTestPublic.validConstructor().m = t0Instance;
+//                                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_fail_A61_t01.dart
@@ -20,8 +20,8 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 not a subtype of a type T1, then it cannot
@@ -30,7 +30,7 @@
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/class_member_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A06_t01.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the mixin member of type T1.
+/// Assignment to instance variable of super class is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_mixin_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+mixin class ClassMemberSuper1_t03 {
+  F1 m = t1Default;
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ClassMember1_t03().m = t0Instance;
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t03().superSetter = t0Instance;
+//                                     ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_mixin_fail_A61_t01.dart
@@ -20,17 +20,18 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
-/// @description Check that if type T0 not a subtype of a type T1, then instance
-/// of T0 cannot be used as a return value of type T1. Return value is tested.
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the mixin member of type T1.
+/// Assignment to instance variable of super class is tested.
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/class_member_mixin_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -42,30 +43,35 @@ void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
 
-F1 returnValueFunc() => t0Instance;
-//                       ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+const t1Default = f1Instance;
 
-class ReturnValueTest {
-  static F1 staticTestMethod() => t0Instance;
-//                                 ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  F1 testMethod() => t0Instance;
-//                    ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+mixin class ClassMemberSuper1_t03 {
+  F1 m = t1Default;
+  void set superSetter(F1 val) {}
+}
 
-  F1 get testGetter => t0Instance;
-//                      ^^^^^^^^^^
+class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
 }
 
 main() {
-  F1 returnValueLocalFunc() => t0Instance;
-//                              ^^^^^^^^^^
+  new ClassMember1_t03().m = t0Instance;
+//                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t03().superSetter = t0Instance;
+//                                     ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A06_t01.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the superclass member of type T1.
+/// Assignment to variable of super class is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/class_member_super_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+const t1Default = f1Instance;
+
+class ClassMemberSuper1_t02 {
+  F1 m = t1Default;
+
+  ClassMemberSuper1_t02(F0 value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.named(F0 value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.valid(F1 value) {
+    m = value;
+  }
+  void set superSetter(F1 val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+  ClassMember1_t02() : super(t0Instance) {}
+  ClassMember1_t02.named() : super.named(t0Instance) {}
+  ClassMember1_t02.valid() : super.valid(t1Default);
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  new ClassMember1_t02.valid().m = t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t02.valid().superSetter = t0Instance;
+//                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_class_member_super_fail_A61_t01.dart
@@ -20,21 +20,20 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
-/// @description Check that if type T0 not a subtype of a type T1, then instance
-/// of T0 cannot be used as a return value of type T1
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the superclass member of type T1.
+/// Assignment to variable of super class is tested.
 /// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/class_member_super_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
-
-import '../../utils/common.dart';
-import '../../../../Utils/expect.dart';
 
 typedef void F0({required int i});
 typedef void F1({int i});
@@ -44,47 +43,54 @@ void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
 
-F1 returnValueFunc() => forgetType(t0Instance);
+const t1Default = f1Instance;
 
-class ReturnValueTest {
-  static F1 staticTestMethod() => forgetType(t0Instance);
+class ClassMemberSuper1_t02 {
+  F1 m = t1Default;
 
-  F1 testMethod() => forgetType(t0Instance);
-
-  F1 get testGetter => forgetType(t0Instance);
+  ClassMemberSuper1_t02(F0 value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.named(F0 value) {
+    m = value;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  ClassMemberSuper1_t02.valid(F1 value) {
+    m = value;
+  }
+  void set superSetter(F1 val) {}
 }
 
-class ReturnValueGen<X> {
-  X testMethod() => forgetType(t0Instance);
-  X get testGetter => forgetType(t0Instance);
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+  ClassMember1_t02() : super(t0Instance) {}
+  ClassMember1_t02.named() : super.named(t0Instance) {}
+  ClassMember1_t02.valid() : super.valid(t1Default);
+  test1() {
+    m = t0Instance;
+//      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  test2() {
+    superSetter = t0Instance;
+//                ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
 }
 
 main() {
-  F1 returnValueLocalFunc() => forgetType(t0Instance);
-
-  Expect.throws(() {
-    returnValueFunc();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    returnValueLocalFunc();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    ReturnValueTest.staticTestMethod();
-  }, (e) => e is TypeError);
-
-  Expect.throws(() {
-    new ReturnValueTest().testMethod();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ReturnValueTest().testGetter;
-  }, (e) => e is TypeError);
-
-  // Test type parameters
-
-  Expect.throws(() {
-    new ReturnValueGen<F1>().testMethod();
-  }, (e) => e is TypeError);
-  Expect.throws(() {
-    new ReturnValueGen<F1>().testGetter;
-  }, (e) => e is TypeError);
+  new ClassMember1_t02.valid().m = t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  new ClassMember1_t02.valid().superSetter = t0Instance;
+//                                           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A06_t01.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to global variable of type T1.
+/// Assignment to global variable is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/global_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  foo() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  static test() {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  t1Instance = t0Instance;
+//             ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  bar () {
+    t1Instance = t0Instance;
+//               ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_global_variable_fail_A61_t01.dart
@@ -20,8 +20,8 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
@@ -30,7 +30,7 @@
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
 /// test_cases/global_variable_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A06_t01.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is not a subtype of a type T1, then
+/// instance of T0 cannot be assigned to the to local variable of type T1.
+/// Assignment to local variable is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+class LocalVariableTest {
+  LocalVariableTest() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  test() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static staticTest() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+main() {
+  F1 t1 = t0Instance;
+//         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  bar () {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_local_variable_fail_A61_t01.dart
@@ -20,18 +20,18 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
 ///
 /// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the mixin member of type T1.
-/// Assignment to instance variable of super class is tested.
+/// instance of T0 cannot be assigned to the to local variable of type T1.
+/// Assignment to local variable is tested.
 /// @author sgrekhov@unipro.ru
 /// @author ngl@unipro.ru
 ///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/class_member_mixin_fail_x01.dart. Don't modify it! 
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
 /// If you need to change this test, then change one of the files above and then 
 /// run generator/generator.dart to regenerate the tests.
 
@@ -43,35 +43,39 @@ void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
 
-const t1Default = f1Instance;
-
-mixin class ClassMemberSuper1_t03 {
-  F1 m = t1Default;
-  void set superSetter(F1 val) {}
-}
-
-class ClassMember1_t03 extends Object with ClassMemberSuper1_t03 {
-  test1() {
-    m = t0Instance;
-//      ^^^^^^^^^^
+class LocalVariableTest {
+  LocalVariableTest() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
-  test2() {
-    superSetter = t0Instance;
-//                ^^^^^^^^^^
+
+  test() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static staticTest() {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 }
 
 main() {
-  new ClassMember1_t03().m = t0Instance;
-//                           ^^^^^^^^^^
+  F1 t1 = t0Instance;
+//         ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  new ClassMember1_t03().superSetter = t0Instance;
-//                                     ^^^^^^^^^^
+
+  bar () {
+    F1 t1 = t0Instance;
+//           ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+  }
 }

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A06_t01.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then instance
+/// of T0 cannot be used as a return value of type T1. Return value is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A061.dart and 
+/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+
+F1 returnValueFunc() => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+class ReturnValueTest {
+  static F1 staticTestMethod() => t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  F1 testMethod() => t0Instance;
+//                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  F1 get testGetter => t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  F1 returnValueLocalFunc() => t0Instance;
+//                              ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A11_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A11_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A12_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A12_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A21_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A21_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A22_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A22_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A23_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A23_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A31_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A31_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A32_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A32_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A33_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A33_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A41_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A41_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A42_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A42_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A43_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A43_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A51_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A51_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A52_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A52_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A53_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A53_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A61_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_fail_return_value_fail_A61_t01.dart
@@ -20,9 +20,19 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 not a subtype of a type T1, then instance
+/// of T0 cannot be used as a return value of type T1. Return value is tested.
+/// @author sgrekhov@unipro.ru
+/// @author ngl@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_fail_A61.dart and 
+/// test_cases/return_value_fail_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
 
 typedef void F0({required int i});
 typedef void F1({int i});
@@ -31,9 +41,31 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
-F1 t1Instance = f1Instance;
 
-const t1Default = f1Instance;
+F1 returnValueFunc() => t0Instance;
+//                       ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 
-//# @T0 = F0
-//# @T1 = F1
+class ReturnValueTest {
+  static F1 staticTestMethod() => t0Instance;
+//                                 ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  F1 testMethod() => t0Instance;
+//                    ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  F1 get testGetter => t0Instance;
+//                      ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  F1 returnValueLocalFunc() => t0Instance;
+//                              ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_global_variable_A06_t01.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/global_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = t0Instance;
+  }
+
+  foo() {
+    t1Instance = t0Instance;
+  }
+
+  static test() {
+    t1Instance = t0Instance;
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = t0Instance;
+  }
+
+  t1Instance = t0Instance;
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_local_variable_A06_t01.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/local_variable_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    F1 t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  static staticTest() {
+    F1 t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  test() {
+    F1 t1 = t0Instance;
+    t1 = t0Instance;
+  }
+}
+
+main() {
+  foo() {
+    F1 t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  F1 t1 = t0Instance;
+  t1 = t0Instance;
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A01_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A01_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A02_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A03_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A03_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A04_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A04_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A05_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A05_t01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A06_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/named_function_types_return_value_A06_t01.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/named_function_types_A06.dart and 
+/// test_cases/return_value_x01.dart. Don't modify it! 
+/// If you need to change this test, then change one of the files above and then 
+/// run generator/generator.dart to regenerate the tests.
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+
+F1 returnValueFunc() => t0Instance;
+
+class ReturnValueTest {
+  static F1 staticTestMethod() => t0Instance;
+
+  F1 testMethod() => t0Instance;
+
+  F1 get testGetter => t0Instance;
+}
+
+main() {
+  F1 returnValueLocalFunc() => t0Instance;
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+}

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A01.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A01.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A02.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A02.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A03.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A03.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with high-level types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A04.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A04.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types with Null type
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A05.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A05.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subset of {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if T0 and T1 satisfies the rules above, then T0 is
 /// subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_A06.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_A06.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a named argument and `T1` has a required
+/// named argument of the same type, then T0 is a subtype of T1.
+/// @author sgrekhov22@gmail.com
+
+typedef void F0({int i});
+typedef void F1({required int i});
+
+void f0Instance({int i = 0}) {}
+void f1Instance({required int i}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+//# @T0 = F0
+//# @T1 = F1

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A061.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A061.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
+/// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
+/// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
+/// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
+/// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
+/// @description Check that if `T0` has a required named argument and `T1` has
+/// not required named argument of the same type and with the same name, then
+/// anyway `T0` is a subtype of `T1`.
+/// @author sgrekhov22@gmail.com
+
+typedef void F0({required int i});
+typedef void F1({int i});
+
+void f0Instance({required int i}) {}
+void f1Instance({int i = 0}) {}
+
+F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
+
+const t1Default = f1Instance;
+
+//# @T0 = F0
+//# @T1 = F1

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A11.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A11.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A12.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A12.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if {yn+1, ..., yq} is not subsetof {xn+1, ..., xm},
 /// then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A21.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A21.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A22.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A22.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A23.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A23.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in 0...n such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Vi[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A31.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A31.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A32.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A32.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A33.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A33.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if there is i in n+1...q such that
 /// Si[Z0/Y0, ..., Zk/Yk] is not subtype of Tj[Z0/X0, ..., Zk/Xk], then T0 is
 /// not a subtype of T1. Test generic types

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A41.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A41.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A42.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A42.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A43.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A43.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if U0[Z0/X0, ..., Zk/Xk] is not a subtype of
 /// U1[Z0/Y0, ..., Zk/Yk], then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A51.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A51.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A52.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A52.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A53.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A53.dart
@@ -3,17 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion A type T0 is a subtype of a type T1 (written T0 <: T1) when:
-/// Named Function Types: T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>
-///   (T0 x0, ..., Tn xn, {Tn+1 xn+1, ..., Tm xm})
-///
-/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn,
-/// {Sn+1 yn+1, ..., Sq yq})
-/// and {yn+1, ..., yq} subsetof {xn+1, ..., xm}
+/// Named Function Types:
+/// T0 is U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn,
+///   {r0n+1 Vn+1 xn+1, ..., r0m Vm xm}) where r0j is empty or required for j in
+///   n+1...m
+/// and T1 is U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ...,
+///   Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq}) where r1j is empty or required
+///   for j in n+1...q
+/// and {yn+1, ... , yq} subsetof {xn+1, ... , xm}
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk] for i in 0...n
 /// and Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk] for i in n+1...q, yj = xi
+/// and for each j such that r0j is required, then there exists an i in n+1...q
+///   such that xj = yi, and r1i is required
 /// and U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]
 /// and B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk] for i in 0...k
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
+///
 /// @description Check that if B0i[Z0/X0, ..., Zk/Xk] !== B1i[Z0/Y0, ..., Zk/Yk]
 /// for any i in 0...k, then T0 is not a subtype of T1. Test generic types
 /// @author sgrekhov@unipro.ru

--- a/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A61.dart
+++ b/LanguageFeatures/Subtyping/test_types/named_function_types_fail_A61.dart
@@ -20,20 +20,9 @@
 /// where the Zi are fresh type variables with bounds B0i[Z0/X0, ..., Zk/Xk]
 ///
 /// @description Check that if `T0` has a required named argument and `T1` has
-/// not required named argument of the same type and with the same name, then
-/// anyway `T0` is a subtype of `T1`.
+/// an optional named argument of the same type and with the same name, then
+/// `T0` is not a subtype of `T1`.
 /// @author sgrekhov22@gmail.com
-///
-/// @description Check that if type T0 is not a subtype of a type T1, then
-/// instance of T0 cannot be assigned to the to local variable of type T1.
-/// Assignment to local variable is tested.
-/// @author sgrekhov@unipro.ru
-/// @author ngl@unipro.ru
-///
-/// This test is generated from test_types/named_function_types_fail_A061.dart and 
-/// test_cases/local_variable_fail_x01.dart. Don't modify it! 
-/// If you need to change this test, then change one of the files above and then 
-/// run generator/generator.dart to regenerate the tests.
 
 typedef void F0({required int i});
 typedef void F1({int i});
@@ -42,40 +31,9 @@ void f0Instance({required int i}) {}
 void f1Instance({int i = 0}) {}
 
 F0 t0Instance = f0Instance;
+F1 t1Instance = f1Instance;
 
-class LocalVariableTest {
-  LocalVariableTest() {
-    F1 t1 = t0Instance;
-//           ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
+const t1Default = f1Instance;
 
-  test() {
-    F1 t1 = t0Instance;
-//           ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-
-  static staticTest() {
-    F1 t1 = t0Instance;
-//           ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-}
-
-main() {
-  F1 t1 = t0Instance;
-//         ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  bar () {
-    F1 t1 = t0Instance;
-//           ^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  }
-}
+//# @T0 = F0
+//# @T1 = F1


### PR DESCRIPTION
Subtypint tests are generated. So, it makes sense to review changes outside of `generated` folders. Other tests are made from them