### PR TITLE
#2142. Change dynamic semantics inline class tests to be extension type tests

### DIFF
--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A01_t01.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A01_t01.dart
@@ -2,26 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion At run time, for a given instance o typed as an inline type V,
+/// @assertion At run time, for a given instance o typed as an extension type V,
 /// there is no reification of V associated with o.
 ///
-/// @description Check that the run-time type of an instance of an inline class
-/// is its representation type
+/// @description Check that the run-time type of an instance of an extension
+/// type is its representation type
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inline-class
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T id;
-  V2(this.id);
-}
+extension type V2<T>(T id) {}
 
 main() {
   var v1 = V1(42);

--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A02_t01.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A02_t01.dart
@@ -2,35 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The run-time representation of a type argument which is an inline
-/// type V is the corresponding instantiated representation type.
+/// @assertion The run-time representation of a type argument which is an
+/// extension type V is the run-time representation of the corresponding
+/// instantiated representation type.
 ///
 /// @description Check that the run-time representation of a type argument which
-/// is an inline type V is the corresponding instantiated representation type.
+/// is an extension type is the the run-time representation of the corresponding
+/// instantiated representation type.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inline-class
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T id;
-  V2(this.id);
+extension type V2<T>(T id) {}
+
+class C<T> {
+  T x;
+  C(this.x);
 }
 
 main() {
-  List<V1> l1 = [];
-  Expect.equals(List<int>, l1.runtimeType);
-  (l1 as List<int>).add(42);
-  Expect.throws(() { (l1 as dynamic).add(3.14);});
+  var l1 = C<V1>(V1(1));
+  Expect.equals(C<int>, l1.runtimeType);
+  (l1 as C<int>).x = 42;
+  Expect.equals(42, l1.x);
+  Expect.throws(() { (l1 as dynamic).x = 3.14;});
 
-  List<V2<String>> l2 = [];
-  Expect.equals(List<String>, l2.runtimeType);
-  (l2 as List<String>).add("42");
-  Expect.throws(() { (l2 as dynamic).add(42);});
+  C<V2<String>> l2 = C<V2<String>>(V2("42"));
+  Expect.equals(C<String>, l2.runtimeType);
+  (l2 as C<String>).x = "answer";
+  Expect.throws(() { (l2 as dynamic).x = 42;});
 }

--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A03_t01.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A03_t01.dart
@@ -2,27 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A type test, o is U or o is! U, and a type cast, o as U, where U
-/// is or contains an inline type, is performed at run time as a type test and
-/// type cast on the run-time representation of the inline type
+/// @assertion A type test, `o is U` or `o is! U`, and a type cast, `o as U`,
+/// where `U` is or contains an extension type, is performed at run time as a
+/// type test and type cast on the run-time representation of the extension type
 ///
 /// @description Check that at run time a type test, `o is U` or `o is! U` is
-/// performed as a type test on the run-time representation of the inline type
+/// performed as a type test on the run-time representation of the extension
+/// type
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inline-class
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T id;
-  V2(this.id);
-}
+extension type V2<T>(T id) {}
 
 void main() {
   var objects = [

--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A03_t02.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A03_t02.dart
@@ -2,27 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A type test, o is U or o is! U, and a type cast, o as U, where U
-/// is or contains an inline type, is performed at run time as a type test and
-/// type cast on the run-time representation of the inline type
+/// @assertion A type test, `o is U` or `o is! U`, and a type cast, `o as U`,
+/// where `U` is or contains an extension type, is performed at run time as a
+/// type test and type cast on the run-time representation of the extension type
 ///
 /// @description Check that at run time a type cast, `o as U` is performed as a
-/// type cast on the run-time representation of the inline type
+/// type cast on the run-time representation of the extension type
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inline-class
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T id;
-  V2(this.id);
-}
+extension type V2<T>(T id) {}
 
 bool testAsInt(Object instance) {
   try {

--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A04_t01.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A04_t01.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An inline type V used as an expression (a type literal) evaluates
-/// to the value of the corresponding instantiated representation type used as
-/// an expression.
+/// @assertion An extension type V used as an expression (a type literal)
+/// evaluates to the value of the extension type erasure of the representation
+/// type used as an expression
 ///
-/// @description Check that if an inline type `V` is used as an expression then
+/// @description Check that if an extension type is used as an expression then
 /// it evaluates to the value of the corresponding instantiated representation
 /// type
 /// @author sgrekhov22@gmail.com
@@ -15,15 +15,9 @@
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T Function(int) f;
-  V2(this.f);
-}
+extension type V2<T>(T Function(int) id) {}
 
 main() {
   Expect.equals(int, V1);

--- a/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A05_t01.dart
+++ b/LanguageFeatures/Inline-classes/dynamic_semantics_inline_class_A05_t01.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Consider an inline class declaration DV named Inline with
+/// @assertion Consider an extension type declaration DV named Name with
 /// representation name id and representation type R. Invocation of a
-/// non-redirecting generative inline class constructor proceeds as follows:
+/// non-redirecting generative extension type constructor proceeds as follows:
 /// A fresh, non-late, final variable v is created. An initializing formal
 /// this.id has the side-effect that it initializes v to the actual argument
 /// passed to this formal. An initializer list element of the form id = e or
@@ -13,23 +13,18 @@
 /// value of v. The value of the instance creation expression that gave rise to
 /// this constructor execution is the value of this.
 ///
-/// @description Check that during the execution of the constructor body, this
-/// and `id` are bound to the value of `v`
+/// @description Check that during the execution of the constructor body, `this`
+/// and `id` are bound to the value of `v`. Check the default constructor
+/// introduced by representation declaration
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inline-class
 
 import "../../Utils/expect.dart";
 
-inline class V1 {
-  final int id;
-  V1(this.id);
-}
+extension type V1(int id) {}
 
-inline class V2<T> {
-  final T id;
-  V2(this.id);
-}
+extension type V2<T>(T id) {}
 
 main() {
   int i = 42;


### PR DESCRIPTION
This also fixes https://github.com/dart-lang/co19/issues/2169