### PR TITLE
Fixes #2268. Fix LibTest/io/WebSocket/closeCode_A01_t02.dart to be not racy

### DIFF
--- a/LibTest/io/WebSocket/closeCode_A01_t02.dart
+++ b/LibTest/io/WebSocket/closeCode_A01_t02.dart
@@ -16,9 +16,7 @@ import "../../../Utils/expect.dart";
 main() {
   HttpServer.bind("127.0.0.1", 0).then((server) {
     server.listen((request) {
-      WebSocketTransformer
-          .upgrade(request)
-          .then((websocket) {
+      WebSocketTransformer.upgrade(request).then((websocket) {
         websocket.close(WebSocketStatus.normalClosure);
       });
     });
@@ -26,6 +24,7 @@ main() {
     var webs = WebSocket.connect("ws://127.0.0.1:${server.port}/");
     webs.then((client) async {
       Expect.isNull(client.closeCode);
+      await client.listen((_) {}).asFuture();
       await server.close();
       client.close().then((_) {
         Expect.equals(WebSocketStatus.normalClosure, client.closeCode);


### PR DESCRIPTION
Updated test is not racy any longer