### PR TITLE
#2398. Update asyncStart/End() to correspond SDK version. Replace asyncMultiTest

### DIFF
--- a/LibTest/async/Completer/completeError_A01_t03.dart
+++ b/LibTest/async/Completer/completeError_A01_t03.dart
@@ -19,7 +19,7 @@ main() {
 
   var v = [1,2,3];
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   var f = new Future.value(v).then((x) {
     asyncEnd();
@@ -34,4 +34,3 @@ main() {
 
   completer.completeError(f);
 }
-

--- a/LibTest/async/Completer/completeError_A01_t04.dart
+++ b/LibTest/async/Completer/completeError_A01_t04.dart
@@ -19,7 +19,7 @@ main() {
 
   var e = new Error();
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   var f = new Future.error(e).catchError((x) {
     asyncEnd();

--- a/LibTest/async/Future/Future.microtask_A01_t03.dart
+++ b/LibTest/async/Future/Future.microtask_A01_t03.dart
@@ -22,7 +22,7 @@ main() {
   var completer2 = new Completer();
   Future future2 = new Future.microtask(() => completer2.future);
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   future
     .then((x) {

--- a/LibTest/async/Future/Future.sync_A01_t04.dart
+++ b/LibTest/async/Future/Future.sync_A01_t04.dart
@@ -27,7 +27,7 @@ main() {
   var completer2 = new Completer();
   Future future2 = new Future.sync(() => completer2.future);
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   future
     .then((x) {

--- a/LibTest/async/Future/Future_A01_t03.dart
+++ b/LibTest/async/Future/Future_A01_t03.dart
@@ -22,7 +22,7 @@ import "../../../Utils/expect.dart";
 
 main() {
   var value = [1, 2, 3];
-  asyncMultiStart(2);
+  asyncStart(2);
   Future future = new Future(() => new Future.value(value));
   Future future2 = new Future(() => new Future.error(value));
 

--- a/LibTest/async/Future/catchError_A01_t02.dart
+++ b/LibTest/async/Future/catchError_A01_t02.dart
@@ -28,6 +28,6 @@ main() {
   f.catchError(onError1);
   f.catchError(onError2);
 
-  asyncMultiStart(2);
+  asyncStart(2);
   completer.completeError('!!!');
 }

--- a/LibTest/async/Future/catchError_A06_t01.dart
+++ b/LibTest/async/Future/catchError_A06_t01.dart
@@ -25,7 +25,7 @@ check(value) {
   Completer completer = new Completer();
   Future f = completer.future;
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   f.catchError(
     (exception) {

--- a/LibTest/async/Stream/asBroadcastStream_A01_t05.dart
+++ b/LibTest/async/Stream/asBroadcastStream_A01_t05.dart
@@ -25,7 +25,7 @@ main() {
   );
   Stream b = controller.stream.asBroadcastStream();
   Expect.isFalse(hasListener);
-  asyncMultiStart(2);
+  asyncStart(2);
   b.listen(
     (_) {
       Expect.isTrue(hasListener);

--- a/LibTest/async/Stream/handleError_A04_t01.dart
+++ b/LibTest/async/Stream/handleError_A04_t01.dart
@@ -38,7 +38,7 @@ main() {
     asyncEnd();
   });
 
-  asyncMultiStart(N);
+  asyncStart(N);
 
   s3.listen((_) {
     Expect.fail('unexpected onData event');

--- a/LibTest/async/Stream/listen_A05_t01.dart
+++ b/LibTest/async/Stream/listen_A05_t01.dart
@@ -33,7 +33,7 @@ main() {
     }
   });
 
-  asyncMultiStart(N);
+  asyncStart(N);
 
   s2.listen((_) {
     Expect.fail('unexpected call to onData');

--- a/LibTest/async/Stream/pipe_A04_t02.test.dart
+++ b/LibTest/async/Stream/pipe_A04_t02.test.dart
@@ -52,7 +52,7 @@ void test(CreateStreamFunction create) {
     }
   );
 
-  asyncMultiStart(2);
+  asyncStart(2);
   s.pipe(c).then(
       (_) {
         Expect.fail("Returned future should complete with error");

--- a/LibTest/async/StreamController/StreamController.broadcast_A01_t03.dart
+++ b/LibTest/async/StreamController/StreamController.broadcast_A01_t03.dart
@@ -25,7 +25,7 @@ check(List events) {
   List expectedData = events.where((e) => !(e is num) || e >= 0).toList();
   List expectedErrors = events.where((e) => e is num && e < 0).toList();
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   List events1 = [], errors1 = [];
   s.listen(

--- a/LibTest/async/StreamController/StreamController.broadcast_A04_t02.dart
+++ b/LibTest/async/StreamController/StreamController.broadcast_A04_t02.dart
@@ -18,7 +18,7 @@ import "../../../Utils/expect.dart";
 main() {
   StreamController controller = new StreamController.broadcast();
   Stream stream = controller.stream;
-  asyncMultiStart(2);
+  asyncStart(2);
   List log1 = [];
   StreamSubscription sub1 =
       stream.listen((event) => log1.add(event), onDone: () {
@@ -27,8 +27,7 @@ main() {
   });
 
   List log2 = [];
-  StreamSubscription sub2 =
-      stream.listen((event) => log2.add(event), onDone: () {
+  stream.listen((event) => log2.add(event), onDone: () {
     Expect.listEquals([1, 2, 3, 4, 5], log2);
     asyncEnd();
   });

--- a/LibTest/async/StreamController/StreamController.broadcast_A07_t03.dart
+++ b/LibTest/async/StreamController/StreamController.broadcast_A07_t03.dart
@@ -16,7 +16,7 @@ import "../../../Utils/expect.dart";
 
 main() {
   int onCancelCallCount = 0;
-  asyncMultiStart(6);
+  asyncStart(6);
   StreamController? controller;
   controller = new StreamController.broadcast(
     onCancel: () {

--- a/LibTest/async/StreamController/StreamController.broadcast_A08_t01.dart
+++ b/LibTest/async/StreamController/StreamController.broadcast_A08_t01.dart
@@ -17,7 +17,7 @@ import "../../../Utils/expect.dart";
 main() {
   bool onListenCalled = false;
   bool onCancelCalled = false;
-  asyncMultiStart(4);
+  asyncStart(4);
 
   StreamController controller = new StreamController.broadcast(
     onListen: () {
@@ -44,4 +44,3 @@ main() {
 
   controller.close();
 }
-

--- a/LibTest/async/StreamTransformer/StreamTransformer_A03_t01.dart
+++ b/LibTest/async/StreamTransformer/StreamTransformer_A03_t01.dart
@@ -38,7 +38,7 @@ main() {
     }
   );
 
-  asyncMultiStart(3);
+  asyncStart(3);
 
   c.stream.transform(tr).listen(
     (x) {

--- a/LibTest/async/Zone/handleUncaughtError_A01_t04.dart
+++ b/LibTest/async/Zone/handleUncaughtError_A01_t04.dart
@@ -32,7 +32,7 @@ void test() {
   } catch (e, st) {
     stackTraces[count] = st;
 
-    asyncMultiStart(2);
+    asyncStart(2);
 
     new Future.error(e,st);
 

--- a/LibTest/html/Element/addEventListener_A01_t03.dart
+++ b/LibTest/html/Element/addEventListener_A01_t03.dart
@@ -15,7 +15,7 @@ main() {
   var x = new ButtonElement();
   document.body?.append(x);
 
-  asyncMultiStart(3);
+  asyncStart(3);
 
   x.addEventListener(type, (e) {
     Expect.equals(type, e.type);

--- a/LibTest/html/Element/addEventListener_A01_t04.dart
+++ b/LibTest/html/Element/addEventListener_A01_t04.dart
@@ -16,7 +16,7 @@ main() {
   var x = new ButtonElement();
   document.body?.append(x);
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   // intercept on capture
   document.body?.addEventListener(type, (e) {

--- a/LibTest/html/Element/addEventListener_A01_t05.dart
+++ b/LibTest/html/Element/addEventListener_A01_t05.dart
@@ -17,7 +17,7 @@ main() {
 
   var n = 10;
 
-  asyncMultiStart(n);
+  asyncStart(n);
 
   EventListener genHandler() => (e) {
         Expect.equals(type, e.type);

--- a/LibTest/html/Element/addEventListener_A01_t06.dart
+++ b/LibTest/html/Element/addEventListener_A01_t06.dart
@@ -17,7 +17,7 @@ main() {
 
   var n = 10;
 
-  asyncMultiStart(n);
+  asyncStart(n);
 
   EventListener genHandler() => (e) {
         Expect.equals(type, e.type);

--- a/LibTest/html/Element/removeEventListener_A01_t01.dart
+++ b/LibTest/html/Element/removeEventListener_A01_t01.dart
@@ -33,7 +33,7 @@ main() {
   x.addEventListener(type, handler1);
   x.addEventListener(type, handler2);
 
-  asyncMultiStart(3); // first time two handlers, second time one handler
+  asyncStart(3); // first time two handlers, second time one handler
   var event = new Event(type);
   x.dispatchEvent(event);
   event = new Event(type);

--- a/LibTest/html/Element/removeEventListener_A01_t02.dart
+++ b/LibTest/html/Element/removeEventListener_A01_t02.dart
@@ -35,7 +35,7 @@ main() {
   body?.addEventListener(type, handler1, true);
   body?.addEventListener(type, handler2, true);
 
-  asyncMultiStart(3); // first time two handlers, second time one handler
+  asyncStart(3); // first time two handlers, second time one handler
   var event = new Event(type);
   x.dispatchEvent(event);
   event = new Event(type);

--- a/LibTest/html/Event/currentTarget_A01_t01.dart
+++ b/LibTest/html/Event/currentTarget_A01_t01.dart
@@ -24,6 +24,6 @@ main() {
     asyncEnd();
   });
 
-  asyncMultiStart(2);
+  asyncStart(2);
   div.dispatchEvent(new MouseEvent('click'));
 }

--- a/LibTest/html/Event/defaultPrevented_A01_t01.dart
+++ b/LibTest/html/Event/defaultPrevented_A01_t01.dart
@@ -25,6 +25,6 @@ main() {
     asyncEnd();
   });
 
-  asyncMultiStart(2);
+  asyncStart(2);
   div.dispatchEvent(new MouseEvent('click'));
 }

--- a/LibTest/html/Event/eventPhase_A01_t01.dart
+++ b/LibTest/html/Event/eventPhase_A01_t01.dart
@@ -30,7 +30,7 @@ main() {
       asyncEnd();
     });
 
-    asyncMultiStart(3);
+    asyncStart(3);
     div.dispatchEvent(new MouseEvent('click'));
   } else {
     Expect.fail("Body is null");

--- a/LibTest/html/Event/matchingTarget_A01_t01.dart
+++ b/LibTest/html/Event/matchingTarget_A01_t01.dart
@@ -38,7 +38,7 @@ main() {
       asyncEnd();
     });
 
-    asyncMultiStart(2);
+    asyncStart(2);
     id1.click();
     class1.click();
   } else {

--- a/LibTest/html/Event/target_A01_t01.dart
+++ b/LibTest/html/Event/target_A01_t01.dart
@@ -30,7 +30,7 @@ main() {
       asyncEnd();
     });
 
-    asyncMultiStart(3);
+    asyncStart(3);
     div.dispatchEvent(new MouseEvent('click'));
   } else {
     Expect.fail("Body is null");

--- a/LibTest/html/IFrameElement/addEventListener_A01_t03.dart
+++ b/LibTest/html/IFrameElement/addEventListener_A01_t03.dart
@@ -15,7 +15,7 @@ main() {
   IFrameElement x = new IFrameElement();
   document.body?.append(x);
 
-  asyncMultiStart(3);
+  asyncStart(3);
 
   x.addEventListener(type, (e) {
     Expect.equals(type, e.type);

--- a/LibTest/html/IFrameElement/addEventListener_A01_t04.dart
+++ b/LibTest/html/IFrameElement/addEventListener_A01_t04.dart
@@ -16,7 +16,7 @@ main() {
   IFrameElement x = new IFrameElement();
   document.body?.append(x);
 
-  asyncMultiStart(2);
+  asyncStart(2);
 
   // intercept on capture
   document.body?.addEventListener(type, (e) {

--- a/LibTest/html/IFrameElement/addEventListener_A01_t05.dart
+++ b/LibTest/html/IFrameElement/addEventListener_A01_t05.dart
@@ -17,7 +17,7 @@ main() {
 
   var n = 10;
 
-  asyncMultiStart(n);
+  asyncStart(n);
 
   EventListener genHandler() => (e) {
         Expect.equals(type, e.type);

--- a/LibTest/html/IFrameElement/addEventListener_A01_t06.dart
+++ b/LibTest/html/IFrameElement/addEventListener_A01_t06.dart
@@ -17,7 +17,7 @@ main() {
 
   var n = 10;
 
-  asyncMultiStart(n);
+  asyncStart(n);
 
   EventListener genHandler() => (e) {
         Expect.equals(type, e.type);

--- a/LibTest/html/IFrameElement/removeEventListener_A01_t01.dart
+++ b/LibTest/html/IFrameElement/removeEventListener_A01_t01.dart
@@ -33,7 +33,7 @@ main() {
   x.addEventListener(type, handler1);
   x.addEventListener(type, handler2);
 
-  asyncMultiStart(3); // first time two handlers, second time one handler
+  asyncStart(3); // first time two handlers, second time one handler
   var event = new Event(type);
   x.dispatchEvent(event);
   event = new Event(type);

--- a/LibTest/html/IFrameElement/removeEventListener_A01_t02.dart
+++ b/LibTest/html/IFrameElement/removeEventListener_A01_t02.dart
@@ -35,7 +35,7 @@ main() {
   body?.addEventListener(type, handler1, true);
   body?.addEventListener(type, handler2, true);
 
-  asyncMultiStart(3); // first time two handlers, second time one handler
+  asyncStart(3); // first time two handlers, second time one handler
   var event = new Event(type);
   x.dispatchEvent(event);
   event = new Event(type);

--- a/LibTest/html/Node/addEventListener_A01_t01.dart
+++ b/LibTest/html/Node/addEventListener_A01_t01.dart
@@ -31,7 +31,7 @@ main() {
     document,
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/addEventListener_A01_t02.dart
+++ b/LibTest/html/Node/addEventListener_A01_t02.dart
@@ -29,7 +29,7 @@ main() {
     document,
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/addEventListener_A01_t03.dart
+++ b/LibTest/html/Node/addEventListener_A01_t03.dart
@@ -31,7 +31,7 @@ main() {
     document,
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/addEventListener_A01_t04.dart
+++ b/LibTest/html/Node/addEventListener_A01_t04.dart
@@ -32,7 +32,7 @@ main() {
     document,
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/addEventListener_A01_t05.dart
+++ b/LibTest/html/Node/addEventListener_A01_t05.dart
@@ -34,7 +34,7 @@ main() {
     document,
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length * n);
+  asyncStart(targets.length * n);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/dispatchEvent_A01_t01.dart
+++ b/LibTest/html/Node/dispatchEvent_A01_t01.dart
@@ -24,7 +24,7 @@ main() {
     new IFrameElement(),
     document,
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/on_A01_t01.dart
+++ b/LibTest/html/Node/on_A01_t01.dart
@@ -25,7 +25,7 @@ main() {
     new IFrameElement(),
     new DocumentFragment(),
   ];
-  asyncMultiStart(targets.length);
+  asyncStart(targets.length);
   for (Node x in targets) {
     check(x);
   }

--- a/LibTest/html/Node/removeEventListener_A01_t01.dart
+++ b/LibTest/html/Node/removeEventListener_A01_t01.dart
@@ -43,7 +43,7 @@ main() {
     new Comment("Comment"),
     new DocumentFragment(),
   ];
-  asyncMultiStart(
+  asyncStart(
       targets.length * 3); // first time two handlers, second time one handler
   for (Node x in targets) {
     check(x);

--- a/LibTest/html/Node/removeEventListener_A01_t02.dart
+++ b/LibTest/html/Node/removeEventListener_A01_t02.dart
@@ -43,7 +43,7 @@ main() {
     new Comment("Comment"),
     new DocumentFragment(),
   ];
-  asyncMultiStart(
+  asyncStart(
       targets.length * 3); // first time two handlers, second time one handler
   for (Node x in targets) {
     check(x);

--- a/LibTest/io/File/create_A02_t01.dart
+++ b/LibTest/io/File/create_A02_t01.dart
@@ -49,7 +49,7 @@ _test(Directory sandbox, {bool exclusive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, exclusive: false);
   await _test(sandbox, exclusive: true);
 }

--- a/LibTest/io/File/create_A02_t02.dart
+++ b/LibTest/io/File/create_A02_t02.dart
@@ -47,7 +47,7 @@ _test(Directory sandbox, {bool exclusive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, exclusive: false);
   await _test(sandbox, exclusive: true);
 }

--- a/LibTest/io/File/create_A03_t01.dart
+++ b/LibTest/io/File/create_A03_t01.dart
@@ -48,7 +48,7 @@ _test(Directory sandbox, {bool recursive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, recursive: false);
   await _test(sandbox, recursive: true);
 }

--- a/LibTest/io/File/create_A03_t02.dart
+++ b/LibTest/io/File/create_A03_t02.dart
@@ -48,7 +48,7 @@ _test(Directory sandbox, {bool recursive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, recursive: true);
   await _test(sandbox, recursive: false);
 }

--- a/LibTest/io/File/create_A03_t03.dart
+++ b/LibTest/io/File/create_A03_t03.dart
@@ -57,7 +57,7 @@ _test(Directory sandbox, {bool recursive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, recursive: false);
   await _test(sandbox, recursive: true);
 }

--- a/LibTest/io/File/create_A03_t04.dart
+++ b/LibTest/io/File/create_A03_t04.dart
@@ -57,7 +57,7 @@ _test(Directory sandbox, {bool recursive = false}) async {
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(2);
+  asyncStart(2);
   await _test(sandbox, recursive: false);
   await _test(sandbox, recursive: true);
 }

--- a/LibTest/io/File/create_A04_t01.dart
+++ b/LibTest/io/File/create_A04_t01.dart
@@ -51,7 +51,7 @@ _test(Directory sandbox,
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(4);
+  asyncStart(4);
   await _test(sandbox, recursive: false, exclusive: false);
   await _test(sandbox, recursive: false, exclusive: true);
   await _test(sandbox, recursive: true, exclusive: false);

--- a/LibTest/io/File/create_A04_t02.dart
+++ b/LibTest/io/File/create_A04_t02.dart
@@ -52,7 +52,7 @@ _test(Directory sandbox,
 }
 
 void _main(Directory sandbox) async {
-  asyncMultiStart(4);
+  asyncStart(4);
   await _test(sandbox, recursive: false, exclusive: false);
   await _test(sandbox, recursive: false, exclusive: true);
   await _test(sandbox, recursive: true, exclusive: false);

--- a/LibTest/io/file_utils.dart
+++ b/LibTest/io/file_utils.dart
@@ -20,9 +20,11 @@ Future<Object?> inSandbox(Object? test(Directory sandbox),
     sandbox = getTempDirectorySync();
   }
   try {
+    asyncStart();
     return await test(sandbox);
   } finally {
     sandbox.deleteSync(recursive: true);
+    asyncEnd();
   }
 }
 
@@ -52,6 +54,7 @@ Future<void> testFileSystemEvent<T extends FileSystemEvent>(Directory root,
     if (failIfNoEvent) {
       Expect.fail("No event was fired for $eventsTimeout seconds");
     }
+    return;
   });
   test(event);
 }


### PR DESCRIPTION
- `asyncStart/End()` updated to correspond SDK version
- `asyncMultiStart()` removed and replaced by `asyncStart()`
- added `asyncStart/End()` to `inSandbox()` function