### PR TITLE
#2291. Update `Link.create()` tests according to the documentation

### DIFF
--- a/LibTest/io/Link/create_A01_t01.dart
+++ b/LibTest/io/Link/create_A01_t01.dart
@@ -6,33 +6,36 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that this method creates the link
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that this method creates the link. Test [Directory] as
+/// a target
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";
@@ -50,6 +53,7 @@ _main(Directory sandbox) async {
   await link.create(target.path).then((Link created) {
     Expect.isTrue(created.existsSync());
     Expect.equals(link.path, created.path);
+    Expect.equals(target.path, created.targetSync());
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A01_t02.dart
+++ b/LibTest/io/Link/create_A01_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that this method creates the link. Test [File] as a
+/// target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +47,13 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  File target = getTempFileSync(parent: sandbox);
+  Link link = new Link(getTempFilePath(parent: sandbox));
   asyncStart();
   await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+    Expect.isTrue(created.existsSync());
+    Expect.equals(link.path, created.path);
+    Expect.equals(target.path, created.targetSync());
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A01_t03.dart
+++ b/LibTest/io/Link/create_A01_t03.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that this method creates the link. Test another [Link]
+/// as a target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +47,13 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  Link target = getTempLinkSync(parent: sandbox);
+  Link link = new Link(getTempFilePath(parent: sandbox));
   asyncStart();
   await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+    Expect.isTrue(created.existsSync());
+    Expect.equals(link.path, created.path);
+    Expect.equals(target.path, created.targetSync());
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A01_t04.dart
+++ b/LibTest/io/Link/create_A01_t04.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that this method creates the link. Test not existing
+/// entity as a target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +47,13 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String target = getTempFilePath(parent: sandbox);
+  Link link = new Link(getTempFilePath(parent: sandbox));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target).then((Link created) {
+    Expect.isTrue(created.existsSync());
+    Expect.equals(link.path, created.path);
+    Expect.equals(target, created.targetSync());
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A02_t01.dart
+++ b/LibTest/io/Link/create_A02_t01.dart
@@ -6,26 +6,36 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that if recursive is false and there are non-existing
-/// path components, then operation fails
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `recursive` is `false` and there are
+/// non-existing path components, then operation fails
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A02_t02.dart
+++ b/LibTest/io/Link/create_A02_t02.dart
@@ -6,34 +6,36 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that if recursive is true, all non-existing path
-/// components are created
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `recursive` is `true`, all non-existing path
+/// components are created
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A02_t03.dart
+++ b/LibTest/io/Link/create_A02_t03.dart
@@ -6,34 +6,36 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that if recursive is true the directories in the path of
-/// target are not affected
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `recursive` is `true` the directories in the
+/// path of target are not affected
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t01.dart
+++ b/LibTest/io/Link/create_A03_t01.dart
@@ -6,34 +6,37 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that if the link exists, the future will complete with
-/// an error.
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have the same
+/// [Directory] as a target
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t01.dart
+++ b/LibTest/io/Link/create_A03_t01.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have the same
-/// [Directory] as a target
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have the same [Directory] as a target
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t02.dart
+++ b/LibTest/io/Link/create_A03_t02.dart
@@ -6,34 +6,37 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test different targets
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have different
+/// directories as targets
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t02.dart
+++ b/LibTest/io/Link/create_A03_t02.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have different
-/// directories as targets
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have different directories as targets
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t03.dart
+++ b/LibTest/io/Link/create_A03_t03.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have the same
+/// [File] as a target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,14 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  File target = getTempFileSync(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target.path);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(tmp.targetSync()).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t03.dart
+++ b/LibTest/io/Link/create_A03_t03.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have the same
-/// [File] as a target
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have the same [File] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t04.dart
+++ b/LibTest/io/Link/create_A03_t04.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have different files
-/// as targets
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have different files as targets
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t04.dart
+++ b/LibTest/io/Link/create_A03_t04.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have different files
+/// as targets
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,15 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  File target1 = getTempFileSync(parent: sandbox);
+  File target2 = getTempFileSync(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target1.path);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target2.path).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t05.dart
+++ b/LibTest/io/Link/create_A03_t05.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have the same
+/// [Link] as a target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,14 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  Link target = getTempLinkSync(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target.path);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(tmp.targetSync()).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t05.dart
+++ b/LibTest/io/Link/create_A03_t05.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have the same
-/// [Link] as a target
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have the same [Link] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t06.dart
+++ b/LibTest/io/Link/create_A03_t06.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have different links
-/// as targets
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have different links as targets
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t06.dart
+++ b/LibTest/io/Link/create_A03_t06.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have different links
+/// as targets
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,15 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  Link target1 = getTempLinkSync(parent: sandbox);
+  Link target2 = getTempLinkSync(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target1.path);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target2.path).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t07.dart
+++ b/LibTest/io/Link/create_A03_t07.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if the link exists, the future will complete with
-/// an error. Test the case when created and existing links have the same not
-/// existing entity as a target
+/// @description Checks that if a link with the same path exists, the future
+/// will complete with an error. Test the case when created and existing links
+/// have the same not existing entity as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";

--- a/LibTest/io/Link/create_A03_t07.dart
+++ b/LibTest/io/Link/create_A03_t07.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have the same not
+/// existing entity as a target
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,14 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String target = getTempFilePath(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(tmp.targetSync()).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t08.dart
+++ b/LibTest/io/Link/create_A03_t08.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if the link exists, the future will complete with
+/// an error. Test the case when created and existing links have different not
+/// existing entities as targets
+/// @author sgrekhov22@gmail.com
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,15 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String target1 = getTempFilePath(parent: sandbox);
+  String target2 = getTempFilePath(parent: sandbox);
+  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
+  Link link = Link(tmp.path);
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target2).then((Link created) {
+    Expect.fail("Link create() should fail");
+    asyncEnd();
+  }, onError: (_) {
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A03_t09.dart
+++ b/LibTest/io/Link/create_A03_t09.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a file with the same path exists, the future
+/// will complete with an error. Test the case when created link has a [File] as
+/// a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  File target = getTempFileSync(parent: sandbox);
+  File file = getTempFileSync(parent: sandbox);
+  Link link = Link(file.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t10.dart
+++ b/LibTest/io/Link/create_A03_t10.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a file with the same path exists, the future
+/// will complete with an error. Test the case when created link has a
+/// [Directory] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  Directory target = getTempDirectorySync(parent: sandbox);
+  File file = getTempFileSync(parent: sandbox);
+  Link link = Link(file.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t11.dart
+++ b/LibTest/io/Link/create_A03_t11.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a file with the same path exists, the future
+/// will complete with an error. Test the case when created link has a not
+/// existing entity as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  String target = getTempFilePath(parent: sandbox);
+  File file = getTempFileSync(parent: sandbox);
+  Link link = Link(file.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t12.dart
+++ b/LibTest/io/Link/create_A03_t12.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a directory with the same path exists, the
+/// future will complete with an error. Test the case when created link has a
+/// [File] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  File target = getTempFileSync(parent: sandbox);
+  Directory dir = getTempDirectorySync(parent: sandbox);
+  Link link = Link(dir.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t13.dart
+++ b/LibTest/io/Link/create_A03_t13.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a directory with the same path exists, the
+/// future will complete with an error. Test the case when created link has a
+/// [Directory] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  Directory target = getTempDirectorySync(parent: sandbox);
+  Directory dir = getTempDirectorySync(parent: sandbox);
+  Link link = Link(dir.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t14.dart
+++ b/LibTest/io/Link/create_A03_t14.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if a directory with the same path exists, the
+/// future will complete with an error. Test the case when created link has a
+/// not existing entity as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,11 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  String target = getTempFilePath(parent: sandbox);
+  Directory dir = getTempDirectorySync(parent: sandbox);
+  Link link = Link(dir.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t15.dart
+++ b/LibTest/io/Link/create_A03_t15.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if to call `create()` on the existing link, the
+/// future will complete with an error. Test the case when the link has a [File]
+/// as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,10 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  File target = getTempFileSync(parent: sandbox);
+  Link link = getTempLinkSync(parent: sandbox, target: target.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t16.dart
+++ b/LibTest/io/Link/create_A03_t16.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if to call `create()` on the existing link, the
+/// future will complete with an error. Test the case when the link has a
+/// [Directory] as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,9 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  Link link = getTempLinkSync(parent: sandbox, target: sandbox.path);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(sandbox.path).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A03_t17.dart
+++ b/LibTest/io/Link/create_A03_t17.dart
@@ -34,9 +34,9 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if a link with the same path exists, the future
-/// will complete with an error. Test the case when created and existing links
-/// have different not existing entities as targets
+/// @description Checks that if to call `create()` on the existing link, the
+/// future will complete with an error. Test the case when the link has a not
+/// existing entity as a target
 /// @author sgrekhov22@gmail.com
 
 import "dart:io";
@@ -48,12 +48,10 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  String target1 = getTempFilePath(parent: sandbox);
-  String target2 = getTempFilePath(parent: sandbox);
-  Link tmp = getTempLinkSync(parent: sandbox, target: target1);
-  Link link = Link(tmp.path);
+  String target = getTempFilePath(parent: sandbox);
+  Link link = getTempLinkSync(parent: sandbox, target: target);
   asyncStart();
-  await link.create(target2).then((Link created) {
+  await link.create(target).then((Link created) {
     Expect.fail("Link create() should fail");
     asyncEnd();
   }, onError: (_) {

--- a/LibTest/io/Link/create_A04_t01.dart
+++ b/LibTest/io/Link/create_A04_t01.dart
@@ -6,30 +6,40 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that on the Windows platform, this will only work with
-/// directories, and the target directory must exist. Test not existing file
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `target` exists then the type of the link will
+/// match the type `target`. Test [Directory] as a target
 /// @author sgrekhov@unipro.ru
-/// @issue 30665
 
 import "dart:io";
+
 import "../../../Utils/expect.dart";
 import "../file_utils.dart";
 
@@ -38,13 +48,12 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  if (Platform.isWindows) { //   Directory sandbox = getTempDirectorySync();
-    Link link = new Link(getTempFilePath(parent: sandbox));
-    asyncStart();
-    await link.create(getTempFilePath()).then((Link created) {
-      Expect.fail("Link shouldn't be created on Windows");
-    }, onError: (e) {
-      asyncEnd();
-    });
-  }
+  Directory target = getTempDirectorySync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
 }

--- a/LibTest/io/Link/create_A04_t02.dart
+++ b/LibTest/io/Link/create_A04_t02.dart
@@ -6,30 +6,40 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that on the Windows platform, this will only work with
-/// directories, and the target directory must exist. Test existing file
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `target` exists then the type of the link will
+/// match the type `target`. Test [File] as a target
 /// @author sgrekhov@unipro.ru
-/// @issue 30665
 
 import "dart:io";
+
 import "../../../Utils/expect.dart";
 import "../file_utils.dart";
 
@@ -38,14 +48,12 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  if (Platform.isWindows) {
-    File file = getTempFileSync(parent: sandbox);
-    Link link = new Link(getTempFilePath(parent: sandbox));
-    asyncStart();
-    await link.create(file.path).then((Link created) {
-      Expect.fail("Link shouldn't be created on Windows");
-    }, onError: (e) {
-      asyncEnd();
-    });
-  }
+  File target = getTempFileSync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
 }

--- a/LibTest/io/Link/create_A04_t04.dart
+++ b/LibTest/io/Link/create_A04_t04.dart
@@ -6,28 +6,37 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that on the Windows platform, this will only work with
-/// directories, and the target directory must exist. Test not existing directory
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if `target` exists then the type of the link will
+/// match the type `target`. Test [Link] pointing to a [File] as a target
 /// @author sgrekhov@unipro.ru
-/// @issue 30665
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -38,14 +47,12 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  if (Platform.isWindows) {
-    Directory target = new Directory(getTempDirectoryPath(parent: sandbox));
-    Link link = new Link(getTempFilePath(parent: sandbox));
-    asyncStart();
-    await link.create(target.path).then((Link created) {
-      Expect.fail("Link shouldn't be created on Windows");
-    }, onError: (_) {
-      asyncEnd();
-    });
-  }
+  File target = getTempFileSync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
 }

--- a/LibTest/io/Link/create_A04_t05.dart
+++ b/LibTest/io/Link/create_A04_t05.dart
@@ -56,7 +56,7 @@ _main(Directory sandbox) async {
   await link.create(target.path).then((Link created) {
     if (Platform.isWindows) {
       Expect.equals(
-          FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
     } else {
       Expect.equals(FileSystemEntityType.notFound,
           FileSystemEntity.typeSync(created.path));

--- a/LibTest/io/Link/create_A04_t05.dart
+++ b/LibTest/io/Link/create_A04_t05.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -35,8 +35,10 @@
 /// be interpreted relative to the directory containing the link.
 ///
 /// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// match the type `target`. Test [Link] pointing to a not existing entity as a
+/// target (expect `file` on Windows and `notFound` on other platforms).
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,18 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
+  Link target = getTempLinkSync(
+      parent: sandbox, target: getTempFilePath(parent: sandbox));
   Link link = Link(getTempFilePath(parent: sandbox));
   asyncStart();
   await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A04_t06.dart
+++ b/LibTest/io/Link/create_A04_t06.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that if `target` not exists then the type of the link
+/// will be `file` on Windows and `notFound` on other platforms.
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,16 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
   Link link = Link(getTempFilePath(parent: sandbox));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(getTempFilePath(parent: sandbox)).then((Link created) {
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A04_t06.dart
+++ b/LibTest/io/Link/create_A04_t06.dart
@@ -53,7 +53,7 @@ _main(Directory sandbox) async {
   await link.create(getTempFilePath(parent: sandbox)).then((Link created) {
     if (Platform.isWindows) {
       Expect.equals(
-          FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
     } else {
       Expect.equals(FileSystemEntityType.notFound,
           FileSystemEntity.typeSync(created.path));

--- a/LibTest/io/Link/create_A05_t01.dart
+++ b/LibTest/io/Link/create_A05_t01.dart
@@ -6,35 +6,36 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
 ///
 /// On the Windows platform, this call will create a true symbolic link instead
-/// of a Junction. In order to create a symbolic link on Windows, Dart must be
-/// run in Administrator mode or the system must have Developer Mode enabled,
-/// otherwise a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD
-/// set as the errno when this call is made.
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-///
-/// @description Checks that on the Windows platform relative paths to the target
-/// is not converted to absolute paths (as it was in the past)
-///
-/// @note The test should run with the Administrator priveleges on Windows.
-/// Dart API Spec reads:
 /// In order to create a symbolic link on Windows, Dart must be run in
 /// Administrator mode or the system must have Developer Mode enabled, otherwise
-/// a FileSystemException will be raised with ERROR_PRIVILEGE_NOT_HELD set as
-/// the errno when this call is made.
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
 ///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that on the Windows platform relative paths to the
+/// target is not converted to absolute paths (as it was in the past)
 /// @author sgrekhov@unipro.ru
 
 import "dart:io";

--- a/LibTest/io/Link/create_A06_t01.dart
+++ b/LibTest/io/Link/create_A06_t01.dart
@@ -6,28 +6,39 @@
 ///  String target, {
 ///  bool recursive: false
 ///  })
-/// Creates a symbolic link. Returns a Future<Link> that completes with the link
-/// when it has been created. If the link exists, the future will complete with
-/// an error.
+/// Creates a symbolic link in the file system.
 ///
-/// If recursive is false, the default, the link is created only if all
-/// directories in its path exist. If recursive is true, all non-existing path
-/// components are created. The directories in the path of target are not
-/// affected, unless they are also in path.
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
 ///
-/// On the Windows platform, this will only work with directories, and the target
-/// directory must exist. The link will be created as a Junction. Only absolute
-/// links will be created, and relative paths to the target will be converted to
-/// absolute paths by joining them with the path of the directory the link is
-/// contained in.
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
 ///
-/// On other platforms, the posix symlink() call is used to make a symbolic link
-/// containing the string target. If target is a relative path, it will be
-/// interpreted relative to the directory containing the link.
-/// @description Checks that on non-Windows platforms only absolute links will be
-/// created, and relative paths to the target will be interpreted relative to the
-/// directory containing the link.
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to
+/// [Directory]
 /// @author sgrekhov@unipro.ru
+/// @issue 53689
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -38,18 +49,30 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  if (!Platform.isWindows) {
+  String dirName = getTempDirectoryName();
+  Directory target = Directory(sandbox.path + Platform.pathSeparator + dirName);
+  target.createSync();
+  Link link = Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
+  asyncStart();
+  await link.create(dirName).then((Link created) {
+    Expect.equals(dirName, created.targetSync());
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    // Now create a directory and move the link into it. Its relative target
+    // should point to a not existing entity after it
     Directory dir = getTempDirectorySync(parent: sandbox);
-    String dirName = getTempDirectoryName();
-    Directory target = new Directory(dir.path +
-        Platform.pathSeparator + dirName);
-    target.createSync();
-    Link link = new Link(dir.path + Platform.pathSeparator +
-        getTempFileName(extension: "lnk"));
-    asyncStart();
-    await link.create(dirName).then((Link created) {
-      Expect.equals(dirName, created.targetSync());
-      asyncEnd();
-    });
-  }
+    Link moved =
+        created.renameSync(dir.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(dirName, moved.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(moved.path));
+    } else {
+      Expect.equals(
+          FileSystemEntityType.notFound, FileSystemEntity.typeSync(moved.path));
+    }
+    asyncEnd();
+  });
 }

--- a/LibTest/io/Link/create_A06_t02.dart
+++ b/LibTest/io/Link/create_A06_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,10 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to [File]
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +48,30 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String fileName = getTempFileName();
+  File target = new File(sandbox.path + Platform.pathSeparator + fileName);
+  target.createSync();
+  Link link = new Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(fileName).then((Link created) {
+    Expect.equals(fileName, created.targetSync());
+    Expect.equals(
+        FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+    // Now create a directory and move the link into it. Its relative target
+    // should point to a not existing entity after it
+    Directory dir = getTempDirectorySync(parent: sandbox);
+    Link moved =
+        created.renameSync(dir.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(fileName, moved.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(moved.path));
+    } else {
+      Expect.equals(
+          FileSystemEntityType.notFound, FileSystemEntity.typeSync(moved.path));
+    }
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A06_t03.dart
+++ b/LibTest/io/Link/create_A06_t03.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,11 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to [Link]
+/// pointing to [Directory]
+/// @author sgrekhov22@gmail.com
+/// @issue 53689
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,30 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String linkName = getTempFileName();
+  Link target = new Link(sandbox.path + Platform.pathSeparator + linkName);
+  target.createSync(sandbox.path);
+  Link link = new Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
+  await link.create(linkName).then((Link created) {
+    Expect.equals(linkName, created.targetSync());
     Expect.equals(FileSystemEntityType.directory,
         FileSystemEntity.typeSync(created.path));
+    // Now create a directory and move the link into it. Its relative target
+    // should point to a not existing entity after it
+    Directory dir = getTempDirectorySync(parent: sandbox);
+    Link moved =
+        created.renameSync(dir.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(linkName, moved.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(moved.path));
+    } else {
+      Expect.equals(
+          FileSystemEntityType.notFound, FileSystemEntity.typeSync(moved.path));
+    }
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A06_t05.dart
+++ b/LibTest/io/Link/create_A06_t05.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,11 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to [Link]
+/// pointing to a not existing entity
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,34 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String notExisting = getTempFileName();
+  String target = getTempFileName(extension: "lnk");
+  Link targetLink =
+      getTempLinkSync(parent: sandbox, target: notExisting, name: target);
+  Link link = Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target).then((Link created) {
+    Expect.equals(target, created.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    // Now create a directory and into it the file with the name as link's
+    // target. Then move the link into the directory. Its relative target should
+    // point to that file after it
+    Directory dir = getTempDirectorySync(parent: sandbox);
+    File file = File(dir.path + Platform.pathSeparator + target);
+    file.createSync();
+    Link moved =
+        created.renameSync(dir.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(target, moved.targetSync());
+    Expect.equals(
+        FileSystemEntityType.file, FileSystemEntity.typeSync(moved.path));
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A06_t06.dart
+++ b/LibTest/io/Link/create_A06_t06.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,11 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to [Link]
+/// pointing to a not existing entity
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,39 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String notExisting = getTempFileName();
+  String target = getTempFileName(extension: "lnk");
+  Link targetLink =
+      getTempLinkSync(parent: sandbox, target: notExisting, name: target);
+  Link link = Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target).then((Link created) {
+    Expect.equals(target, created.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    // Now create a directory and into it another directory with the name as
+    // link's target. Then move the link into the first directory. Its relative
+    // target should point to the second directory after it (except Windows)
+    Directory dir1 = getTempDirectorySync(parent: sandbox);
+    Directory dir2 = Directory(dir1.path + Platform.pathSeparator + target);
+    dir2.createSync();
+    Link moved =
+        created.renameSync(dir1.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(target, moved.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(moved.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(moved.path));
+    }
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A06_t07.dart
+++ b/LibTest/io/Link/create_A06_t07.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,11 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path to a not
+/// existing entity
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,31 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String target = getTempFileName();
+  Link link = Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target).then((Link created) {
+    Expect.equals(target, created.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    // Now create a directory and into it the file with the name as link's
+    // target. Then move the link into the directory. Its relative target should
+    // point to that file after it
+    Directory dir = getTempDirectorySync(parent: sandbox);
+    File file = File(dir.path + Platform.pathSeparator + target);
+    file.createSync();
+    Link moved =
+        created.renameSync(dir.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(target, moved.targetSync());
+    Expect.equals(
+        FileSystemEntityType.file, FileSystemEntity.typeSync(moved.path));
     asyncEnd();
   });
 }

--- a/LibTest/io/Link/create_A06_t08.dart
+++ b/LibTest/io/Link/create_A06_t08.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -34,9 +34,11 @@
 /// link containing the string `target`. If `target` is a relative path, it will
 /// be interpreted relative to the directory containing the link.
 ///
-/// @description Checks that if `target` exists then the type of the link will
-/// match the type `target`. Test [Link] pointing to a [Directory] as a target
-/// @author sgrekhov@unipro.ru
+/// @description Checks that relative paths to the target will be interpreted
+/// relative to the directory containing the link. Test relative path a not
+/// existing entity
+/// @author sgrekhov22@gmail.com
+/// @issue 53684
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -47,12 +49,36 @@ main() async {
 }
 
 _main(Directory sandbox) async {
-  Link target = getTempLinkSync(parent: sandbox, target: sandbox.path);
-  Link link = Link(getTempFilePath(parent: sandbox));
+  String target = "target";
+  Link link = Link(sandbox.path +
+      Platform.pathSeparator +
+      getTempFileName(extension: "lnk"));
   asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.equals(FileSystemEntityType.directory,
-        FileSystemEntity.typeSync(created.path));
+  await link.create(target).then((Link created) {
+    Expect.equals(target, created.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    // Now create a directory and into it another directory with the name as
+    // link's target. Then move the link into the first directory. Its relative
+    // target should point to the second directory after it
+    Directory dir1 = getTempDirectorySync(parent: sandbox);
+    Directory dir2 = Directory(dir1.path + Platform.pathSeparator + target);
+    dir2.createSync();
+    Link moved =
+        created.renameSync(dir1.path + Platform.pathSeparator + "moved.lnk");
+    Expect.equals(target, moved.targetSync());
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(moved.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(moved.path));
+    }
     asyncEnd();
   });
 }


### PR DESCRIPTION
These tests written according to the documentation and https://github.com/dart-lang/sdk/issues/53684

This is just the part of the changes. The second part should add tests checking behaviour of links when its target is deleted and another `FileSystemEntity` is created instead. Say delete `File` target and create a `Directory` with the same name instead. 

The third part will update `createSync()` tests