### PR TITLE
Fixes #970. Don't use Process.kill() to exit a process

### DIFF
--- a/LibTest/io/Stdin/readByteSync_A02_t01.dart
+++ b/LibTest/io/Stdin/readByteSync_A02_t01.dart
@@ -21,8 +21,6 @@ run_process() async {
   stdout.write(stdin.readByteSync());
   // print [OK] finally
   print("OK");
-  await stdout.flush();
-  exit(0);
 }
 
 run_main() async {

--- a/LibTest/io/Stdin/readByteSync_A02_t01.dart
+++ b/LibTest/io/Stdin/readByteSync_A02_t01.dart
@@ -21,6 +21,8 @@ run_process() async {
   stdout.write(stdin.readByteSync());
   // print [OK] finally
   print("OK");
+  await stdout.flush();
+  exit(0);
 }
 
 run_main() async {
@@ -34,7 +36,7 @@ run_main() async {
       .then((Process process) async {
     process.stdin.add([5]);
     await new Future.delayed(new Duration(seconds: 2)).then((_) async {
-      process.kill();
+      await process.stdin.close();
       await process.exitCode.then((_) async {
         process.stderr.toList().then((errors) {
           Expect.isTrue(errors.isEmpty);


### PR DESCRIPTION
Thanks to @mraleph for helping with it!