### PR TITLE
Fixes #2668. Reorder switch expressions to avoid flow analysis secondary issues

### DIFF
--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t04.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t04.dart
@@ -73,9 +73,14 @@ int test6(S s) {
   }
 }
 
-
 void main() {
   S s = F();
+
+  var i0 = switch (s) { C _ => 1, F _ => 2 };
+//         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
   int i1 = switch (s) { C _ => 1 };
 //         ^^^^^^
 // [analyzer] unspecified
@@ -91,10 +96,9 @@ void main() {
 // [analyzer] unspecified
 // [cfe] unspecified
 
+  // The same as `i0` but the error is not reported. It's flow analysis issue
+  // described in #53392. Considered Ok.
   var i4 = switch (s) { C _ => 1, F _ => 2 };
-//         ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 
   final i5 = switch (s) { M _ => 1, F _ => 2 };
 //           ^^^^^^

--- a/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t05.dart
+++ b/LanguageFeatures/Patterns/Exhaustiveness/exhaustiveness_sealed_A02_t05.dart
@@ -75,6 +75,11 @@ int test6(S s) {
 
 void main() {
   S s = F();
+  var i0 = switch (s) { C() => 1, F() => 2 };
+//         ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
   int i1 = switch (s) { C() => 1 };
 //         ^^^^^^
 // [analyzer] unspecified
@@ -90,10 +95,9 @@ void main() {
 // [analyzer] unspecified
 // [cfe] unspecified
 
+  // The same as `i0` but the error is not reported. It's flow analysis issue
+  // described in #53392. Considered Ok.
   var i4 = switch (s) { C() => 1, F() => 2 };
-//         ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 
   final i5 = switch (s) { M() => 1, F() => 2 };
 //           ^^^^^^


### PR DESCRIPTION
The fix suggested in this comment https://github.com/dart-lang/sdk/issues/53392#issuecomment-2113062914  doesn’t work. Adding `{...}` doesn’t help, but reordering does.

It’s hard for me to explain why I preserved `i4` expecting no error. To me, it seems useful to have these issues somewhere in the tests. If, one day, someone fixes it (probably unintentionally), and flow analysis starts reporting an error for `i4` too, then the tests will fail, and the author will know that (s)he fixed it as well.

If you believe that it is not necessary, let me know, and I’ll remove it. At least there is no issue in real life. To make the code work, people have to fix all their issues, and eventually, the unreported ones become the first one and will be reported. 