### PR TITLE
#2094. Remove mixin-related TODO and @dart=2.19

### DIFF
--- a/Language/Classes/definition_t01.dart
+++ b/Language/Classes/definition_t01.dart
@@ -11,11 +11,6 @@
 /// to this syntax do not cause any errors and can be instantiated.
 /// @author msyabro
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 abstract class I {}
 abstract class J {}
 abstract class IT<T> {}
@@ -23,10 +18,10 @@ abstract class IT<T> {}
 class A {}
 class B extends A {}
 class C extends B implements I {}
-class D implements I, J {}
+mixin class D implements I, J {}
 class E extends D implements I, J {}
 
-class F<T> {}
+mixin class F<T> {}
 class G<S, T> extends F<T> {}
 class H<T> implements I {}
 class K extends G<int, int> implements I {}

--- a/Language/Classes/definition_t23.dart
+++ b/Language/Classes/definition_t23.dart
@@ -12,11 +12,6 @@
 /// errors and can be instantiated.
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 @A() abstract class I1<T> = A1 with B1;
 abstract class J1<T> = A1 with B1;
 @B() class X1<T> = B1 with A1;
@@ -30,8 +25,8 @@ class Y2 = A1 with B1;
 @B() class X3<T> = B1 with A1 implements A1;
 class Y3<T> = B1 with A1 implements A1;
 
