### PR TITLE
#2559. Update assertion text and rename some tests

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t01.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t01_lib.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t02.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t02_lib.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t03.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t03_lib.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t04.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t04_lib.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t05.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A09_t05_lib.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
+/// @assertion A compile-time error occurs if a declaration with the basename
 /// `augmented` occurs in a location where the outermost enclosing declaration
 /// is augmenting.
 ///
@@ -17,24 +17,24 @@ augment library 'augmented_expression_A09_t05.dart';
 
 augment class C {
   static void staticMethod<augmented>(int v) {}
-//                          ^^^^^^^^^
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
   void instanceMethod<augmented>(int v) {}
-//                     ^^^^^^^^^
+//                    ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment mixin M {
   static void staticMethod<augmented>(int v) {}
-//                          ^^^^^^^^^
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
   void instanceMethod<augmented>(int v) {}
-//                     ^^^^^^^^^
+//                    ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
@@ -42,24 +42,24 @@ augment mixin M {
 augment enum E {
   augment e0;
   static void staticMethod<augmented>(int v) {}
-//                          ^^^^^^^^^
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
   void instanceMethod<augmented>(int v) {}
-//                     ^^^^^^^^^
+//                    ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension Ext {
   static void staticMethod<augmented>(int v) {}
-//                          ^^^^^^^^^
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
   void instanceMethod<augmented>(int v) {}
-//                     ^^^^^^^^^
+//                    ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test an object pattern.
+/// function named `augmented` in a location where the outermost enclosing
+/// declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t13_lib.dart';
+import augment 'augmented_expression_A10_t01_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01_lib.dart
@@ -2,60 +2,60 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a parenthesized pattern.
+/// function named `augmented` in a location where the outermost enclosing
+/// declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t07.dart';
+augment library 'augmented_expression_A10_t01.dart';
 
 augment class C {
   static void staticMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -63,45 +63,45 @@ augment class C {
 
 augment mixin M {
   static void staticMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -110,45 +110,45 @@ augment mixin M {
 augment enum E {
   augment e0;
   static void staticMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -156,45 +156,45 @@ augment enum E {
 
 augment extension Ext {
   static void staticMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented) = 42;
-//       ^^^^^^^^^
+    int augmented() => 42;
+//      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a variable pattern.
+/// enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t08_lib.dart';
+import augment 'augmented_expression_A10_t02_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02_lib.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
@@ -13,7 +13,7 @@
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t07.dart';
+augment library 'augmented_expression_A10_t02.dart';
 
 augment class C {
   static void staticMethod() {

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a map pattern.
+/// enclosing declaration is augmenting. Test a variable pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t11_lib.dart';
+import augment 'augmented_expression_A10_t03_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03_lib.dart
@@ -2,200 +2,248 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// enclosing declaration is augmenting. Test a variable pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t12.dart';
+augment library 'augmented_expression_A10_t03.dart';
 
 augment class C {
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment mixin M {
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment enum E {
   augment e0;
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment extension Ext {
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    switch((1,)) {
+      case (var augmented,):
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting.
+/// enclosing declaration is augmenting. Test a parenthesized pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t07_lib.dart';
+import augment 'augmented_expression_A10_t04_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04_lib.dart
@@ -2,248 +2,200 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test an object pattern.
+/// enclosing declaration is augmenting. Test a parenthesized pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t13.dart';
+augment library 'augmented_expression_A10_t04.dart';
 
 augment class C {
   static void staticMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment mixin M {
   static void staticMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment enum E {
   augment e0;
   static void staticMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment extension Ext {
   static void staticMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
+    int (augmented) = 42;
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// enclosing declaration is augmenting. Test a list pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t12_lib.dart';
+import augment 'augmented_expression_A09_t10_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05_lib.dart
@@ -2,60 +2,60 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a map pattern.
+/// enclosing declaration is augmenting. Test a list pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t11.dart';
+augment library 'augmented_expression_A09_t10.dart';
 
 augment class C {
   static void staticMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -63,45 +63,45 @@ augment class C {
 
 augment mixin M {
   static void staticMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -110,45 +110,45 @@ augment mixin M {
 augment enum E {
   augment e0;
   static void staticMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -156,45 +156,45 @@ augment enum E {
 
 augment extension Ext {
   static void staticMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
+    var [augmented] = [42];
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a parenthesized pattern.
+/// enclosing declaration is augmenting. Test a map pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t09_lib.dart';
+import augment 'augmented_expression_A10_t06_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06_lib.dart
@@ -2,60 +2,60 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// function named `augmented` in a location where the outermost enclosing
-/// declaration is augmenting.
+/// variable whose name is `augmented` in a location where the outermost
+/// enclosing declaration is augmenting. Test a map pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t06.dart';
+augment library 'augmented_expression_A10_t06.dart';
 
 augment class C {
   static void staticMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -63,45 +63,45 @@ augment class C {
 
 augment mixin M {
   static void staticMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -110,45 +110,45 @@ augment mixin M {
 augment enum E {
   augment e0;
   static void staticMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -156,45 +156,45 @@ augment enum E {
 
 augment extension Ext {
   static void staticMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int augmented() => 42;
-//      ^^^^^^^^^
+    var {"key": augmented} = {"key": 42};
+//              ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t07.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t07.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// function named `augmented` in a location where the outermost enclosing
-/// declaration is augmenting.
+/// variable whose name is `augmented` in a location where the outermost
+/// enclosing declaration is augmenting. Test a record pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t06_lib.dart';
+import augment 'augmented_expression_A10_t07_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t07_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t07_lib.dart
@@ -2,248 +2,200 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a variable pattern.
+/// enclosing declaration is augmenting. Test a record pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t08.dart';
+augment library 'augmented_expression_A10_t07.dart';
 
 augment class C {
   static void staticMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment mixin M {
   static void staticMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment enum E {
   augment e0;
   static void staticMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }
 
 augment extension Ext {
   static void staticMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   static int get staticGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   void instanceMethod() {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 
   int get instanceGetter {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
+    int (augmented,) = (42,);
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-    }
   }
 }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a list pattern.
+/// enclosing declaration is augmenting. Test an object pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A09_t10_lib.dart';
+import augment 'augmented_expression_A10_t08_lib.dart';
 
 class C {}
 mixin M {}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08_lib.dart
@@ -2,200 +2,248 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A compile-time error occurs if a declaration with the name
-/// `augmented` occurs in a location where the outermost enclosing declaration
-/// is augmenting.
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
 /// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a list pattern.
+/// enclosing declaration is augmenting. Test an object pattern.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A09_t10.dart';
+augment library 'augmented_expression_A10_t08.dart';
 
 augment class C {
   static void staticMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment mixin M {
   static void staticMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment enum E {
   augment e0;
   static void staticMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }
 
 augment extension Ext {
   static void staticMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   static int get staticGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   static void set staticSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   void instanceMethod() {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 
   int get instanceGetter {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
     return 0;
   }
 
   void set instanceSetter(int _) {
-    var [augmented] = [42];
-//       ^^^^^^^^^
+    switch(1) {
+      case int(isEven: var augmented):
+//                         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
+    }
   }
 }


### PR DESCRIPTION
Tests that renamed to `*_A10_*` check another statement in the spec. So they were renamed and assertion text updated. There will be more tests. We need tests for initializing expression, for example.