### PR TITLE
#2559. Add tests checking that `augment` is a built-in identifier

### DIFF
--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A01_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A01_t02.dart
@@ -34,9 +34,33 @@ void foo<abstract>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<abstract> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<abstract>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<abstract extends Comparable<abstract>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<abstract>()? c = null;
+//                  ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A02_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A02_t02.dart
@@ -34,9 +34,33 @@ void foo<as>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<as> on List {}
+//            ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<as>();
+//             ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<as extends Comparable<as>> = int Function();
+//         ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<as>()? c = null;
+//                  ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A03_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A03_t02.dart
@@ -34,9 +34,33 @@ void foo<covariant>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<covariant> on List {}
+//            ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<covariant>();
+//             ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<covariant extends Comparable<covariant>> = int Function();
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<covariant>()? c = null;
+//                  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A04_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A04_t02.dart
@@ -35,9 +35,33 @@ void foo<deferred>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<deferred> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<deferred>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<deferred extends Comparable<deferred>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<deferred>()? c = null;
+//                  ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A05_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A05_t02.dart
@@ -34,9 +34,33 @@ void foo<dynamic>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<dynamic> on List {}
+//            ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<dynamic>();
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<dynamic extends Comparable<dynamic>> = int Function();
+//         ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<dynamic>()? c = null;
+//                  ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A06_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A06_t02.dart
@@ -34,9 +34,33 @@ void foo<export>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<export> on List {}
+//            ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<export>();
+//             ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<export extends Comparable<export>> = int Function();
+//         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<export>()? c = null;
+//                  ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A07_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A07_t02.dart
@@ -34,9 +34,33 @@ void foo<external>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<external> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<external>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<external extends Comparable<external>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<external>()? c = null;
+//                  ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A08_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A08_t02.dart
@@ -29,8 +29,28 @@ enum E<extension> {
   e1;
 }
 
