### PR TITLE
#2548. Add `out` and `inout` to built-in identifiers tests

### DIFF
--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t01.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t01.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the declared name of a class, mixin or enum.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+class inout {}
+//    ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+mixin inout {}
+//    ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+enum inout {e1;}
+//   ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t02.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the declared name of a type variable.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+class C<inout> {
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+mixin M<inout> {
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E<inout> {
+//     ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  e1;
+}
+
+void foo<inout>() {}
+//       ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  print(C);
+  print(M);
+  print(E);
+  print(foo);
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t03.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t03.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the declared name of a type alias.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+typedef int inout();
+//          ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef inout = int;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t04.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t04.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the declared name of a prefix.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+import "../lib.dart" as inout;
+//                      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  inout.x;
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t05.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t05.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the name of an extension.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+extension inout on int {}
+//        ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t06.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t06.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `inout` is used as the name, type parameter or alias of an extension
+/// type
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=inline-class,variance
+
+extension type inout(int _) {}
+//             ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ListET<inout>(List<inout> _) {}
+//                    ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ET(int _) {}
+
+typedef inout = ET;
+//      ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t01.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t01.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the declared name of a class, mixin or enum.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+class out {}
+//    ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+mixin out {}
+//    ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+enum out {e1;}
+//   ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t02.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the declared name of a type variable.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+class C<out> {
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+mixin M<out> {
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E<out> {
+//     ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  e1;
+}
+
+void foo<out>() {}
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  print(C);
+  print(M);
+  print(E);
+  print(foo);
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t03.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t03.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the declared name of a type alias.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+typedef int out();
+//          ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef out = int;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t04.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t04.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the declared name of a prefix.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+import "../lib.dart" as out;
+//                      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  out.x;
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t05.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t05.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the name of an extension.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=variance
+
+extension out on int {}
+//        ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t06.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t06.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `out` is used as the name, type parameter or alias of an extension
+/// type
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=inline-class,variance
+
+extension type out(int _) {}
+//             ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ListET<out>(List<out> _) {}
+//                    ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ET(int _) {}
+
+typedef out = ET;
+//      ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
