### PR TITLE
Fixes #2087. Reorder covariance tests to make maintenance easier

### DIFF
--- a/Language/Classes/Instance_Methods/covariant_A01_t02.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t02.dart
@@ -8,29 +8,51 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member
+/// @description Checks that it is a compile-time error if there is a member
 /// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is a subtype of `p`
+/// name but with the parameter which is not a subtype or supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(num a) {}
-  void m2([num a = 0]) {}
-  void m3({num a = 0}) {}
-  void m4({required num a}) {}
+  void m1(covariant num a) {}
+  void m2([covariant num a = 0]) {}
+  void m3({covariant a = 0}) {}
+  void m4({required covariant num a}) {}
 
-  void set s(num n) {}
-  void operator +(num n) {}
+  void set s(covariant num n) {}
+  void operator +(covariant num n) {}
 }
 
 class C extends A {
-  void m1(covariant Object a) {}
-  void m2([covariant Object a = ""]) {}
-  void m3({covariant Object a = ""}) {}
-  void m4({required covariant Object a}) {}
+  void m1(String a) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
 
-  void set s(covariant Object s) {}
-  void operator +(covariant Object n) {}
+  void m2([String a = ""]) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m3({String a = ""}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m4({required String a}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void set s(String s) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void operator +(String n) {}
+//              ^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 main() {

--- a/Language/Classes/Instance_Methods/covariant_A01_t03.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t03.dart
@@ -8,9 +8,9 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member with a
-/// covariant parameter `p` and there is another member with the same name but
-/// with the parameter which is a supertype of `p`
+/// @description Checks that it is a compile-time error if there is a member
+/// with a covariant parameter `p` and there is another member with the same
+/// name but with the parameter which is not a subtype or supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
@@ -20,19 +20,42 @@ class A {
   void m4({required num a}) {}
 
   void set s(num n) {}
+
   void operator +(num n) {}
 }
 
-class C extends A {
-  void m1(covariant int a) {}
-  void m2([covariant int a = 1]) {}
-  void m3({covariant int a = 1}) {}
-  void m4({required covariant int a}) {}
+mixin M on A {
+  void m1(covariant String a) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
 
-  void set s(covariant int s) {}
-  void operator +(covariant int n) {}
+  void m2([covariant String a = ""]) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m3({covariant String a = ""}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m4({required covariant String a}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void set s(covariant String s) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void operator +(covariant String n) {}
+//              ^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 main() {
-  print(C);
+  print(M);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t04.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t04.dart
@@ -23,7 +23,7 @@ class A {
   void operator +(covariant num n) {}
 }
 
-class C extends A {
+mixin M on A {
   void m1(String a) {}
 //     ^^
 // [analyzer] unspecified
@@ -56,5 +56,5 @@ class C extends A {
 }
 
 main() {
-  print(C);
+  print(M);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t07.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t07.dart
@@ -8,31 +8,63 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member
+/// @description Checks that it is a compile-time error if there is a member
 /// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is a subtype of `p`
+/// name but with the parameter which is not a subtype or supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(covariant Object a) {}
-  void m2([covariant Object a = ""]) {}
-  void m3({covariant Object a = ""}) {}
-  void m4({required covariant Object a}) {}
-
-  void set s(covariant Object s) {}
-  void operator +(covariant Object n) {}
-}
-
-class C extends A {
   void m1(num a) {}
   void m2([num a = 0]) {}
-  void m3({num a = 0}) {}
+  void m3({a = 0}) {}
   void m4({required num a}) {}
 
   void set s(num n) {}
   void operator +(num n) {}
 }
 
+abstract class B {
+  void m1(covariant String a);
+  void m2([covariant String a = ""]);
+  void m3({covariant String a = ""});
+  void m4({required covariant String a});
+
+  void set s(covariant String s);
+  void operator +(covariant String n);
+}
+
+mixin M on A implements B {
+  void m1(int a) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m2([int a = 1]) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m3({int a = 1}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void m4({required int a}) {}
+//     ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void set s(int s) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void operator +(int n) {}
+//              ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
 main() {
-  print(C);
+  print(M);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t08.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t08.dart
@@ -23,24 +23,14 @@ class A {
   void operator +(num n) {}
 }
 
-abstract class B {
-  void m1(covariant Object a);
-  void m2([covariant Object a = ""]);
-  void m3({covariant Object a = ""});
-  void m4({required covariant Object a});
+class C extends A {
+  void m1(covariant Object a) {}
+  void m2([covariant Object a = ""]) {}
+  void m3({covariant Object a = ""}) {}
+  void m4({required covariant Object a}) {}
 
-  void set s(covariant Object s);
-  void operator +(covariant Object n);
-}
-
-class C extends A implements B {
-  void m1(int a) {}
-  void m2([int a = 0]) {}
-  void m3({int a = 0}) {}
-  void m4({required int a}) {}
-
-  void set s(int n) {}
-  void operator +(int n) {}
+  void set s(covariant Object s) {}
+  void operator +(covariant Object n) {}
 }
 
 main() {

--- a/Language/Classes/Instance_Methods/covariant_A01_t09.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t09.dart
@@ -14,6 +14,16 @@
 /// @author sgrekhov22@gmail.com
 
 class A {
+  void m1(covariant Object a) {}
+  void m2([covariant Object a = ""]) {}
+  void m3({covariant Object a = ""}) {}
+  void m4({required covariant Object a}) {}
+
+  void set s(covariant Object s) {}
+  void operator +(covariant Object n) {}
+}
+
+class C extends A {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -21,26 +31,6 @@ class A {
 
   void set s(num n) {}
   void operator +(num n) {}
-}
-
-abstract mixin class B {
-  void m1(covariant Object a);
-  void m2([covariant Object a = ""]);
-  void m3({covariant Object a = ""});
-  void m4({required covariant Object a});
-
-  void set s(covariant Object s);
-  void operator +(covariant Object n);
-}
-
-class C extends A with B {
-  void m1(int a) {}
-  void m2([int a = 0]) {}
-  void m3({int a = 0}) {}
-  void m4({required int a}) {}
-
-  void set s(int n) {}
-  void operator +(int n) {}
 }
 
 main() {

--- a/Language/Classes/Instance_Methods/covariant_A01_t10.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t10.dart
@@ -8,22 +8,12 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member with a
-/// covariant parameter `p` and there is another member with the same name but
-/// with the parameter which is a supertype of `p`
+/// @description Checks that it is not an error if there is a member
+/// with a covariant parameter `p` and there is another member with the same
+/// name but with the parameter which is a subtype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(covariant int a) {}
-  void m2([covariant int a = 1]) {}
-  void m3({covariant int a = 1}) {}
-  void m4({required covariant int a}) {}
-
-  void set s(covariant int s) {}
-  void operator +(covariant int n) {}
-}
-
-class C extends A {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -31,6 +21,26 @@ class C extends A {
 
   void set s(num n) {}
   void operator +(num n) {}
+}
+
+abstract class B {
+  void m1(covariant Object a);
+  void m2([covariant Object a = ""]);
+  void m3({covariant Object a = ""});
+  void m4({required covariant Object a});
+
+  void set s(covariant Object s);
+  void operator +(covariant Object n);
+}
+
+class C extends A implements B {
+  void m1(int a) {}
+  void m2([int a = 0]) {}
+  void m3({int a = 0}) {}
+  void m4({required int a}) {}
+
+  void set s(int n) {}
+  void operator +(int n) {}
 }
 
 main() {

--- a/Language/Classes/Instance_Methods/covariant_A01_t11.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t11.dart
@@ -8,32 +8,12 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member with a
-/// covariant parameter `p` and there is another member with the same name but
-/// with the parameter which is a supertype of `p`
+/// @description Checks that it is not an error if there is a member
+/// with a covariant parameter `p` and there is another member with the same
+/// name but with the parameter which is a subtype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(Object a) {}
-  void m2([Object a = 1]) {}
-  void m3({Object a = 1}) {}
-  void m4({required Object a}) {}
-
-  void set s(Object s) {}
-  void operator +(Object n) {}
-}
-
-abstract class B {
-  void m1(covariant int a);
-  void m2([covariant int a = 1]);
-  void m3({covariant int a = 1});
-  void m4({required covariant int a});
-
-  void set s(covariant int s);
-  void operator +(covariant int n);
-}
-
-class C extends A implements B {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -41,6 +21,26 @@ class C extends A implements B {
 
   void set s(num n) {}
   void operator +(num n) {}
+}
+
+abstract mixin class B {
+  void m1(covariant Object a);
+  void m2([covariant Object a = ""]);
+  void m3({covariant Object a = ""});
+  void m4({required covariant Object a});
+
+  void set s(covariant Object s);
+  void operator +(covariant Object n);
+}
+
+class C extends A with B {
+  void m1(int a) {}
+  void m2([int a = 0]) {}
+  void m3({int a = 0}) {}
+  void m4({required int a}) {}
+
+  void set s(int n) {}
+  void operator +(int n) {}
 }
 
 main() {

--- a/Language/Classes/Instance_Methods/covariant_A01_t12.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t12.dart
@@ -8,32 +8,12 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member with a
-/// covariant parameter `p` and there is another member with the same name but
-/// with the parameter which is a supertype of `p`
+/// @description Checks that it is not an error if there is a member
+/// with a covariant parameter `p` and there is another member with the same
+/// name but with the parameter which is a subtype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(Object a) {}
-  void m2([Object a = 1]) {}
-  void m3({Object a = 1}) {}
-  void m4({required Object a}) {}
-
-  void set s(Object s) {}
-  void operator +(Object n) {}
-}
-
-abstract mixin class B {
-  void m1(covariant int a);
-  void m2([covariant int a = 1]);
-  void m3({covariant int a = 1});
-  void m4({required covariant int a});
-
-  void set s(covariant int s);
-  void operator +(covariant int n);
-}
-
-class C extends A with B {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -42,6 +22,18 @@ class C extends A with B {
   void set s(num n) {}
   void operator +(num n) {}
 }
+
+mixin M on A {
+  void m1(covariant Object a) {}
+  void m2([covariant Object a = ""]) {}
+  void m3({covariant Object a = ""}) {}
+  void m4({required covariant Object a}) {}
+
+  void set s(covariant Object s) {}
+  void operator +(covariant Object n) {}
+}
+
+class C = A with M;
 
 main() {
   print(C);

--- a/Language/Classes/Instance_Methods/covariant_A01_t13.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t13.dart
@@ -8,54 +8,33 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is a compile-time error if there is a member
+/// @description Checks that it is not an error if there is a member
 /// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is not a subtype or supertype of `p`
+/// name but with the parameter which is a subtype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
+  void m1(covariant Object a) {}
+  void m2([covariant Object a = ""]) {}
+  void m3({covariant Object a = ""}) {}
+  void m4({required covariant Object a}) {}
+
+  void set s(covariant Object s) {}
+  void operator +(covariant Object n) {}
+}
+
+mixin M on A {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
   void m4({required num a}) {}
 
   void set s(num n) {}
-
   void operator +(num n) {}
 }
 
-mixin M on A {
-  void m1(covariant String a) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m2([covariant String a = ""]) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m3({covariant String a = ""}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m4({required covariant String a}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void set s(covariant String s) {}
-//         ^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void operator +(covariant String n) {}
-//              ^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
+class C = A with M;
 
 main() {
-  print(M);
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t14.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t14.dart
@@ -23,14 +23,24 @@ class A {
   void operator +(num n) {}
 }
 
-mixin M on A {
-  void m1(covariant Object a) {}
-  void m2([covariant Object a = ""]) {}
-  void m3({covariant Object a = ""}) {}
-  void m4({required covariant Object a}) {}
+abstract class B {
+  void m1(covariant Object a);
+  void m2([covariant Object a = ""]);
+  void m3({covariant Object a = ""});
+  void m4({required covariant Object a});
 
-  void set s(covariant Object s) {}
-  void operator +(covariant Object n) {}
+  void set s(covariant Object s);
+  void operator +(covariant Object n);
+}
+
+mixin M on A implements B {
+  void m1(int a) {}
+  void m2([int a = 0]) {}
+  void m3({int a = 0}) {}
+  void m4({required int a}) {}
+
+  void set s(int n) {}
+  void operator +(int n) {}
 }
 
 class C = A with M;

--- a/Language/Classes/Instance_Methods/covariant_A01_t15.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t15.dart
@@ -8,9 +8,9 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member with a
-/// covariant parameter `p` and there is another member with the same name but
-/// with the parameter which is a supertype of `p`
+/// @description Checks that it is not an error if there is a member
+/// with a covariant parameter `p` and there is another member with the same
+/// name but with the parameter which is a subtype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
@@ -23,17 +23,25 @@ class A {
   void operator +(num n) {}
 }
 
-mixin M on A {
-  void m1(covariant int a) {}
-  void m2([covariant int a = 1]) {}
-  void m3({covariant int a = 1}) {}
-  void m4({required covariant int a}) {}
+mixin B on A {
+  void m1(covariant Object a);
+  void m2([covariant Object a = ""]);
+  void m3({covariant Object a = ""});
+  void m4({required covariant Object a});
 
-  void set s(covariant int s) {}
-  void operator +(covariant int n) {}
+  void set s(covariant Object s);
+  void operator +(covariant Object n);
 }
 
-class C = A with M;
+class C extends A with B {
+  void m1(int a) {}
+  void m2([int a = 0]) {}
+  void m3({int a = 0}) {}
+  void m4({required int a}) {}
+
+  void set s(int n) {}
+  void operator +(int n) {}
+}
 
 main() {
   print(C);

--- a/Language/Classes/Instance_Methods/covariant_A01_t16.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t16.dart
@@ -8,53 +8,31 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is a compile-time error if there is a member
-/// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is not a subtype or supertype of `p`
+/// @description Checks that it is not an error if there is a member with a
+/// covariant parameter `p` and there is another member with the same name but
+/// with the parameter which is a supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(covariant num a) {}
-  void m2([covariant num a = 0]) {}
-  void m3({covariant a = 0}) {}
-  void m4({required covariant num a}) {}
+  void m1(num a) {}
+  void m2([num a = 0]) {}
+  void m3({num a = 0}) {}
+  void m4({required num a}) {}
 
-  void set s(covariant num n) {}
-  void operator +(covariant num n) {}
+  void set s(num n) {}
+  void operator +(num n) {}
 }
 
-mixin M on A {
-  void m1(String a) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C extends A {
+  void m1(covariant int a) {}
+  void m2([covariant int a = 1]) {}
+  void m3({covariant int a = 1}) {}
+  void m4({required covariant int a}) {}
 
-  void m2([String a = ""]) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m3({String a = ""}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m4({required String a}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void set s(String s) {}
-//         ^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void operator +(String n) {}
-//              ^
-// [analyzer] unspecified
-// [cfe] unspecified
+  void set s(covariant int s) {}
+  void operator +(covariant int n) {}
 }
 
 main() {
-  print(M);
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t17.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t17.dart
@@ -8,63 +8,31 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is a compile-time error if there is a member
-/// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is not a subtype or supertype of `p`
+/// @description Checks that it is not an error if there is a member with a
+/// covariant parameter `p` and there is another member with the same name but
+/// with the parameter which is a supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
+  void m1(covariant int a) {}
+  void m2([covariant int a = 1]) {}
+  void m3({covariant int a = 1}) {}
+  void m4({required covariant int a}) {}
+
+  void set s(covariant int s) {}
+  void operator +(covariant int n) {}
+}
+
+class C extends A {
   void m1(num a) {}
   void m2([num a = 0]) {}
-  void m3({a = 0}) {}
+  void m3({num a = 0}) {}
   void m4({required num a}) {}
 
   void set s(num n) {}
   void operator +(num n) {}
 }
 
-abstract class B {
-  void m1(covariant String a);
-  void m2([covariant String a = ""]);
-  void m3({covariant String a = ""});
-  void m4({required covariant String a});
-
-  void set s(covariant String s);
-  void operator +(covariant String n);
-}
-
-mixin M on A implements B {
-  void m1(int a) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m2([int a = 1]) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m3({int a = 1}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void m4({required int a}) {}
-//     ^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void set s(int s) {}
-//         ^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-  void operator +(int n) {}
-//              ^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
-
 main() {
-  print(M);
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/covariant_A01_t18.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t18.dart
@@ -8,22 +8,32 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member
-/// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is a subtype of `p`
+/// @description Checks that it is not an error if there is a member with a
+/// covariant parameter `p` and there is another member with the same name but
+/// with the parameter which is a supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
-  void m1(covariant Object a) {}
-  void m2([covariant Object a = ""]) {}
-  void m3({covariant Object a = ""}) {}
-  void m4({required covariant Object a}) {}
+  void m1(Object a) {}
+  void m2([Object a = 1]) {}
+  void m3({Object a = 1}) {}
+  void m4({required Object a}) {}
 
-  void set s(covariant Object s) {}
-  void operator +(covariant Object n) {}
+  void set s(Object s) {}
+  void operator +(Object n) {}
 }
 
-mixin M on A {
+abstract class B {
+  void m1(covariant int a);
+  void m2([covariant int a = 1]);
+  void m3({covariant int a = 1});
+  void m4({required covariant int a});
+
+  void set s(covariant int s);
+  void operator +(covariant int n);
+}
+
+class C extends A implements B {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -32,8 +42,6 @@ mixin M on A {
   void set s(num n) {}
   void operator +(num n) {}
 }
-
-class C = A with M;
 
 main() {
   print(C);

--- a/Language/Classes/Instance_Methods/covariant_A01_t19.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t19.dart
@@ -8,12 +8,32 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member
-/// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is a subtype of `p`
+/// @description Checks that it is not an error if there is a member with a
+/// covariant parameter `p` and there is another member with the same name but
+/// with the parameter which is a supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
+  void m1(Object a) {}
+  void m2([Object a = 1]) {}
+  void m3({Object a = 1}) {}
+  void m4({required Object a}) {}
+
+  void set s(Object s) {}
+  void operator +(Object n) {}
+}
+
+abstract mixin class B {
+  void m1(covariant int a);
+  void m2([covariant int a = 1]);
+  void m3({covariant int a = 1});
+  void m4({required covariant int a});
+
+  void set s(covariant int s);
+  void operator +(covariant int n);
+}
+
+class C extends A with B {
   void m1(num a) {}
   void m2([num a = 0]) {}
   void m3({num a = 0}) {}
@@ -22,28 +42,6 @@ class A {
   void set s(num n) {}
   void operator +(num n) {}
 }
-
-abstract class B {
-  void m1(covariant Object a);
-  void m2([covariant Object a = ""]);
-  void m3({covariant Object a = ""});
-  void m4({required covariant Object a});
-
-  void set s(covariant Object s);
-  void operator +(covariant Object n);
-}
-
-mixin M on A implements B {
-  void m1(int a) {}
-  void m2([int a = 0]) {}
-  void m3({int a = 0}) {}
-  void m4({required int a}) {}
-
-  void set s(int n) {}
-  void operator +(int n) {}
-}
-
-class C = A with M;
 
 main() {
   print(C);

--- a/Language/Classes/Instance_Methods/covariant_A01_t20.dart
+++ b/Language/Classes/Instance_Methods/covariant_A01_t20.dart
@@ -8,9 +8,9 @@
 /// that m′′ has a parameter p′′ that corresponds to p, unless the type of p is
 /// a subtype or a supertype of the type of p′′
 ///
-/// @description Checks that it is not an error if there is a member
-/// with a covariant parameter `p` and there is another member with the same
-/// name but with the parameter which is a subtype of `p`
+/// @description Checks that it is not an error if there is a member with a
+/// covariant parameter `p` and there is another member with the same name but
+/// with the parameter which is a supertype of `p`
 /// @author sgrekhov22@gmail.com
 
 class A {
@@ -23,25 +23,17 @@ class A {
   void operator +(num n) {}
 }
 
-mixin B on A {
-  void m1(covariant Object a);
-  void m2([covariant Object a = ""]);
-  void m3({covariant Object a = ""});
-  void m4({required covariant Object a});
+mixin M on A {
+  void m1(covariant int a) {}
+  void m2([covariant int a = 1]) {}
+  void m3({covariant int a = 1}) {}
+  void m4({required covariant int a}) {}
 
-  void set s(covariant Object s);
-  void operator +(covariant Object n);
+  void set s(covariant int s) {}
+  void operator +(covariant int n) {}
 }
 
-class C extends A with B {
-  void m1(int a) {}
-  void m2([int a = 0]) {}
-  void m3({int a = 0}) {}
-  void m4({required int a}) {}
-
-  void set s(int n) {}
-  void operator +(int n) {}
-}
+class C = A with M;
 
 main() {
   print(C);


### PR DESCRIPTION
Github shows doens of changes, but in fact, this is renaming of existing tests only. No any other changes, just renaming