### PR TITLE
Fixes #2624. Add more extension type tests for union types

### DIFF
--- a/LanguageFeatures/Extension-types/nullability_A01_t05.dart
+++ b/LanguageFeatures/Extension-types/nullability_A01_t05.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An extension type `V` is a proper subtype of `Object?`. It is
+/// potentially non-nullable, unless it implements `Object` or a subtype thereof
+///
+/// @description Checks that an extension type is assignable to a type `T?` when
+/// `T` is its representation type
+/// @author sgrekhov22@gmail.com
+
+import "../../Utils/expect.dart";
+
+extension type ET(int _) implements int {}
+
+main() {
+  int? et = null;
+  if (2 > 1) {
+    et = ET(1);
+  }
+  int x = et is int ? et : 2;
+  Expect.equals(1, x);
+}

--- a/LanguageFeatures/Extension-types/nullability_A01_t05.dart
+++ b/LanguageFeatures/Extension-types/nullability_A01_t05.dart
@@ -6,7 +6,7 @@
 /// potentially non-nullable, unless it implements `Object` or a subtype thereof
 ///
 /// @description Checks that an extension type is assignable to a type `T?` when
-/// `T` is its representation type
+/// it implements `T`
 /// @author sgrekhov22@gmail.com
 
 import "../../Utils/expect.dart";

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t01.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+namedArgumentsFunc1(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+positionalArgumentsFunc1(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(FutureOr<int> t1) {}
+
+  ArgumentsBindingClass.named(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(FutureOr<int> t1, {FutureOr<int> t2  = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  namedArgumentsMethod(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  positionalArgumentsMethod(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  set testSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(forgetType(t0Instance), t2: forgetType(t0Instance));
+  positionalArgumentsFunc1(forgetType(t0Instance), forgetType(t0Instance));
+
+  // test class constructors
+  ArgumentsBindingClass instance1 =
+      new ArgumentsBindingClass(forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1 = new ArgumentsBindingClass.positional(forgetType(t0Instance),
+      forgetType(t0Instance));
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance1.positionalArgumentsMethod(forgetType(t0Instance),
+      forgetType(t0Instance));
+  instance1.testSetter = forgetType(t0Instance);
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(
+      forgetType(t0Instance), forgetType(t0Instance));
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<FutureOr<int>>(forgetType(t0Instance), t2: forgetType(t0Instance));
+
+  // test generic class constructors
+  ArgumentsBindingGen<FutureOr<int>> instance2 =
+      new ArgumentsBindingGen<FutureOr<int>>(forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<FutureOr<int>>.fNamed(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2 = new ArgumentsBindingGen<FutureOr<int>>.named(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(forgetType(t0Instance),
+      t2: forgetType(t0Instance));
+  instance2.testSetter = forgetType(t0Instance);
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t02.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t02.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x02.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+class ArgumentsBindingSuper1_t02 {
+  FutureOr<int> m;
+
+  ArgumentsBindingSuper1_t02(FutureOr<int> value): m = value {}
+  ArgumentsBindingSuper1_t02.named(FutureOr<int> value, {FutureOr<int> val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(FutureOr<int> value, [FutureOr<int> val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(FutureOr<int> val) {}
+  void superTestPositioned(FutureOr<int> val, [FutureOr<int> val2 = t1Default]) {}
+  void superTestNamed(FutureOr<int> val, {FutureOr<int> val2 = t1Default}) {}
+  FutureOr<int> get superGetter => m;
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value) : m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}) : m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+
+  ArgumentsBinding2_t02<FutureOr<int>> c2 =
+    new ArgumentsBinding2_t02<FutureOr<int>>(forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<FutureOr<int>>.c2(t1Instance, forgetType(t0Instance));
+  c2 = new ArgumentsBinding2_t02<FutureOr<int>>.c5(forgetType(t0Instance));
+
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+  c2.superGetter;
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t02.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t02.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t03.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t03.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x03.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+mixin class ArgumentsBindingMixin1_t03 {
+  FutureOr<int> m = t1Default;
+
+  void superTest(FutureOr<int> val) {}
+  void superTestPositioned(FutureOr<int> val, [FutureOr<int> val2 = t1Default]) {}
+  void superTestNamed(FutureOr<int> val, {FutureOr<int> val2 = t1Default}) {}
+  FutureOr<int> get superGetter => m;
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin class ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(forgetType(t0Instance), t1Instance);
+  c1.superTest(forgetType(t0Instance));
+  c1.superTestPositioned(forgetType(t0Instance));
+  c1.superTestPositioned(t1Instance, forgetType(t0Instance));
+  c1.superTestNamed(forgetType(t0Instance));
+  c1.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c1.superSetter = forgetType(t0Instance);
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<FutureOr<int>> c2 = new ArgumentsBinding2_t03<FutureOr<int>>();
+  c2.test(forgetType(t0Instance), t1Instance);
+  c2.superTest(forgetType(t0Instance));
+  c2.superTestNamed(t1Instance, val2: forgetType(t0Instance));
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t03.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_arguments_binding_A11_t03.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t01.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+class ClassMember1_t01 {
+  static FutureOr<int> s = forgetType(t0Instance);
+  FutureOr<int> m = forgetType(t0Instance);
+  FutureOr<int> _p = forgetType(t0Instance);
+
+  ClassMember1_t01() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  ClassMember1_t01.named(FutureOr<int> value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = forgetType(t0Instance);
+    m = forgetType(t0Instance);
+    _p = forgetType(t0Instance);
+  }
+
+  set setter(FutureOr<int> val) {
+    _p = val;
+  }
+
+  FutureOr<int> get getter => forgetType(_p);
+
+  static staticTest() {
+    s = forgetType(t0Instance);
+  }
+
+  static set staticSetter(FutureOr<int> val) {
+    s = val;
+  }
+
+  static FutureOr<int> get staticGetter => forgetType(t0Instance);
+}
+
+class ClassMember2_t01<X> {
+  X m;
+  X _p;
+
+  ClassMember2_t01():  m = forgetType(t0Instance), _p = forgetType(t0Instance) {
+  }
+
+  ClassMember2_t01.named(X value): m = value, _p = value {
+  }
+
+  ClassMember2_t01.short(this.m, this._p);
+
+  test(X v) {
+    m = v;
+    _p = v;
+  }
+
+  set setter(X val) {
+    _p = val;
+  }
+
+  FutureOr<int> get getter => forgetType(_p);
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(forgetType(t0Instance),
+      forgetType(t0Instance));
+  c1 = new ClassMember1_t01.named(forgetType(t0Instance));
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.setter = forgetType(t0Instance);
+  c1.getter;
+
+  ClassMember1_t01.s = forgetType(t0Instance);
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = forgetType(t0Instance);
+  ClassMember1_t01.staticGetter;
+
+  // Test type parameters
+
+  ClassMember2_t01<FutureOr<int>> c2 = new ClassMember2_t01<FutureOr<int>>();
+  c2 = new ClassMember2_t01<FutureOr<int>>.short(forgetType(t0Instance),
+  forgetType(t0Instance));
+  c2 = new ClassMember2_t01<FutureOr<int>>.named(forgetType(t0Instance));
+  c2.m = forgetType(t0Instance);
+  c2.test(forgetType(t0Instance));
+  c2.getter;
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t02.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t02.dart
@@ -1,0 +1,106 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x02.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+class ClassMemberSuper1_t02 {
+  FutureOr<int> m;
+
+  ClassMemberSuper1_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember1_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+class ClassMemberSuper2_t02<X> {
+  X m;
+
+  ClassMemberSuper2_t02(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.named(dynamic value): m = value {
+  }
+
+  ClassMemberSuper2_t02.short(this.m);
+
+  void set superSetter(X val) {}
+}
+
+class ClassMember2_t02<X> extends ClassMemberSuper2_t02<X> {
+
+  ClassMember2_t02() : super(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.named() : super.named(forgetType(t0Instance)) {}
+
+  ClassMember2_t02.short() : super.short(forgetType(t0Instance));
+
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t02<FutureOr<int>> c2 = new ClassMember2_t02<FutureOr<int>>();
+  c2 = new ClassMember2_t02<FutureOr<int>>.short();
+  c2 = new ClassMember2_t02<FutureOr<int>>.named();
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t02.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t02.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t03.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t03.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x03.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+mixin class ClassMemberMixin1_t03 {
+  FutureOr<int> m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+mixin class ClassMemberMixin2_t03<X> {
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember2_t03<X> extends Object with ClassMemberMixin2_t03<X> {
+  X m;
+  ClassMember2_t03(X x): m = x {  }
+  test() {
+    m = forgetType(t0Instance);
+    superSetter = forgetType(t0Instance);
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = forgetType(t0Instance);
+  c1.test();
+  c1.superSetter = forgetType(t0Instance);
+
+  // Test type parameters
+
+  ClassMember2_t03<FutureOr<int>> c2 = new ClassMember2_t03<FutureOr<int>>(t1Instance);
+  c2.m = forgetType(t0Instance);
+  c2.test();
+  c2.superSetter = forgetType(t0Instance);
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t03.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_class_member_A11_t03.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_global_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_global_variable_A11_t01.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/global_variable_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  foo() {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  static test() {
+    t1Instance = forgetType(t0Instance);
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = forgetType(t0Instance);
+  }
+
+  t1Instance = forgetType(t0Instance);
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_global_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_global_variable_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_local_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_local_variable_A11_t01.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/local_variable_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    FutureOr<int> t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  static staticTest() {
+    FutureOr<int> t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  test() {
+    FutureOr<int> t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+}
+
+main() {
+  foo() {
+    FutureOr<int> t1 = forgetType(t0Instance);
+    t1 = forgetType(t0Instance);
+  }
+
+  FutureOr<int> t1 = forgetType(t0Instance);
+  t1 = forgetType(t0Instance);
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_local_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_local_variable_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_return_value_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_return_value_A11_t01.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/return_value_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import '../../utils/common.dart';
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+FutureOr<int> returnValueFunc() => forgetType(t0Instance);
+
+class ReturnValueTest {
+  static FutureOr<int> staticTestMethod() => forgetType(t0Instance);
+
+  FutureOr<int> testMethod() => forgetType(t0Instance);
+
+  FutureOr<int> get testGetter => forgetType(t0Instance);
+}
+
+class ReturnValueGen<X> {
+  X testMethod() => forgetType(t0Instance);
+  X get testGetter => forgetType(t0Instance);
+}
+
+main() {
+  FutureOr<int> returnValueLocalFunc() => forgetType(t0Instance);
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+
+  // Test type parameters
+
+  new ReturnValueGen<FutureOr<int>>().testMethod();
+  new ReturnValueGen<FutureOr<int>>().testGetter;
+}

--- a/TypeSystem/subtyping/dynamic/generated/extension_type_return_value_A11_t01.dart
+++ b/TypeSystem/subtyping/dynamic/generated/extension_type_return_value_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t01.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+namedArgumentsFunc1(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+positionalArgumentsFunc1(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+namedArgumentsFunc2<X>(X t1, {required X t2}) {}
+
+class ArgumentsBindingClass {
+  ArgumentsBindingClass(FutureOr<int> t1) {}
+
+  ArgumentsBindingClass.named(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  ArgumentsBindingClass.positional(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  factory ArgumentsBindingClass.fNamed(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {
+    return new ArgumentsBindingClass.named(t1, t2: t2);
+  }
+  factory ArgumentsBindingClass.fPositional(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {
+    return new ArgumentsBindingClass.positional(t1, t2);
+  }
+
+  static namedArgumentsStaticMethod(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  static positionalArgumentsStaticMethod(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  namedArgumentsMethod(FutureOr<int> t1, {FutureOr<int> t2 = t1Default}) {}
+  positionalArgumentsMethod(FutureOr<int> t1, [FutureOr<int> t2 = t1Default]) {}
+
+  set testSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBindingGen<X>  {
+  ArgumentsBindingGen(X t1) {}
+
+  ArgumentsBindingGen.named(X t1, {required X t2}) {}
+
+  factory ArgumentsBindingGen.fNamed(X t1, {required X t2}) {
+    return new ArgumentsBindingGen.named(t1, t2: t2);
+  }
+
+  namedArgumentsMethod(X t1, {required X t2}) {}
+
+  set testSetter(X val) {}
+}
+
+main() {
+  // test functions
+  namedArgumentsFunc1(t0Instance, t2: t0Instance);
+  positionalArgumentsFunc1(t0Instance, t0Instance);
+
+  // test class constructors
+  ArgumentsBindingClass instance1 = new ArgumentsBindingClass(t0Instance);
+  instance1 = new ArgumentsBindingClass.fNamed(t0Instance, t2: t0Instance);
+  instance1 = new ArgumentsBindingClass.fPositional(t0Instance, t0Instance);
+  instance1 = new ArgumentsBindingClass.named(t0Instance, t2: t0Instance);
+  instance1 = new ArgumentsBindingClass.positional(t0Instance, t0Instance);
+
+  // tests methods and setters
+  instance1.namedArgumentsMethod(t0Instance, t2: t0Instance);
+  instance1.positionalArgumentsMethod(t0Instance, t0Instance);
+  instance1.testSetter = t0Instance;
+
+  // test static methods
+  ArgumentsBindingClass.namedArgumentsStaticMethod(t0Instance, t2: t0Instance);
+  ArgumentsBindingClass.positionalArgumentsStaticMethod(t0Instance, t0Instance);
+
+  // Test type parameters
+
+  // test generic functions
+  namedArgumentsFunc2<FutureOr<int>>(t0Instance, t2: t0Instance);
+
+  // test generic class constructors
+  ArgumentsBindingGen<FutureOr<int>> instance2 = new ArgumentsBindingGen<FutureOr<int>>(t0Instance);
+  instance2 = new ArgumentsBindingGen<FutureOr<int>>.fNamed(t0Instance, t2: t0Instance);
+  instance2 = new ArgumentsBindingGen<FutureOr<int>>.named(t0Instance, t2: t0Instance);
+
+  // test generic class methods and setters
+  instance2.namedArgumentsMethod(t0Instance, t2: t0Instance);
+  instance2.testSetter = t0Instance;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t02.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t02.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test superclass members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x02.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+class ArgumentsBindingSuper1_t02 {
+  FutureOr<int> m = t1Default;
+
+  ArgumentsBindingSuper1_t02(FutureOr<int> value): m = value {}
+  ArgumentsBindingSuper1_t02.named(FutureOr<int> value, {FutureOr<int> val2 = t1Default}): m = value {}
+  ArgumentsBindingSuper1_t02.positional(FutureOr<int> value, [FutureOr<int> val2 = t1Default]): m = value {}
+  ArgumentsBindingSuper1_t02.short(this.m);
+
+  void superTest(FutureOr<int> val) {}
+  void superTestPositioned(FutureOr<int> val, [FutureOr<int> val2 = t1Default]) {}
+  void superTestNamed(FutureOr<int> val, {FutureOr<int> val2 = t1Default}) {}
+  FutureOr<int> get superGetter => m;
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBinding1_t02 extends ArgumentsBindingSuper1_t02 {
+  ArgumentsBinding1_t02(dynamic t1) : super(t1) {}
+  ArgumentsBinding1_t02.c1(dynamic t1) : super.named(t1) {}
+  ArgumentsBinding1_t02.c2(dynamic t1, dynamic t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding1_t02.c3(dynamic t1) : super.positional(t1) {}
+  ArgumentsBinding1_t02.c4(dynamic t1, dynamic t2) : super.positional(t1, t2) {}
+  ArgumentsBinding1_t02.c5(dynamic t1) : super.short(t1) {}
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+class ArgumentsBindingSuper2_t02<X> {
+  X m;
+
+  ArgumentsBindingSuper2_t02(X value): m = value {}
+  ArgumentsBindingSuper2_t02.named(X value, {required X val2}): m = value {}
+  ArgumentsBindingSuper2_t02.short(this.m);
+
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  X get superGetter => m;
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t02<X> extends ArgumentsBindingSuper2_t02<X> {
+  ArgumentsBinding2_t02(X t1) : super(t1) {}
+  ArgumentsBinding2_t02.c2(X t1, X t2) : super.named(t1, val2: t2) {}
+  ArgumentsBinding2_t02.c5(X t1) : super.short(t1) {}
+
+  test(X t1, X t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t02 c1 = new ArgumentsBinding1_t02(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c1(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c2(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c3(t0Instance);
+  c1 = new ArgumentsBinding1_t02.c4(t1Instance, t0Instance);
+  c1 = new ArgumentsBinding1_t02.c5(t0Instance);
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(t0Instance);
+  c1.superTestPositioned(t0Instance);
+  c1.superTestPositioned(t1Instance, t0Instance);
+  c1.superTestNamed(t0Instance);
+  c1.superTestNamed(t1Instance, val2: t0Instance);
+  c1.superSetter = t0Instance;
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t02<FutureOr<int>> c2 =
+    new ArgumentsBinding2_t02<FutureOr<int>>(t0Instance);
+  c2 = new ArgumentsBinding2_t02<FutureOr<int>>.c2(t1Instance, t0Instance);
+  c2 = new ArgumentsBinding2_t02<FutureOr<int>>.c5(t0Instance);
+
+  c2.test(t0Instance, t1Instance);
+  c2.superTest(t0Instance);
+  c2.superTestNamed(t1Instance, val2: t0Instance);
+  c2.superSetter = t0Instance;
+  c2.superGetter;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t02.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t02.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t03.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t03.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t03.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_arguments_binding_A11_t03.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as an argument of type T1. Test mixin members
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/arguments_binding_x03.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+mixin ArgumentsBindingMixin1_t03 {
+  FutureOr<int> m = t1Default;
+
+  void superTest(FutureOr<int> val) {}
+  void superTestPositioned(FutureOr<int> val, [FutureOr<int> val2 = t1Default]) {}
+  void superTestNamed(FutureOr<int> val, {FutureOr<int> val2 = t1Default}) {}
+  FutureOr<int> get superGetter => m;
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ArgumentsBinding1_t03 extends Object with ArgumentsBindingMixin1_t03 {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestPositioned(t1);
+    superTestPositioned(t2, t1);
+    superTestNamed(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+    m = t1;
+    superGetter;
+  }
+}
+
+mixin ArgumentsBindingMixin2_t03<X> {
+  void superTest(X val) {}
+  void superTestNamed(X val, {required X val2}) {}
+  void set superSetter(X val) {}
+}
+
+class ArgumentsBinding2_t03<X> extends Object with ArgumentsBindingMixin2_t03<X> {
+
+  test(dynamic t1, dynamic t2) {
+    superTest(t1);
+    superTestNamed(t2, val2: t1);
+    superSetter = t1;
+  }
+}
+
+main() {
+  ArgumentsBinding1_t03 c1 = new ArgumentsBinding1_t03();
+
+  c1.test(t0Instance, t1Instance);
+  c1.superTest(t0Instance);
+  c1.superTestPositioned(t0Instance);
+  c1.superTestPositioned(t1Instance, t0Instance);
+  c1.superTestNamed(t0Instance);
+  c1.superTestNamed(t1Instance, val2: t0Instance);
+  c1.superSetter = t0Instance;
+  c1.superGetter;
+
+  // Test type parameters
+  ArgumentsBinding2_t03<FutureOr<int>> c2 = new ArgumentsBinding2_t03<FutureOr<int>>();
+  c2.test(t0Instance, t1Instance);
+  c2.superTest(t0Instance);
+  c2.superTestNamed(t1Instance, val2: t0Instance);
+  c2.superSetter = t0Instance;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t01.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the class member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+class ClassMember1_t01 {
+  static FutureOr<int> s = t0Instance;
+  FutureOr<int> m = t0Instance;
+  FutureOr<int> _p = t0Instance;
+
+  ClassMember1_t01() {
+    s = t0Instance;
+    m = t0Instance;
+    _p = t0Instance;
+  }
+
+  ClassMember1_t01.named(FutureOr<int> value) {
+    s = value;
+    m = value;
+    _p = value;
+  }
+
+  ClassMember1_t01.short(this.m, this._p);
+
+  test() {
+    s = t0Instance;
+    m = t0Instance;
+    _p = t0Instance;
+  }
+
+  set setter(FutureOr<int> val) {
+    _p = val;
+  }
+
+  FutureOr<int> get getter => _p;
+
+  static staticTest() {
+    s = t0Instance;
+  }
+
+  static set staticSetter(FutureOr<int> val) {
+    s = val;
+  }
+
+  static FutureOr<int> get staticGetter => t0Instance;
+}
+
+main() {
+  ClassMember1_t01 c1 = new ClassMember1_t01();
+  c1 = new ClassMember1_t01.short(t0Instance,
+      t0Instance);
+  c1 = new ClassMember1_t01.named(t0Instance);
+  c1.m = t0Instance;
+  c1.test();
+  c1.setter = t0Instance;
+  c1.getter;
+
+  ClassMember1_t01.s = t0Instance;
+  ClassMember1_t01.staticTest();
+  ClassMember1_t01.staticSetter = t0Instance;
+  ClassMember1_t01.staticGetter;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t02.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t02.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the superclass member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x02.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+class ClassMemberSuper1_t02 {
+  FutureOr<int> m = t1Default;
+
+  ClassMemberSuper1_t02(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.named(dynamic value) {
+    m = value;
+  }
+
+  ClassMemberSuper1_t02.short(this.m);
+
+  void set superSetter(FutureOr<int> val) {}
+}
+
+class ClassMember1_t02 extends ClassMemberSuper1_t02 {
+
+  ClassMember1_t02() : super(t0Instance) {}
+
+  ClassMember1_t02.named() : super.named(t0Instance) {}
+
+  ClassMember1_t02.short() : super.short(t0Instance);
+
+  test() {
+    m = t0Instance;
+    superSetter = t0Instance;
+  }
+}
+
+main() {
+  ClassMember1_t02 c1 = new ClassMember1_t02();
+  c1 = new ClassMember1_t02.short();
+  c1 = new ClassMember1_t02.named();
+  c1.m = t0Instance;
+  c1.test();
+  c1.superSetter = t0Instance;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t02.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t02.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t03.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t03.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the mixin member of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/class_member_x03.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+mixin class ClassMemberMixin1_t03 {
+  FutureOr<int> m = t1Default;
+
+  void set superSetter(dynamic val) {}
+}
+
+class ClassMember1_t03 extends Object with ClassMemberMixin1_t03 {
+  test() {
+    m = t0Instance;
+    superSetter = t0Instance;
+  }
+}
+
+main() {
+  ClassMember1_t03 c1 = new ClassMember1_t03();
+  c1.m = t0Instance;
+  c1.test();
+  c1.superSetter = t0Instance;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t03.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_class_member_A11_t03.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_global_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_global_variable_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_global_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_global_variable_A11_t01.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to global variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/global_variable_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+class GlobalVariableTest {
+  GlobalVariableTest() {
+    t1Instance = t0Instance;
+  }
+
+  foo() {
+    t1Instance = t0Instance;
+  }
+
+  static test() {
+    t1Instance = t0Instance;
+  }
+}
+
+main() {
+  bar () {
+    t1Instance = t0Instance;
+  }
+
+  t1Instance = t0Instance;
+  bar();
+  GlobalVariableTest t = new GlobalVariableTest();
+  t.foo();
+  GlobalVariableTest.test();
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_local_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_local_variable_A11_t01.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be assigned to the to local variable of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/local_variable_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+class LocalVariableTest {
+
+  LocalVariableTest() {
+    FutureOr<int> t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  static staticTest() {
+    FutureOr<int> t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  test() {
+    FutureOr<int> t1 = t0Instance;
+    t1 = t0Instance;
+  }
+}
+
+main() {
+  foo() {
+    FutureOr<int> t1 = t0Instance;
+    t1 = t0Instance;
+  }
+
+  FutureOr<int> t1 = t0Instance;
+  t1 = t0Instance;
+  foo();
+  LocalVariableTest x = new LocalVariableTest();
+  x.test();
+  LocalVariableTest.staticTest();
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_local_variable_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_local_variable_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/static/generated/extension_type_return_value_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_return_value_A11_t01.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+///
+/// @description Check that if type T0 is a subtype of a type T1, then instance
+/// of T0 can be used as a return value of type T1
+/// @author sgrekhov@unipro.ru
+///
+/// This test is generated from test_types/extension_type_A11.dart and
+/// test_cases/return_value_x01.dart. Don't modify it!
+/// If you need to change this test, then change one of the files above and then
+/// run generator/generator.dart to regenerate the tests.
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+ET t0Instance = ET(Future<int>(() => 2));
+
+FutureOr<int> returnValueFunc() => t0Instance;
+
+class ReturnValueTest {
+  static FutureOr<int> staticTestMethod() => t0Instance;
+
+  FutureOr<int> testMethod() => t0Instance;
+
+  FutureOr<int> get testGetter => t0Instance;
+}
+
+main() {
+  FutureOr<int> returnValueLocalFunc() => t0Instance;
+
+  returnValueFunc();
+  returnValueLocalFunc();
+
+  ReturnValueTest.staticTestMethod();
+
+  new ReturnValueTest().testMethod();
+  new ReturnValueTest().testGetter;
+}

--- a/TypeSystem/subtyping/static/generated/extension_type_return_value_A11_t01.dart
+++ b/TypeSystem/subtyping/static/generated/extension_type_return_value_A11_t01.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 ///

--- a/TypeSystem/subtyping/test_types/extension_type_A11.dart
+++ b/TypeSystem/subtyping/test_types/extension_type_A11.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We say that a type T0 is a subtype of a type T1 (written
+/// T0 <: T1) when:
+/// Assume that DV declares an extension type declaration named Name with type
+/// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
+/// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
+///
+/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
+/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
+/// `i`. Test union types.
+/// @author sgrekhov22@gmail.com
+/// @issue 55578
+
+import "dart:async";
+
+extension type ET(Future<int> _) implements Future<int> {}
+
+FutureOr<int> t1Instance = Future<int>(() => 1);
+ET t0Instance = ET(Future<int>(() => 2));
+
+const t1Default = 42;
+
+//# @T0 = ET
+//# @T1 = FutureOr<int>

--- a/TypeSystem/subtyping/test_types/extension_type_A11.dart
+++ b/TypeSystem/subtyping/test_types/extension_type_A11.dart
@@ -8,9 +8,8 @@
 /// parameters X1 .. Xs, and V1 is a superinterface of DV. Then Name<T1, .. Ts>
 /// is a subtype of [T1/X1 .. Ts/Xs]V1 for all T1, .. Ts.
 ///
-/// @description Check that an extension type `ET<T1, ..., Ts>` is a subtype of
-/// an extension type `ET<X1, ..., Xs>` if `Ti` is a subtype of `Xi` for all
-/// `i`. Test union types.
+/// @description Check that an extension type `ET` that implements `S` is a
+/// subtype of `FutureOr<S>`.
 /// @author sgrekhov22@gmail.com
 /// @issue 55578
 


### PR DESCRIPTION
For subtyping tests it's enough to review `TypeSystem/subtyping/test_types/extension_type_A11.dart`. All other tests are generated ones