### PR TITLE
#2258. Update assertions of private fields promotion tests. Add new ones

### DIFF
--- a/LanguageFeatures/Private-fields-promotion/promotion_A01_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A01_t01.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met

--- a/LanguageFeatures/Private-fields-promotion/promotion_A01_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A01_t02.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test type variable

--- a/LanguageFeatures/Private-fields-promotion/promotion_A01_t03.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A01_t03.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test type variable

--- a/LanguageFeatures/Private-fields-promotion/promotion_A01_t04.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A01_t04.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test the case when there are other concrete

--- a/LanguageFeatures/Private-fields-promotion/promotion_A01_t05.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A01_t05.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test that the right variable is promoted

--- a/LanguageFeatures/Private-fields-promotion/promotion_A02_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A02_t01.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable even if it is late
 /// @author sgrekhov22@gmail.com

--- a/LanguageFeatures/Private-fields-promotion/promotion_A02_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A02_t02.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable even if it is late
 /// @author sgrekhov22@gmail.com

--- a/LanguageFeatures/Private-fields-promotion/promotion_A02_t03.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A02_t03.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,20 +12,26 @@
 /// - There is no implicit noSuchMethod forwarder with the same name elsewhere
 ///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @description Checks that an instance field is not promotable if it is an
+/// external field (which actually is a getter)
 /// @author sgrekhov22@gmail.com
+/// @issue 53426
 
 // SharedOptions=--enable-experiment=inference-update-2
 
