### PR TITLE
Fixes #2323. Don't test datagram size more than 65503

### DIFF
--- a/LibTest/io/RawDatagramSocket/receive_A02_t01.dart
+++ b/LibTest/io/RawDatagramSocket/receive_A02_t01.dart
@@ -4,8 +4,6 @@
 
 /// @assertion Datagram receive()
 /// Receive a datagram.
-/// . . .
-/// The maximum length of the datagram that can be received is 65503 bytes.
 ///
 /// @description Checks that the 65503 bytes datagram can be received.
 /// @author ngl@unipro.ru


### PR DESCRIPTION
@brianquinlan seems that maximum size of 65503 exists on MacOS only. See https://dart-current-results.web.app/#/filter=co19/LibTest/io/RawDatagramSocket/receive_A02_t02. But I didn't find any specification confirming that. So, I preserved the test which confirms that 65503 bytes can be received and deleted the one checking what's going on when UDP size is more than 65503