### PR TITLE
#2559. Add augmenting types tests. Part 5

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A04_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A04_t01.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a compile-time error if:
+/// ...
+/// - An augmenting extension declares an on clause. We don't allow filling this
+///   in for extensions, it must be on the original declaration. This
+///   restriction could be lifted later if we have a compelling use case, as
+///   there is no fundamental reason it cannot be allowed, although it would be
+///   a parse error today to have an extension with no on clause.
+///
+/// @description Checks that it is a compile-time error if an augmenting
+/// extension declares an `on` clause
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+import augment 'augmenting_types_A04_t01_lib.dart';
+
+class C {}
+
+extension Ext on C {
+  String foo() => "Extension Ext on C";
+}
+
+extension on C {
+  String bar() => "Extension on C";
+}
+
+main() {
+  print(C);
+}

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A04_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A04_t01_lib.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion It is a compile-time error if:
+/// ...
+/// - An augmenting extension declares an on clause. We don't allow filling this
+///   in for extensions, it must be on the original declaration. This
+///   restriction could be lifted later if we have a compelling use case, as
+///   there is no fundamental reason it cannot be allowed, although it would be
+///   a parse error today to have an extension with no on clause.
+///
+/// @description Checks that it is a compile-time error if an augmenting
+/// extension declares an `on` clause
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+augment library 'augmenting_types_A04_t01.dart';
+
+augment extension on C {
+//                ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+augment extension Ext on C {
+//                    ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}


### PR DESCRIPTION
This PR doesn't include test for augmenting unnamed extension (`augment extension {...}`). I'm expecting it to be a compile-time error. But probably a separate statement will be added for this case. Anyway I'll add an appropriate test later