-library promotion_A06_t04_lib;
-
 class C {
-  int? _x = 43;
+  external final int? _x;
 
-  void testC() {
-    print(_x);
+  void test() {
+    if (_x is int) {
+      _x.isOdd;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    }
   }
+}
+
+main() {
+  C().test();
 }

--- a/LanguageFeatures/Private-fields-promotion/promotion_A02_t04.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A02_t04.dart
@@ -12,7 +12,7 @@
 /// - There is no implicit noSuchMethod forwarder with the same name elsewhere
 ///   in the library.
 ///
-/// @description Checks that an instance field is promotable even if it is
+/// @description Checks that an instance field is not promotable if it is
 /// external
 /// @author sgrekhov22@gmail.com
 /// @issue 53426
@@ -23,8 +23,8 @@ class A {
   void foo() {}
 }
 
-class C<T extends A> {
-  external final T? _x;
+class C<T> {
+   external final T _x;
 
   void test() {
     if (_x is A) {

--- a/LanguageFeatures/Private-fields-promotion/promotion_A02_t04.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A02_t04.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,20 +12,30 @@
 /// - There is no implicit noSuchMethod forwarder with the same name elsewhere
 ///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @description Checks that an instance field is promotable even if it is
+/// external
 /// @author sgrekhov22@gmail.com
+/// @issue 53426
 
 // SharedOptions=--enable-experiment=inference-update-2
 
-library promotion_A06_t04_lib;
+class A {
+  void foo() {}
+}
 
-class C {
-  int? _x = 43;
+class C<T extends A> {
+  external final T? _x;
 
-  void testC() {
-    print(_x);
+  void test() {
+    if (_x is A) {
+      _x.foo();
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    }
   }
+}
+
+main() {
+  C().test();
 }

--- a/LanguageFeatures/Private-fields-promotion/promotion_A03_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A03_t01.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is not promotable if it is not
 /// private

--- a/LanguageFeatures/Private-fields-promotion/promotion_A03_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A03_t02.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is not promotable if it is not
 /// private. Test type variable

--- a/LanguageFeatures/Private-fields-promotion/promotion_A04_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A04_t01.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is not promotable if it is not
 /// final

--- a/LanguageFeatures/Private-fields-promotion/promotion_A04_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A04_t02.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is not promotable if it is not
 /// final

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t01.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @description Checks that if there is a non-final field with the same name
+/// in some class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t02.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test type variable and the case when the variable
-/// with the same name is not final in some class in the same library
+/// @descriptionChecks that if there is a non-final field with the same name
+/// in some class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t03.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t03.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some mixin in the same library
+/// @description Checks that if there is a non-final field with the same name
+/// in some mixin in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t04.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t04.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that if there are other concrete instance getters with
 /// the same name in the same library and they are not a final fields then the

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t05.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t05.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when there is a getter with the same name in
-/// some class in the same library
+/// @description Checks that if there is a concrete instance getters with the
+/// same name in some class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t06.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t06.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test type variable and case when there is a getter
-/// with the same name in some class in the same library
+/// @description Checks that if there is a concrete instance getters with the
+/// same name in some class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t07.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t07.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test the case when there is a getter with the same
-/// name in some mixin in the same library
+/// @description Checks that if there is a concrete instance getters with the
+/// same name in some mixin in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t08.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t08.dart
@@ -2,22 +2,24 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test type variable and the case when there is not a
-/// final getter with the same name in an abstract class
+/// @descriptionChecks that if there is a non-final field with the same name
+/// in some abstract class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2
 
 class A<T> {
-  T _x;
+  final T _x;
   A(this._x);
 
   void testA() {

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t09.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t09.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test type variable and the case when there is not a
-/// final getter with the same name in an abstract class
+/// @descriptionChecks that if there is a getter with the same name in some
+/// abstract class in the same library then the field is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t10.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t10.dart
@@ -2,16 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library but in another file
+/// @descriptionChecks that if there is a non-final field with the same name in
+/// some class in the same library  but in another file then the field is not
+/// promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A05_t10.lib.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A05_t10.lib.dart
@@ -2,16 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @descriptionChecks that if there is a non-final field with the same name in
+/// some class in the same library  but in another file then the field is not
+/// promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A06_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A06_t01.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test the case when library contains not a final

--- a/LanguageFeatures/Private-fields-promotion/promotion_A06_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A06_t02.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test the case when library contains not a final

--- a/LanguageFeatures/Private-fields-promotion/promotion_A06_t03.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A06_t03.dart
@@ -2,15 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test the case when library contains a static
-/// variables and getters with the same name
+/// variables and a static getter with the same name
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2

--- a/LanguageFeatures/Private-fields-promotion/promotion_A06_t04.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A06_t04.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An instance field is promotable only if
-/// (a) it is private,
-/// (b) it is final, and
-/// (c) all other concrete instance getters with the same name in the same
-/// library are also final fields
+/// @assertion An instance field is promotable if all the following conditions
+/// hold:
+/// - It refers to a field (not a getter)
+/// - The field is private
+/// - The field is final
+/// - There is no getter with the same name elsewhere in the library
+/// - There is no non-final field with the same name elsewhere in the library
+/// - There is no implicit noSuchMethod forwarder with the same name elsewhere
+///   in the library.
 ///
 /// @description Checks that an instance field is promotable if all of the
 /// conditions above are met. Test the case when library imports another library

--- a/LanguageFeatures/Private-fields-promotion/promotion_A07_t01.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A07_t01.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,20 +12,31 @@
 /// - There is no implicit noSuchMethod forwarder with the same name elsewhere
 ///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @description Checks that a getter is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2
 
-library promotion_A06_t04_lib;
-
 class C {
-  int? _x = 43;
+  int? get _x => 42;
 
-  void testC() {
-    print(_x);
+  void test() {
+    if (_x != null) {
+      _x.isOdd;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    }
   }
+}
+
+main() {
+  C c = C();
+  if (c._x is int) {
+    c._x.isEven;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  c.test();
 }

--- a/LanguageFeatures/Private-fields-promotion/promotion_A07_t02.dart
+++ b/LanguageFeatures/Private-fields-promotion/promotion_A07_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,20 +12,33 @@
 /// - There is no implicit noSuchMethod forwarder with the same name elsewhere
 ///   in the library.
 ///
-/// @description Checks that if there are other concrete instance getters with
-/// the same name in the same library and they are not a final fields then the
-/// field is not promotable. Test when the variable with the same name is not
-/// final in some class in the same library
+/// @description Checks that a getter is not promotable
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=inference-update-2
 
-library promotion_A06_t04_lib;
+class C<T> {
+  T _t;
+  T get _x => _t;
+  C(this._t);
 
-class C {
-  int? _x = 43;
-
-  void testC() {
-    print(_x);
+  void test() {
+    if (_x is int) {
+      _x.isOdd;
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    }
   }
+}
+
+main() {
+  C<num> c = C(42);
+  if (c._x is int) {
+    c._x.isEven;
+//       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+  c.test();
 }


### PR DESCRIPTION
There going to be two more changes.
- Rename and reorder existing tests according to the new assertion text
- Add new tests