### PR TITLE
#2641. Check that it is still an error to declare more than one enum member named `_`

### DIFF
--- a/LanguageFeatures/Wildcards/other_declarations_A05_t22.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t22.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test a static variable vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  static int _ = 1;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  static int _ = 1;
+  static int _() => 2;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  static int _ = 1;
+  static int get _ => 3;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4 {
+  e0;
+  static int _ = 1;
+//           ^
+// [cfe] unspecified
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E5 {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+  final int _ = 5;
+//          ^
+// [cfe] unspecified
+}
+
+enum E6 {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+  int _() => 6;
+//    ^
+// [cfe] unspecified
+}
+
+enum E6With with ContainsWildcardMethod {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E7 {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+  int get _ => 7;
+//        ^
+// [cfe] unspecified
+}
+
+enum E7With with ContainsWildcardGetter {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E8 {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set _(int v) {}
+//         ^
+// [cfe] unspecified
+}
+
+enum E8With with ContainsWildcardSetter {
+  e0;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E3);
+  print(E4);
+  print(E5);
+  print(E6);
+  print(E6With);
+  print(E7);
+  print(E7With);
+  print(E8);
+  print(E8With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t23.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t23.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test a static getter vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  static int get _ => 1;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  static int get _ => 1;
+  static int _() => 2;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  static int get _ => 1;
+  static int get _ => 3;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4 {
+  e0;
+  static int get _ => 1;
+  static void set _(int v) {}  // Ok
+}
+
+enum E5 {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+  final int _ = 5;
+//          ^
+// [cfe] unspecified
+}
+
+enum E6 {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+  int _() => 6;
+//    ^
+// [cfe] unspecified
+}
+
+enum E6With with ContainsWildcardMethod {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E7 {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+  int get _ => 7;
+//        ^
+// [cfe] unspecified
+}
+
+enum E7With with ContainsWildcardGetter {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E8 {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set _(int v) {}
+}
+
+enum E8With with ContainsWildcardSetter {
+  e0;
+  static int get _ => 1;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E3);
+  print(E4);
+  print(E5);
+  print(E6);
+  print(E6With);
+  print(E7);
+  print(E7With);
+  print(E8);
+  print(E8With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t24.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t24.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test a static method vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  static int _() => 1;
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  static int _() => 1;
+  static int _() => 2;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  static int _() => 1;
+  static int get _ => 3;
+//               ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4 {
+  e0;
+  static int _() => 1;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E5 {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+  final int _ = 5;
+//          ^
+// [cfe] unspecified
+}
+
+enum E6 {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+  int _() => 6;
+//    ^
+// [cfe] unspecified
+}
+
+enum E6With with ContainsWildcardMethod {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E7 {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+  int get _ => 7;
+//        ^
+// [cfe] unspecified
+}
+
+enum E7With with ContainsWildcardGetter {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E8 {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void set _(int v) {}
+}
+
+enum E8With with ContainsWildcardSetter {
+  e0;
+  static int _() => 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E3);
+  print(E4);
+  print(E5);
+  print(E6);
+  print(E6With);
+  print(E7);
+  print(E7With);
+  print(E8);
+  print(E8With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t25.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t25.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test a static setter vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [cfe] unspecified
+  static int _ = 1;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  static void set _(int v) {}
+  static int _() => 2;
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  static void set _(int v) {}
+  static int get _ => 3; // Ok
+}
+
+enum E4 {
+  e0;
+  static void set _(int v) {}
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E5 {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  final int _ = 5;
+}
+
+enum E6 {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  int _() => 6;
+}
+
+enum E6With with ContainsWildcardMethod {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E7 {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+  int get _ => 7;
+}
+
+enum E7With with ContainsWildcardGetter {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E8 {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+  void set _(int v) {}
+//         ^
+// [cfe] unspecified
+}
+
+enum E8With with ContainsWildcardSetter {
+  e0;
+  static void set _(int v) {}
+//                ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+
+main() {
+  print(E1);
+  print(E2);
+  print(E3);
+  print(E4);
+  print(E5);
+  print(E6);
+  print(E7);
+  print(E8);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t26.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t26.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test an instance variable vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  final int _ = 1;
+  final int _ = 5;
+//          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  final int _ = 1;
+  int _() => 6;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2With with ContainsWildcardMethod {
+  e0;
+  final int _ = 1;
+//          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  final int _ = 1;
+  int get _ => 7;
+//        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3With with ContainsWildcardGetter {
+  e0;
+  final int _ = 1; // Ok
+}
+
+enum E4 {
+  e0;
+  final int _ = 1;
+  void set _(int v) {} // Ok
+}
+
+enum E4With with ContainsWildcardSetter {
+  e0;
+  final int _ = 1; // Ok
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E2With);
+  print(E3);
+  print(E3With);
+  print(E4);
+  print(E4With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t27.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t27.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test an instance getter vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  int get _ => 1;
+  final int _ = 5;
+//          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  int get _ => 1;
+  int _() => 6;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2With with ContainsWildcardMethod {
+  e0;
+  int get _ => 1;
+//        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  int get _ => 1;
+  int get _ => 7;
+//        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3With with ContainsWildcardGetter {
+  e0;
+  int get _ => 1; // Ok
+}
+
+enum E4 {
+  e0;
+  int get _ => 1;
+  void set _(int v) {} // Ok
+}
+
+enum E4With with ContainsWildcardSetter {
+  e0;
+  int get _ => 1; // Ok
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E2With);
+  print(E3);
+  print(E3With);
+  print(E4);
+  print(E4With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t28.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t28.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test an instance method vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  int _() => 1;
+  final int _ = 5;
+//          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2 {
+  e0;
+  int _() => 1;
+  int _() => 6;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2With with ContainsWildcardMethod {
+  e0;
+  int _() => 1; // Ok
+}
+
+enum E3 {
+  e0;
+  int _() => 1;
+  int get _ => 7;
+//        ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3With with ContainsWildcardGetter {
+  e0;
+  int _() => 1;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4 {
+  e0;
+  int _() => 1;
+  void set _(int v) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4With with ContainsWildcardSetter {
+  e0;
+  int _() => 1;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E2With);
+  print(E3);
+  print(E3With);
+  print(E4);
+  print(E4With);
+}

--- a/LanguageFeatures/Wildcards/other_declarations_A05_t29.dart
+++ b/LanguageFeatures/Wildcards/other_declarations_A05_t29.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Other declarations: top-level variables, top-level function
+/// names, type names, member names, etc. are unchanged. They can be named `_`
+/// as they are today.
+///
+/// @description Checks that it is a compile-time error to declare more than one
+/// member named `_`. Test an instance setter vs other enum members conflict.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=wildcard-variables
+
+mixin class ContainsWildcardMethod {
+  int _() => 0;
+}
+
+mixin class ContainsWildcardGetter {
+  int get _ => 0;
+}
+
+mixin class ContainsWildcardSetter {
+  void set _(int v) {}
+}
+
+enum E1 {
+  e0;
+  void set _(int v) {}
+  final int _ = 5; // Ok
+}
+
+enum E2 {
+  e0;
+  void set _(int v) {}
+  int _() => 6;
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E2With with ContainsWildcardMethod {
+  e0;
+  void set _(int v) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E3 {
+  e0;
+  void set _(int v) {}
+  int get _ => 7; // Ok
+}
+
+enum E3With with ContainsWildcardGetter {
+  e0;
+  void set _(int v) {} // Ok
+}
+
+enum E4 {
+  e0;
+  void set _(int v) {}
+  void set _(int v) {}
+//         ^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+enum E4With with ContainsWildcardSetter {
+  e0;
+  void set _(int v) {} // Ok
+}
+
+main() {
+  print(E1);
+  print(E2);
+  print(E2With);
+  print(E3);
+  print(E3With);
+  print(E4);
+  print(E4With);
+}


### PR DESCRIPTION
There are no "implements" tests because `enum E implements ContainsWildcardMethod` is an error itself without implementation of `_`