### PR TITLE
#2436. Add expected constant evaluation error for CFE

### DIFF
--- a/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t01.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t01.dart
@@ -20,7 +20,11 @@ class C {
 }
 
 enum E {
+//   ^
+// [cfe] unspecified
   a(1);
+//^
+// [cfe] unspecified
 
   final int x;
   external const E(this.x);

--- a/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t02.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t02.dart
@@ -20,7 +20,11 @@ class C {
 }
 
 enum E {
+//   ^
+// [cfe] unspecified
   a(x: 1);
+//^
+// [cfe] unspecified
 
   final int x;
   external const E({this.x = 0});

--- a/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t03.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t03.dart
@@ -20,7 +20,11 @@ class C {
 }
 
 enum E {
+//   ^
+// [cfe] unspecified
   a(x: 1);
+//^
+// [cfe] unspecified
 
   final int x;
   external const E({required this.x});

--- a/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t04.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/initializing_formal_parameter_A02_t04.dart
@@ -20,7 +20,11 @@ class C {
 }
 
 enum E {
+//   ^
+// [cfe] unspecified
   a(1);
+//^
+// [cfe] unspecified
 
   final int x;
   external const E([this.x = 0]);


### PR DESCRIPTION
These tests fail in CFE because of the constant evaluation error. I believe it's Ok and updated the tests accordingly