### PR TITLE
#2339. Add test for extension named type and a record type

### DIFF
--- a/LanguageFeatures/Extension-methods/syntax_t07.dart
+++ b/LanguageFeatures/Extension-methods/syntax_t07.dart
@@ -15,13 +15,11 @@
 /// name `type`. Test record type
 /// @author sgrekhov22@gmail.com
 
-class C<T> {}
-
 extension type on (int i,) {}
-//        ^^^^
+//                      ^
 // [analyzer] unspecified
 // [cfe] unspecified
 
 main() {
-  C();
+  print((int,));
 }

--- a/LanguageFeatures/Extension-methods/syntax_t07.dart
+++ b/LanguageFeatures/Extension-methods/syntax_t07.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion an extension declaration is a top-level declaration with a grammar
+/// similar to:
+/// <extension> ::=
+///   `extension' <identifier>? <typeParameters>? `on' <type> `?'? `{'
+///     memberDeclaration*
+///   `}'
+/// Such a declaration introduces its name (the identifier) into the surrounding
+/// scope
+///
+/// @description Check that it is a compile-time error if an extension has the
+/// name `type`. Test record type
+/// @author sgrekhov22@gmail.com
+
+class C<T> {}
+
+extension type on (int i,) {}
+//        ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  C();
+}


### PR DESCRIPTION
We have an interesting case here. 
Without `// SharedOptions=--enable-experiment=inline-class`  experimental flag  `extension type on (int i,)` should be treated as an `extension` named `type` on record type `(int,)`.
With  `// SharedOptions=--enable-experiment=inline-class` it became an extension type with a excesive comma after the representation type.

So, we may have two tests here
```dart
extension type on 
//        ^^^^
// [analyzer] unspecified
// [cfe] unspecified
    (int i,) {}
```
And
```dart
// SharedOptions=--enable-experiment=inline-class
extension type on
    (int i,) {}
//        ^
// [analyzer] unspecified
// [cfe] unspecified
```
But the first one became an invalid when the extension types will stop to be an experiment but became the part of the language. So I added only the one tests expecting an error in the right place when the extension types will be shipped. If you believe that we have more tests here, then let me know