-void foo<external>() {}
-//       ^^^^^^^^
+void foo<extension>() {}
+//       ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension Ext<extension> on List {}
+//            ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<extension>();
+//             ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<extension extends Comparable<extension>> = int Function();
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<extension>()? c = null;
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
@@ -39,4 +59,8 @@ main() {
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A09_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A09_t02.dart
@@ -34,9 +34,33 @@ void foo<factory>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<factory> on List {}
+//            ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<factory>();
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<factory extends Comparable<factory>> = int Function();
+//         ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<factory>()? c = null;
+//                  ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A10_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A10_t02.dart
@@ -34,9 +34,33 @@ void foo<Function>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<Function> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<Function>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<Function extends Comparable<Function>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<Function>()? c = null;
+//                  ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A11_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A11_t02.dart
@@ -34,9 +34,33 @@ void foo<get>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<get> on List {}
+//            ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<get>();
+//             ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<get extends Comparable<get>> = int Function();
+//         ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<get>()? c = null;
+//                  ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A12_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A12_t02.dart
@@ -34,9 +34,33 @@ void foo<implements>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<implements> on List {}
+//            ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<implements>();
+//             ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<implements extends Comparable<implements>> = int Function();
+//         ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<implements>()? c = null;
+//                  ^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A13_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A13_t02.dart
@@ -34,9 +34,33 @@ void foo<import>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<import> on List {}
+//            ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<import>();
+//             ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<import extends Comparable<import>> = int Function();
+//         ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<import>()? c = null;
+//                  ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A14_t02.dart
@@ -36,9 +36,33 @@ void foo<inout>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<inout> on List {}
+//            ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<inout>();
+//             ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<inout extends Comparable<inout>> = int Function();
+//         ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<inout>()? c = null;
+//                  ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A15_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A15_t02.dart
@@ -34,9 +34,33 @@ void foo<interface>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<interface> on List {}
+//            ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<interface>();
+//             ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<interface extends Comparable<interface>> = int Function();
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<interface>()? c = null;
+//                  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A16_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A16_t02.dart
@@ -34,9 +34,33 @@ void foo<late>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<late> on List {}
+//            ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<late>();
+//             ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<late extends Comparable<late>> = int Function();
+//         ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<late>()? c = null;
+//                  ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A17_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A17_t02.dart
@@ -34,9 +34,33 @@ void foo<library>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<library> on List {}
+//            ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<library>();
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<library extends Comparable<library>> = int Function();
+//         ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<library>()? c = null;
+//                  ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A18_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A18_t02.dart
@@ -34,9 +34,33 @@ void foo<mixin>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<mixin> on List {}
+//            ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<mixin>();
+//             ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<mixin extends Comparable<mixin>> = int Function();
+//         ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<mixin>()? c = null;
+//                  ^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A19_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A19_t02.dart
@@ -34,9 +34,33 @@ void foo<operator>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<operator> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<operator>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<operator extends Comparable<operator>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<operator>()? c = null;
+//                  ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A20_t02.dart
@@ -36,9 +36,33 @@ void foo<out>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<out> on List {}
+//            ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<out>();
+//             ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<out extends Comparable<out>> = int Function();
+//         ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<out>()? c = null;
+//                  ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A21_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A21_t02.dart
@@ -34,9 +34,33 @@ void foo<part>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<part> on List {}
+//            ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<part>();
+//             ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<part extends Comparable<part>> = int Function();
+//         ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<part>()? c = null;
+//                  ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A22_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A22_t02.dart
@@ -29,8 +29,28 @@ enum E<required> {
   e1;
 }
 
-void foo<mixin>() {}
-//       ^^^^^
+void foo<required>() {}
+//       ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension Ext<required> on List {}
+//            ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<required>();
+//             ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<required extends Comparable<required>> = int Function();
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<required>()? c = null;
+//                  ^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
@@ -39,4 +59,8 @@ main() {
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A23_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A23_t02.dart
@@ -30,7 +30,27 @@ enum E<set> {
 }
 
 void foo<set>() {}
-//       ^^^^
+//       ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension Ext<set> on List {}
+//            ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<set>();
+//             ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<set extends Comparable<set>> = int Function();
+//         ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<set>()? c = null;
+//                  ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
@@ -39,4 +59,8 @@ main() {
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A24_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A24_t02.dart
@@ -34,9 +34,33 @@ void foo<static>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<static> on List {}
+//            ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<static>();
+//             ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<static extends Comparable<augment>> = int Function();
+//         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<static>()? c = null;
+//                  ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A25_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A25_t02.dart
@@ -34,9 +34,33 @@ void foo<typedef>() {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+extension Ext<typedef> on List {}
+//            ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef int F1<typedef>();
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<typedef extends Comparable<augment>> = int Function();
+//         ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<typedef>()? c = null;
+//                  ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
+  print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t01.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t01.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the declared name of a class, mixin or enum.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+class augment {}
+//    ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+mixin augment {}
+//    ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+enum augment {e1;}
+//   ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t02.dart
@@ -41,10 +41,28 @@ extension Ext<augment> on List {}
 // [analyzer] unspecified
 // [cfe] unspecified
 
+typedef int F1<augment>();
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef F2<augment extends Comparable<augment>> = int Function();
+//         ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+const void Function<augment>()? c = null;
+//                  ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
 main() {
   print(C);
   print(M);
   print(E);
   print(foo);
   print(List);
+  print(F1);
+  print(F2);
+  print(c);
 }

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t02.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t02.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the declared name of a type variable.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+class C<augment> {
+//      ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+mixin M<augment> {
+//      ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E<augment> {
+//     ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  e1;
+}
+
+void foo<augment>() {}
+//       ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension Ext<augment> on List {}
+//            ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  print(C);
+  print(M);
+  print(E);
+  print(foo);
+  print(List);
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t03.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t03.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the declared name of a type alias.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+typedef int augment();
+//          ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+typedef augment = int;
+//      ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t04.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t04.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the declared name of a prefix.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+import "../lib.dart" as augment;
+//                      ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+  augment.x;
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t05.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t05.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the name of an extension.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+extension augment on int {}
+//        ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t06.dart
+++ b/Language/Expressions/Identifier_Reference/built_in_identifier_A26_t06.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a syntax error if a built-in identifier is used as the
+/// declared name of a prefix, class, mixin, enum, type parameter, type alias,
+/// or extension.
+///
+/// @description Checks that it is a compile-time error if a built-in identifier
+/// `augment` is used as the name, type parameter or alias of an extension type
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+extension type augment(int _) {}
+//             ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ListET<augment>(List<augment> _) {}
+//                    ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+extension type ET(int _) {}
+
+typedef augment = ET;
+//      ^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}


### PR DESCRIPTION
According to the Augmentation libraries [specification](https://github.com/dart-lang/language/blob/main/working/augmentation-libraries/feature-specification.md)

> There is a new built-in identifier, augment, which is used to syntactically mark a declaration as an augmentation of an existing one.