### PR TITLE
#2559. Make enum augmenting types tests stronger

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A01_t01_lib2.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A01_t01_lib2.dart
@@ -15,12 +15,12 @@
 
 augment library 'augmenting_types_A01_t01.dart';
 
-augment enum C {}
+augment enum C {e0;}
 //           ^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-augment enum M {}
+augment enum M {e0;}
 //           ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A01_t02_lib2.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A01_t02_lib2.dart
@@ -15,12 +15,12 @@
 
 augment library 'augmenting_types_A01_t02.dart';
 
-augment enum CAlias {}
+augment enum CAlias {e0;}
 //           ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-augment enum MAlias {}
+augment enum MAlias {e0;}
 //           ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified


### PR DESCRIPTION
Add enum values to avoid false-positive outcome because of missing values