### PR TITLE
#2291. Update `Link.create()` according to the documentation. Part 2

### DIFF
--- a/LibTest/io/Link/create_A04_t07.dart
+++ b/LibTest/io/Link/create_A04_t07.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target directory was created and
+/// then this directory was deleted and created again, then the link stays valid
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  Directory target1 = getTempDirectorySync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    Directory target2 = Directory(target1.path);
+    target2.createSync();
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    Directory linkTarget = getTempDirectorySync();
+    target3.createSync(linkTarget.path);
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t08.dart
+++ b/LibTest/io/Link/create_A04_t08.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target directory was created and
+/// then this directory was deleted and a file with the same name created, then
+/// on Windows the link became invalid on other platforms it changes its type
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  Directory target1 = getTempDirectorySync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    File target2 = File(target1.path);
+    target2.createSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    File linkTarget = getTempFileSync();
+    target3.createSync(linkTarget.path);
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t09.dart
+++ b/LibTest/io/Link/create_A04_t09.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target file was created and
+/// then this file was deleted and created again, then the link stays valid
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  File target1 = getTempFileSync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(
+        FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    File target2 = File(target1.path);
+    target2.createSync();
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    File linkTarget = getTempFileSync();
+    target3.createSync(linkTarget.path);
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t10.dart
+++ b/LibTest/io/Link/create_A04_t10.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target file was created and then
+/// this file was deleted and a directory with the same name created, then
+/// on Windows the link became invalid on other platforms it changes its type
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  File target1 = getTempFileSync(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    Directory target2 = Directory(target1.path);
+    target2.createSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(created.path));
+    }
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    Directory linkTarget = getTempDirectorySync();
+    target3.createSync(linkTarget.path);
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t11.dart
+++ b/LibTest/io/Link/create_A04_t11.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target another link pointing to
+/// a directory was created and then this link was deleted and created again,
+/// then the first link stays valid
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  Directory linkTarget = getTempDirectorySync(parent: sandbox);
+  Link target1 = getTempLinkSync(parent: sandbox, target: linkTarget.path);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    Directory target2 = Directory(target1.path);
+    target2.createSync();
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    target3.createSync(sandbox.path);
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t12.dart
+++ b/LibTest/io/Link/create_A04_t12.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target another link pointing to
+/// a directory was created and then this link was deleted and a file with the
+/// same path or link to a file created again, then the first link became
+/// invalid on Windows and changes its type on other platforms
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  Directory linkTarget = getTempDirectorySync();
+  Link target1 = getTempLinkSync(parent: sandbox, target: linkTarget.path);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.directory,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    File target2 = File(target1.path);
+    target2.createSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    File linkTarget = getTempFileSync();
+    target3.createSync(linkTarget.path);
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t13.dart
+++ b/LibTest/io/Link/create_A04_t13.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target another link pointing to
+/// a file was created and then this link was deleted and created again, then
+/// the link stays valid
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  File linkTarget = getTempFileSync(parent: sandbox);
+  Link target1 = getTempLinkSync(parent: sandbox, target: linkTarget.path);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(
+        FileSystemEntityType.file, FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    File target2 = File(target1.path);
+    target2.createSync();
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    File linkTarget = getTempFileSync();
+    target3.createSync(linkTarget.path);
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t14.dart
+++ b/LibTest/io/Link/create_A04_t14.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the target another link pointing to
+/// a file was created and then this link was deleted and a directory with the
+/// same name created, then on Windows the link became invalid on other
+/// platforms it changes its type
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  File linkTarget = getTempFileSync(parent: sandbox);
+  Link target1 = getTempLinkSync(parent: sandbox, target: linkTarget.path);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(target1.path).then((Link created) {
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    target1.deleteSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    Directory target2 = Directory(target1.path);
+    target2.createSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(created.path));
+    }
+    target2.deleteSync();
+
+    Link target3 = Link(target1.path);
+    Directory linkTarget = getTempDirectorySync();
+    target3.createSync(linkTarget.path);
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.file,
+          FileSystemEntity.typeSync(created.path));
+    }
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t15.dart
+++ b/LibTest/io/Link/create_A04_t15.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the not existing target was created
+/// and then a file on the link's target was created, then the link became valid
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  String linkTarget = getTempFilePath(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(linkTarget).then((Link created) {
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    File target2 = File(linkTarget);
+    target2.createSync();
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    target2.deleteSync();
+
+    Link target3 = Link(linkTarget);
+    File _linkTarget = getTempFileSync();
+    target3.createSync(_linkTarget.path);
+    Expect.equals(FileSystemEntityType.file,
+        FileSystemEntity.typeSync(created.path));
+    asyncEnd();
+  });
+}

--- a/LibTest/io/Link/create_A04_t16.dart
+++ b/LibTest/io/Link/create_A04_t16.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<Link> create(
+///  String target, {
+///  bool recursive: false
+///  })
+/// Creates a symbolic link in the file system.
+///
+/// The created link will point to the path at `target`, whether that path
+/// exists or not.
+///
+/// Returns a `Future<Link>` that completes with the link when it has been
+/// created. If the link path already exists, the future will complete with an
+/// error.
+///
+/// If `recursive` is `false`, the default, the link is created only if all
+/// directories in its path exist. If `recursive` is `true`, all non-existing
+/// parent paths are created first. The directories in the path of target are
+/// not affected, unless they are also in [path].
+///
+/// On the Windows platform, this call will create a true symbolic link instead
+/// of a junction. The link represents a file or directory and does not change
+/// its type after creation. If `target` exists then the type of the link will
+/// match the type `target`, otherwise a file symlink is created.
+///
+/// In order to create a symbolic link on Windows, Dart must be run in
+/// Administrator mode or the system must have Developer Mode enabled, otherwise
+/// a [FileSystemException] will be raised with `ERROR_PRIVILEGE_NOT_HELD` set
+/// as the errno when this call is made.
+///
+/// On other platforms, the POSIX `symlink()` call is used to make a symbolic
+/// link containing the string `target`. If `target` is a relative path, it will
+/// be interpreted relative to the directory containing the link.
+///
+/// @description Checks that if a link with the not existing target was created
+/// and then a directory on the link's target was created, then the link become
+/// invalid on Windows and changes its type on other platforms
+/// @author sgrekhov22@gmail.com
+
+import "dart:io";
+import "../../../Utils/expect.dart";
+import "../file_utils.dart";
+
+main() async {
+  await inSandbox(_main);
+}
+
+_main(Directory sandbox) async {
+  String linkTarget = getTempFilePath(parent: sandbox);
+  Link link = Link(getTempFilePath(parent: sandbox));
+  asyncStart();
+  await link.create(linkTarget).then((Link created) {
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.notFound,
+          FileSystemEntity.typeSync(created.path));
+    }
+    Directory target2 = Directory(linkTarget);
+    target2.createSync();
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(created.path));
+    }
+    target2.deleteSync();
+
+    Link target3 = Link(linkTarget);
+    target3.createSync(sandbox.path);
+    if (Platform.isWindows) {
+      Expect.equals(
+          FileSystemEntityType.link, FileSystemEntity.typeSync(created.path));
+    } else {
+      Expect.equals(FileSystemEntityType.directory,
+          FileSystemEntity.typeSync(created.path));
+    }
+    asyncEnd();
+  });
+}


### PR DESCRIPTION
Tests written according to the https://github.com/dart-lang/sdk/issues/53684
On Windows invalid `Link` reports itself as `FileSystemEntityType.link`  (`FileSystemEntityType.notFound` on other platforms). Also, on Windows, Link created as link pointing to a directory cannot point to a file and vice versa  