-abstract class A1 {}
-class B1 {}
+abstract mixin class A1 {}
+mixin class B1 {}
 
 @B.fromInt(1) class A {
   const A();

--- a/Language/Classes/mixins_t01.dart
+++ b/Language/Classes/mixins_t01.dart
@@ -10,20 +10,14 @@
 /// mixins:
 ///   with typeList
 /// ;
-/// @description Checks that a correct class declaration with mixins is 
-/// accepted.
+/// @description Checks that a correct class declaration with mixins is accepted
 /// @author kaigorodov
-
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
 
 class A {
   int a() {return 1;}
 }
 
-class M {
+mixin M {
   var m;
 }
 

--- a/Language/Classes/mixins_t02.dart
+++ b/Language/Classes/mixins_t02.dart
@@ -10,23 +10,19 @@
 /// mixins:
 ///   with typeList
 /// ;
-/// @description Checks that mixins without superclass are allowed
+/// @description Checks that mixins can be specified without superclass (`with`
+/// without `extends`)
 /// @author kaigorodov
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
-class A {
-  int a() {return 1;}
+mixin class A {
+  int a() => 1;
 }
 
-class M {
+mixin M {
   var m;
 }
 
-class AM with A,M {
+class AM with A, M {
 }
 
 main() {

--- a/Language/Expressions/Lookup/Getter_and_Setter_Lookup/definition_t08.dart
+++ b/Language/Expressions/Lookup/Getter_and_Setter_Lookup/definition_t08.dart
@@ -9,21 +9,17 @@
 /// has a superclass S, then the result of the lookup is the result of looking
 /// up getter (respectively setter) m in S with respect to L. Otherwise, we say
 /// that the lookup has failed.
+///
 /// @description Checks that implicit getters and setters are found during
 /// lookup.
 /// @author ilya
-
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
 
 import '../../../../Utils/expect.dart';
 
 class A {
 }
 
-class M {
+mixin M {
   int mValue = 0;
   int get m => -1;
   void set m(int val) {

--- a/Language/Expressions/Lookup/Method_Lookup/instance_t03.dart
+++ b/Language/Expressions/Lookup/Method_Lookup/instance_t03.dart
@@ -8,20 +8,14 @@
 /// 
 /// @description Checks that result of a lookup of a method m in object o
 /// is method m in class C, where C is class of o
-/// 
 /// @author sgrekhov@unipro.ru
-
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
 
 import '../../../../Utils/expect.dart';
 
 class A {
 }
 
-class M {
+mixin M {
   int m1() => 1;
 }
 

--- a/Language/Expressions/Lookup/Method_Lookup/superclass_t09.dart
+++ b/Language/Expressions/Lookup/Method_Lookup/superclass_t09.dart
@@ -8,21 +8,17 @@
 /// if C has a superclass S, then the result of the lookup is the result of
 /// looking up m in S with respect to L. Otherwise, we say that the method
 /// lookup has failed.
-/// @description Checks that methods added to the superclass by mixin are
-/// found during lookup
+///
+/// @description Checks that methods added to the superclass by mixin are found
+/// during lookup
 /// @author sgrekhov@unipro.ru
-
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
 
 import '../../../../Utils/expect.dart';
 
 class A {
 }
 
-class M {
+mixin class M {
   int m() => 1;
 }
 

--- a/Language/Expressions/Method_Invocation/Ordinary_Invocation/accessible_instance_member_t07.dart
+++ b/Language/Expressions/Method_Invocation/Ordinary_Invocation/accessible_instance_member_t07.dart
@@ -20,9 +20,6 @@
 /// that extends class Function and doesn't implement method call.
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
 // @dart=2.19
 
 import '../../../../Utils/expect.dart';

--- a/Language/Expressions/Method_Invocation/Ordinary_Invocation/accessible_instance_member_t08.dart
+++ b/Language/Expressions/Method_Invocation/Ordinary_Invocation/accessible_instance_member_t08.dart
@@ -15,14 +15,12 @@
 ///   subclass of Function that fails to implement call will also provoke a
 ///   warning, as this exemption is limited to type Function, and does not apply
 ///   to its subtypes.
+///
 /// @description Checks that there is no static warning if T is a local function
 /// and m is a method call. Local function is declared in an instance method of
 /// a class that extends class Function and implements method call.
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
 // @dart=2.19
 
 import '../../../../Utils/expect.dart';

--- a/Language/Expressions/Property_Extraction/Super_Getter_Access_and_Method_Closurization/method_extraction_t03.dart
+++ b/Language/Expressions/Property_Extraction/Super_Getter_Access_and_Method_Closurization/method_extraction_t03.dart
@@ -9,21 +9,17 @@
 /// looking up method m in Sdynamic with respect to the current library L. If
 /// method lookup succeeds then i evaluates to the closurization of method f
 /// with respect to superclass Sdynamic.
+///
 /// @description Check that if method lookup succeeds then result of the
 /// property extraction is method that was found in a mixin.
 /// @author sgrekhov@unipro.ru
-
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
 
 import '../../../../Utils/expect.dart';
 
 class A {
 }
 
-class M {
+mixin class M {
   int m() => 1;
 }
 

--- a/Language/Generics/Superbounded_types/class_A04_t03.dart
+++ b/Language/Generics/Superbounded_types/class_A04_t03.dart
@@ -8,16 +8,12 @@
 /// [T] is an immediate subterm of an [extends] clause of a class (10.8), or it
 /// occurs as an element in the type list of an [implements] clause (10.9), or a
 /// [with] clause (10).
+///
 /// @description Checks that exception is thrown if super-bounded class occurs in
 /// as an element in the type list of [with] clause
 /// @author iarkh@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
-class A<T extends A<T>> {}
+mixin class A<T extends A<T>> {}
 class C {}
 
 class B1 extends C with A {}

--- a/Language/Types/Interface_Types/direct_supertype_t04.dart
+++ b/Language/Types/Interface_Types/direct_supertype_t04.dart
@@ -9,19 +9,15 @@
 /// • If I is listed in the implements clause of J
 /// • If I is listed in the with clause of J
 /// • If J is a mixin application of the mixin of I.
+///
 /// @description Checks that a type listed in the with clause of another class
 /// is its supertype.
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../../Utils/expect.dart";
 
 class I {}
-class M {}
+mixin M {}
 class J extends I with M {}
 
 main() {

--- a/Language/Types/Interface_Types/direct_supertype_t05.dart
+++ b/Language/Types/Interface_Types/direct_supertype_t05.dart
@@ -9,19 +9,15 @@
 /// • If I is listed in the implements clause of J
 /// • If I is listed in the with clause of J
 /// • If J is a mixin application of the mixin of I.
+///
 /// @description Checks that a mixin aplication of the mixin of I is its
 /// supertype.
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../../Utils/expect.dart";
 
 class I {}
-class M {}
+mixin M {}
 class J = I with M;
 
 main() {

--- a/LanguageFeatures/Super-mixins/implementation_t07.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t07.dart
@@ -15,12 +15,7 @@
 /// to the class with mixins only one of the interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
-class B {
+mixin class B {
   String get gb1 => "B.gb1";
 }
 abstract class C {

--- a/LanguageFeatures/Super-mixins/implementation_t08.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t08.dart
@@ -16,12 +16,7 @@
 /// interface is not abstract
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
-class B {
+mixin class B {
   String get gb1 => "B.gb1";
 }
 class C {

--- a/LanguageFeatures/Super-mixins/mixin_application_t05.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t05.dart
@@ -14,16 +14,11 @@
 /// declaration. Test 'mixin' implementation of 'on' clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 String console = "";
 
-class A {
+mixin class A {
   String get a1 => "A.a1";
   set a2(String v) {
     console = "A:$v";

--- a/LanguageFeatures/Super-mixins/mixin_application_t06.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t06.dart
@@ -15,11 +15,6 @@
 /// 'implements' part of the mixin
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 String console = "";
@@ -32,6 +27,7 @@ class I {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 1);
 }
+
 abstract class J {
   String get j1;
   void set j2(String v);
@@ -39,7 +35,7 @@ abstract class J {
   String operator -() => j1.substring(0, 1);
 }
 
-class A {
+mixin class A {
   String get a1 => "A.a1";
   set a2(String v) {
     console = "A:$v";

--- a/LanguageFeatures/Super-mixins/mixin_application_t11.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t11.dart
@@ -14,11 +14,6 @@
 /// declaration. Test 'mixin' implementation of 'on' clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 class S {}
@@ -28,7 +23,7 @@ class Y extends T {}
 
 String console = "";
 
-class A<T> {
+mixin class A<T> {
   String get a1 => "A.a1";
   set a2(String v) {
     console = "A:$v";

--- a/LanguageFeatures/Super-mixins/mixin_application_t12.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t12.dart
@@ -15,11 +15,6 @@
 /// 'implements' part of the mixin
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 class S {}
@@ -37,6 +32,7 @@ class I<T> {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 1);
 }
+
 abstract class J<T> {
   String get j1;
   void set j2(String v);
@@ -44,7 +40,7 @@ abstract class J<T> {
   String operator -() => j1.substring(0, 1);
 }
 
-class A<T> {
+mixin class A<T> {
   String get a1 => "A.a1";
   set a2(String v) {
     console = "A:$v";
@@ -52,12 +48,14 @@ class A<T> {
   String a3() => "A.a3";
   String operator +(A v) => a1.substring(0, 1);
 }
+
 abstract class B<T> extends A<T> {
   String get b1;
   void set b2(String v);
   String b3();
   String operator -(B v) => b1.substring(0, 1);
 }
+
 class C<T1, T2> extends B<T1> with A<T1> implements J<T2> {
   String get b1 => "C.b1";
   void set b2(String v) {

--- a/LanguageFeatures/Super-mixins/super_invocation_t03.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t03.dart
@@ -12,14 +12,9 @@
 /// Test getters and "mixin" implementation of "on" clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
-class A {
+mixin class A {
   String get a => "A.a";
 }
 

--- a/LanguageFeatures/Super-mixins/super_invocation_t06.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t06.dart
@@ -12,14 +12,9 @@
 /// Test getters and "mixin" implementation of "on" clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
-class A {
+mixin class A {
   String a1() => "A.a1";
   String a2() {
     return "A.a2";

--- a/LanguageFeatures/Super-mixins/super_invocation_t09.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t09.dart
@@ -12,11 +12,6 @@
 /// Test setters and "mixin" implementation of "on" clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 String console = "";
@@ -27,7 +22,7 @@ class A {
   }
 }
 
-class B {
+mixin class B {
   void set b1(String s) {
     console = "B:$s";
   }

--- a/LanguageFeatures/Super-mixins/super_invocation_t12.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t12.dart
@@ -12,11 +12,6 @@
 /// Test property and "mixin" implementation of "on" clause interfaces
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 String console = "";
@@ -25,7 +20,7 @@ class A {
   String a = "A.a";
 }
 
-class B {
+mixin class B {
   String b = "B.b";
 }
 

--- a/LanguageFeatures/Super-mixins/super_invocation_t15.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t15.dart
@@ -13,11 +13,6 @@
 /// parameters
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
 class S {}
@@ -25,7 +20,7 @@ class T {}
 class X extends S {}
 class Y extends T {}
 
-class A<T1> {
+mixin class A<T1> {
   T1 a(T1 t) => t;
 }
 

--- a/LanguageFeatures/Super-mixins/super_invocation_t18.dart
+++ b/LanguageFeatures/Super-mixins/super_invocation_t18.dart
@@ -12,14 +12,9 @@
 /// Test operators and "mixin" implementation of "on" clause interfaces
 /// @author ngl@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 import "../../Utils/expect.dart";
 
-class A {
+mixin class A {
   int va = 1;
   int operator +(A v1) {return v1.va + 10000;}
 }

--- a/LanguageFeatures/nnbd/weak/import_legacy_lib_A01_t09.dart
+++ b/LanguageFeatures/nnbd/weak/import_legacy_lib_A01_t09.dart
@@ -13,16 +13,11 @@
 /// @description Check that all fields of legacy type T* are nullable.
 /// @author sgrekhov@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 // Requirements=nnbd-weak
 
 import "legacy_lib.dart";
 
-class MyMx {
+mixin class MyMx {
   String sMx = "Let it be";
 }
 

--- a/LanguageFeatures/nnbd/weak/overriding/override_checking_A01_opted_in_futureor_lib.dart
+++ b/LanguageFeatures/nnbd/weak/overriding/override_checking_A01_opted_in_futureor_lib.dart
@@ -8,11 +8,6 @@
 ///
 /// @author iarkh@unipro.ru
 
-// TODO(https://github.com/dart-lang/sdk/issues/51557): Decide if the mixins
-// being applied in this test should be "mixin", "mixin class" or the test
-// should be left at 2.19.
-// @dart=2.19
-
 library override_opted_in_lib;
 
 import "dart:async";


### PR DESCRIPTION
Main part of the changes is to remove `// @dart=2.19` and to replace `class` by `mixin class` where necessary