### PR TITLE
#2641. Add wildcard initializer tests

### DIFF
--- a/LanguageFeatures/Wildcards/binding_A03_t01.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t01.dart
@@ -7,7 +7,7 @@
 /// the same namespace without a collision error. The initializer, if there is
 /// one, is still executed, but the value is not accessible.
 ///
-/// @description Checks that an initializer is executed for local variables
+/// @description Checks that an initializer is executed for local variable
 /// declarations named `_`
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Wildcards/binding_A03_t01.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t01.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A local declaration whose name is `_` does not bind that name to
+/// anything. This means you can have multiple local declarations named `_` in
+/// the same namespace without a collision error. The initializer, if there is
+/// one, is still executed, but the value is not accessible.
+///
+/// @description Checks that an initializer is executed for local variables
+/// declarations named `_`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+import '../../Utils/expect.dart';
+
+String _log = "";
+
+int init(int val) {
+  _log += "init($val);";
+  return val;
+}
+
+test1() {
+  var _ = init(1);
+}
+
+test2() {
+  final _ = init(2);
+}
+
+test3() {
+  int _ = init(3);
+}
+
+test4() {
+  int _ = init(4), _ = init(5);
+}
+
+main() {
+  test1();
+  Expect.equals("init(1);", _log);
+  _log = "";
+
+  test2();
+  Expect.equals("init(2);", _log);
+  _log = "";
+
+  test3();
+  Expect.equals("init(3);", _log);
+  _log = "";
+
+  test4();
+  Expect.equals("init(4);init(5);", _log);
+}

--- a/LanguageFeatures/Wildcards/binding_A03_t02.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t02.dart
@@ -7,7 +7,7 @@
 /// the same namespace without a collision error. The initializer, if there is
 /// one, is still executed, but the value is not accessible.
 ///
-/// @description Checks that for late local variables declarations named `_`
+/// @description Checks that for late local variable declarations named `_`
 /// initializer is not executed
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Wildcards/binding_A03_t02.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t02.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A local declaration whose name is `_` does not bind that name to
+/// anything. This means you can have multiple local declarations named `_` in
+/// the same namespace without a collision error. The initializer, if there is
+/// one, is still executed, but the value is not accessible.
+///
+/// @description Checks that for late local variables declarations named `_`
+/// initializer is not executed
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+import '../../Utils/expect.dart';
+
+String _log = "";
+
+int init(int val) {
+  _log = "init($val);";
+  return val;
+}
+
+test1() {
+  late var _ = init(1);
+}
+
+test2() {
+  late final _ = init(2);
+}
+
+test3() {
+  late int _ = init(3);
+}
+
+main() {
+  test1();
+  Expect.equals("", _log);
+  test2();
+  Expect.equals("", _log);
+  test3();
+  Expect.equals("", _log);
+}

--- a/LanguageFeatures/Wildcards/binding_A03_t03.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t03.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A local declaration whose name is `_` does not bind that name to
+/// anything. This means you can have multiple local declarations named `_` in
+/// the same namespace without a collision error. The initializer, if there is
+/// one, is still executed, but the value is not accessible.
+///
+/// @description Checks that an initializer is executed for for-loop variables
+/// declarations named `_`
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+import '../../Utils/expect.dart';
+
+String _log = "";
+
+int init(int val) {
+  _log += "init($val);";
+  return val;
+}
+
+main() {
+  for (int _ = init(1);;) {
+    break;
+  }
+  Expect.equals("init(1);", _log);
+  _log = "";
+
+  for (int _ = init(2), _ = init(3);;) {
+    break;
+  }
+  Expect.equals("init(2);init(3);", _log);
+}


### PR DESCRIPTION
Function parameters initializers must be constants therefore cannot be tested