### PR TITLE
#2359. Update tests according to the new nullability rules. Part 1

### DIFF
--- a/LanguageFeatures/Extension-types/dynamic_semantics_extension_type_A03_t02.dart
+++ b/LanguageFeatures/Extension-types/dynamic_semantics_extension_type_A03_t02.dart
@@ -27,7 +27,7 @@ bool testAsInt(Object instance) {
   }
 }
 
-bool testAsV1(Object instance) {
+bool testAsV1(Object? instance) {
   try {
     instance as V1;
     return true;
@@ -36,7 +36,7 @@ bool testAsV1(Object instance) {
   }
 }
 
-bool testAsT<T>(Object instance) {
+bool testAsT<T>(Object? instance) {
   try {
     instance as T;
     return true;
@@ -45,7 +45,7 @@ bool testAsT<T>(Object instance) {
   }
 }
 
-bool testAsV2<T>(Object instance) {
+bool testAsV2<T>(Object? instance) {
   try {
     instance as V2<T>;
     return true;

--- a/LanguageFeatures/Extension-types/nullability_A02_t01.dart
+++ b/LanguageFeatures/Extension-types/nullability_A02_t01.dart
@@ -20,7 +20,7 @@ extension type ET1<T>(T _) {
   }
 }
 
-extension type ET2<T extends Object>(T _) {
+extension type ET2<T extends Object>(T _) implements Object {
   void test() {
     this ?? print("Expect a warning here!");
 //       ^^

--- a/LanguageFeatures/Extension-types/static_analysis_extension_types_A17_t01.dart
+++ b/LanguageFeatures/Extension-types/static_analysis_extension_types_A17_t01.dart
@@ -26,6 +26,6 @@ extension type V1(int id) {}
 extension type V2<T1, T2 extends num?>(T1 id) {}
 
 main() {
-  Object v1 = V1(42);
-  Object v2 = V2<String, int?>("42");
+  Object? v1 = V1(42);
+  Object? v2 = V2<String, int?>("42");
 }

--- a/LanguageFeatures/Extension-types/upper_bound_A01_t03.dart
+++ b/LanguageFeatures/Extension-types/upper_bound_A01_t03.dart
@@ -19,8 +19,8 @@
 
 import '../../Utils/static_type_helper.dart';
 
-extension type ET1(String s) {}
-extension type ET2(int n) {}
+extension type ET1(String s) implements Object {}
+extension type ET2(int n) implements Object {}
 
 extension type ET3(String s) implements String {}
 extension type ET4(int i) implements num {}

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t01.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t02.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_arguments_binding_A02_t03.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t01.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t02.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_class_member_A02_t03.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_global_variable_A02_t01.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_local_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_local_variable_A02_t01.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/dynamic/generated/extension_type_return_value_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/dynamic/generated/extension_type_return_value_A02_t01.dart
@@ -29,7 +29,7 @@
 
 import '../../utils/common.dart';
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t01.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t02.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_arguments_binding_A02_t03.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t01.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t02.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t02.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t03.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_class_member_A02_t03.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_global_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_global_variable_A02_t01.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_local_variable_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_local_variable_A02_t01.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/static/generated/extension_type_return_value_A02_t01.dart
+++ b/LanguageFeatures/Subtyping/static/generated/extension_type_return_value_A02_t01.dart
@@ -27,7 +27,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 V<int> t0Instance = V<int>(42);
 

--- a/LanguageFeatures/Subtyping/test_types/extension_type_A02.dart
+++ b/LanguageFeatures/Subtyping/test_types/extension_type_A02.dart
@@ -18,7 +18,7 @@
 
 // SharedOptions=--enable-experiment=inline-class
 
-extension type const V<T>(T id) {}
+extension type const V<T extends Object>(T id) implements Object {}
 
 Object t1Instance = Object();
 V<int> t0Instance = V<int>(42);


### PR DESCRIPTION
This PR contains not all of the tests mentioned in #2359. It contains only the tests that can be updated to not fail with both old and new nullability rules. So, they won't break anything and can be merged safely. 

Other tests will be fixed after the landing of the https://dart-review.googlesource.com/c/sdk/+/333500