### PR TITLE
#2559. Remove erroneous test cases, add more tests for augmented expression

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t01_lib.dart
@@ -167,13 +167,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    int augmented() => 42;
-//      ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   void instanceMethod() {
     int augmented() => 42;
 //      ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t02_lib.dart
@@ -247,17 +247,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    int augmented = 42;
-//      ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    for (int augmented = 0; augmented < 0; augmented++) {}
-//           ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   void instanceMethod() {
     int augmented = 42;
 //      ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t03_lib.dart
@@ -207,15 +207,6 @@ augment enum E {
     }
   }
 
-  final instanceVariable = () {
-    switch((1,)) {
-      case (var augmented,):
-//              ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    }
-  };
-
   void instanceMethod() {
     switch((1,)) {
       case (var augmented,):

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t04_lib.dart
@@ -160,13 +160,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    int (augmented) = 42;
-//       ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   void instanceMethod() {
     int (augmented) = 42;
 //       ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t05_lib.dart
@@ -166,13 +166,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    var [augmented] = [42];
-//       ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   void instanceMethod() {
     var [augmented] = [42];
 //       ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t06_lib.dart
@@ -173,13 +173,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    var {"key": augmented} = {"key": 42};
-//              ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   int get instanceGetter {
     var {"key": augmented} = {"key": 42};
 //              ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t08_lib.dart
@@ -206,15 +206,6 @@ augment enum E {
     }
   }
 
-  final instanceVariable = () {
-    switch(1) {
-      case int(isEven: var augmented):
-//                         ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    }
-  };
-
   void instanceMethod() {
     switch(1) {
       case int(isEven: var augmented):

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t09_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t09_lib.dart
@@ -246,17 +246,6 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
-    int v = augmented;
-//          ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-    for (int i = augmented; i < 0; i++) {}
-//               ^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  };
-
   void instanceMethod() {
     int v = augmented;
 //          ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t10_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t10_lib.dart
@@ -46,6 +46,37 @@ augment class C {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     augmented? x;
 //  ^^^^^^^^^
@@ -62,6 +93,37 @@ augment class C {
   };
 
   void instanceMethod() {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     augmented? x;
 //  ^^^^^^^^^
 // [analyzer] unspecified
@@ -108,6 +170,37 @@ augment mixin M {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     augmented? x;
 //  ^^^^^^^^^
@@ -124,6 +217,37 @@ augment mixin M {
   };
 
   void instanceMethod() {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     augmented? x;
 //  ^^^^^^^^^
 // [analyzer] unspecified
@@ -172,7 +296,7 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
+  static int get staticGetter {
     augmented? x;
 //  ^^^^^^^^^
 // [analyzer] unspecified
@@ -185,9 +309,56 @@ augment enum E {
 //   ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
 
   void instanceMethod() {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     augmented? x;
 //  ^^^^^^^^^
 // [analyzer] unspecified
@@ -233,7 +404,70 @@ augment extension Ext {
 // [analyzer] unspecified
 // [cfe] unspecified
   }
+
+  static int get staticGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   void instanceMethod() {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    augmented? x;
+//  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    var f = (augmented x) {};
+//           ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    (augmented? x,) r = (null,);
+//   ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     augmented? x;
 //  ^^^^^^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t11.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t11.dart
@@ -21,7 +21,7 @@ class C {}
 
 mixin M {}
 
-enum E2 {
+enum E {
   e1;
 }
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t11_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t11_lib.dart
@@ -32,6 +32,23 @@ augment class C {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     foo(); // Ok
     foo(augmented: 1);
@@ -41,6 +58,23 @@ augment class C {
   };
 
   void instanceMethod() {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     foo(); // Ok
     foo(augmented: 1);
 //      ^^^^^^^^^
@@ -66,6 +100,23 @@ augment mixin M {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     foo(); // Ok
     foo(augmented: 1);
@@ -75,6 +126,23 @@ augment mixin M {
   };
 
   void instanceMethod() {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     foo(); // Ok
     foo(augmented: 1);
 //      ^^^^^^^^^
@@ -101,15 +169,41 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
+  static int get staticGetter {
     foo(); // Ok
     foo(augmented: 1);
 //      ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
 
   void instanceMethod() {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     foo(); // Ok
     foo(augmented: 1);
 //      ^^^^^^^^^
@@ -135,7 +229,41 @@ augment extension Ext {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   void instanceMethod() {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    foo(); // Ok
+    foo(augmented: 1);
+//      ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     foo(); // Ok
     foo(augmented: 1);
 //      ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t12_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t12_lib.dart
@@ -30,6 +30,21 @@ augment class C {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     print((augmented: 1));
 //         ^^^^^^^^^
@@ -38,6 +53,21 @@ augment class C {
   };
 
   void instanceMethod() {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     print((augmented: 1));
 //         ^^^^^^^^^
 // [analyzer] unspecified
@@ -60,6 +90,21 @@ augment mixin M {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   var instanceVariable = () {
     print((augmented: 1));
 //         ^^^^^^^^^
@@ -68,6 +113,21 @@ augment mixin M {
   };
 
   void instanceMethod() {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     print((augmented: 1));
 //         ^^^^^^^^^
 // [analyzer] unspecified
@@ -91,14 +151,42 @@ augment enum E {
 // [cfe] unspecified
   }
 
-  final instanceVariable = () {
+  static int get staticGetter {
     print((augmented: 1));
 //         ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  final instanceVariable = (augmented: 1);
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 
   void instanceMethod() {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     print((augmented: 1));
 //         ^^^^^^^^^
 // [analyzer] unspecified
@@ -121,7 +209,37 @@ augment extension Ext {
 // [cfe] unspecified
   }
 
+  static int get staticGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
   void instanceMethod() {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print((augmented: 1));
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     print((augmented: 1));
 //         ^^^^^^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t13.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t13.dart
@@ -21,7 +21,7 @@ class C {}
 
 mixin M {}
 
-enum E2 {
+enum E {
   e1;
 }
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t13_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t13_lib.dart
@@ -50,6 +50,41 @@ augment class C {
     };
   }
 
+  static int get staticGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
   var instanceVariable = () {
     switch ("") {
       case augmented:
@@ -68,6 +103,41 @@ augment class C {
   };
 
   void instanceMethod() {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
+  int get instanceGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     switch ("") {
       case augmented:
 //         ^^^^^^^^^
@@ -120,6 +190,41 @@ augment mixin M {
     };
   }
 
+  static int get staticGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
   var instanceVariable = () {
     switch ("") {
       case augmented:
@@ -138,6 +243,41 @@ augment mixin M {
   };
 
   void instanceMethod() {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
+  int get instanceGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     switch ("") {
       case augmented:
 //         ^^^^^^^^^
@@ -191,7 +331,7 @@ augment enum E {
     };
   }
 
-  final instanceVariable = () {
+  static int get staticGetter {
     switch ("") {
       case augmented:
 //         ^^^^^^^^^
@@ -206,9 +346,62 @@ augment enum E {
 // [cfe] unspecified
       _ => 0
     };
-  };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
 
   void instanceMethod() {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
+  int get instanceGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     switch ("") {
       case augmented:
 //         ^^^^^^^^^
@@ -261,7 +454,77 @@ augment extension Ext {
     };
   }
 
+  static int get staticGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
   void instanceMethod() {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+  }
+
+  int get instanceGetter {
+    switch ("") {
+      case augmented:
+//         ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      default:
+    }
+    var x = switch("") {
+      augmented => 1,
+//    ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+      _ => 0
+    };
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
     switch ("") {
       case augmented:
 //         ^^^^^^^^^

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t14.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t14.dart
@@ -6,14 +6,14 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
-/// outermost enclosing declaration is augmenting.
+/// @description Checks that it is a compile-time error to declare a local
+/// function with a formal positional parameter named `augmented` in a location
+/// where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+import augment 'augmented_expression_A10_t14_lib.dart';
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t14_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t14_lib.dart
@@ -7,69 +7,69 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// function with a formal positional parameter named `augmented` in a location
+/// where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A10_t07.dart';
+augment library 'augmented_expression_A10_t14.dart';
 
 augment class C {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -77,113 +77,120 @@ augment class C {
 
 augment mixin M {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 }
 
 augment enum E {
-  augment e0;
+  augment e1;
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
+  final instanceVariable = () {
+    void local(int augmented) {}
+//                 ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -191,51 +198,52 @@ augment enum E {
 
 augment extension Ext {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
+
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local(int augmented) {}
+//                 ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t15.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t15.dart
@@ -6,14 +6,14 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
-/// outermost enclosing declaration is augmenting.
+/// @description Checks that it is a compile-time error to declare a local
+/// function with an optional positional parameter named `augmented` in a
+/// location where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+import augment 'augmented_expression_A10_t15_lib.dart';
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t15_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t15_lib.dart
@@ -7,69 +7,69 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// function with an optional positional parameter named `augmented` in a
+/// location where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A10_t07.dart';
+augment library 'augmented_expression_A10_t15.dart';
 
 augment class C {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -77,113 +77,113 @@ augment class C {
 
 augment mixin M {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 }
 
 augment enum E {
-  augment e0;
+  augment e1;
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -191,51 +191,52 @@ augment enum E {
 
 augment extension Ext {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
+
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local([int augmented = 0]) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t16.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t16.dart
@@ -6,14 +6,14 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
-/// outermost enclosing declaration is augmenting.
+/// @description Checks that it is a compile-time error to declare a local
+/// function with a named parameter whose name is `augmented` in a location
+/// where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+import augment 'augmented_expression_A10_t16_lib.dart';
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t16_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t16_lib.dart
@@ -7,69 +7,69 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// function with a named parameter whose name is `augmented` in a location 
+/// where the outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A10_t07.dart';
+augment library 'augmented_expression_A10_t16.dart';
 
 augment class C {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -77,113 +77,113 @@ augment class C {
 
 augment mixin M {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 }
 
 augment enum E {
-  augment e0;
+  augment e1;
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -191,51 +191,52 @@ augment enum E {
 
 augment extension Ext {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
+
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local({int augmented = 0}) {}
+//                  ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t17.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t17.dart
@@ -6,14 +6,17 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
-/// outermost enclosing declaration is augmenting.
+/// @description Checks that it is a compile-time error to declare a local
+/// function with a constant with name `augmented` as a default value of a
+/// formal parameter, in a location where the outermost enclosing declaration is
+/// augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+import augment 'augmented_expression_A10_t17_lib.dart';
+
+const augmented = "Should not be used";
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t17_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t17_lib.dart
@@ -1,0 +1,364 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
+///
+/// @description Checks that it is a compile-time error to declare a local
+/// function with a constant with name `augmented` as a default value of a 
+/// formal parameter, in a location where the outermost enclosing declaration is 
+/// augmenting.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+augment library 'augmented_expression_A10_t17.dart';
+
+augment class C {
+  static var staticVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  static void staticMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  var instanceVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  void instanceMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment mixin M {
+  static var staticVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  static void staticMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  var instanceVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  void instanceMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment enum E {
+  augment e1;
+  static var staticVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  static void staticMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  void instanceMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment extension Ext {
+  static var staticVariable = () {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
+  static void staticMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  void instanceMethod() {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    void local1([String v = augmented]) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    void local2({String v = augmented}) {}
+//                          ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18.dart
@@ -6,14 +6,16 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
+/// @description Checks that it is a compile-time error to use a type whose name
+/// is `augmented` in `is` ans `as` expressions in a location where the
 /// outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+//import augment 'augmented_expression_A10_t18_lib.dart';
+
+typedef augmented = Null;
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18.dart
@@ -7,7 +7,7 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to use a type whose name
-/// is `augmented` in `is` ans `as` expressions in a location where the
+/// is `augmented` in `is` and `as` expressions in a location where the
 /// outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18_lib.dart
@@ -1,0 +1,367 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A compile-time error occurs if the identifier `augmented` occurs
+/// in a non-augmenting declaration, of a kind that can be augmenting, inside an
+/// augmenting declaration.
+///
+/// @description Checks that it is a compile-time error to use a type whose name
+/// is `augmented` in `is` ans `as` expressions in a location where the
+/// outermost enclosing declaration is augmenting.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+augment library 'augmented_expression_A10_t18.dart';
+
+augment class C {
+  static var staticVariable1 = null as augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static var staticVariable2 = null is augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static void staticMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  var instanceVariable1 = null as augmented;
+//                                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  var instanceVariable2 = null is augmented;
+//                                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void instanceMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment mixin M {
+  static var staticVariable1 = null as augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static var staticVariable2 = null is augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static void staticMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  var instanceVariable1 = null as augmented;
+//                                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  var instanceVariable2 = null is augmented;
+//                                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void instanceMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment enum E {
+  augment e1;
+  static var staticVariable1 = null as augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static var staticVariable2 = null is augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static void staticMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  final instanceVariable1 = null as augmented;
+//                                  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  final instanceVariable2 = null is augmented;
+//                                  ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  void instanceMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}
+
+augment extension Ext {
+  static var staticVariable1 = null as augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static var staticVariable2 = null is augmented;
+//                                     ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  static void staticMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  static int get staticGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  static void set staticSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  void instanceMethod() {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+
+  int get instanceGetter {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    return 0;
+  }
+
+  void set instanceSetter(int _) {
+    print(null as augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+    print(null is augmented);
+//                ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  }
+}

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t18_lib.dart
@@ -7,7 +7,7 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to use a type whose name
-/// is `augmented` in `is` ans `as` expressions in a location where the
+/// is `augmented` in `is` and `as` expressions in a location where the
 /// outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t19.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t19.dart
@@ -6,14 +6,14 @@
 /// in a non-augmenting declaration, of a kind that can be augmenting, inside an
 /// augmenting declaration.
 ///
-/// @description Checks that it is a compile-time error to use a record with
-/// a named parameter whose name is `augmented` in a location where the
+/// @description Checks that it is a compile-time error to declare a local
+/// function with a type parameter named `augmented` in a location where the
 /// outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmented_expression_A10_t12_lib.dart';
+import augment 'augmented_expression_A10_t19_lib.dart';
 
 class C {}
 

--- a/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t19_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmented_expression_A10_t19_lib.dart
@@ -7,69 +7,69 @@
 /// augmenting declaration.
 ///
 /// @description Checks that it is a compile-time error to declare a local
-/// variable whose name is `augmented` in a location where the outermost
-/// enclosing declaration is augmenting. Test a record pattern.
+/// function with a type parameter named `augmented` in a location where the
+/// outermost enclosing declaration is augmenting.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmented_expression_A10_t07.dart';
+augment library 'augmented_expression_A10_t19.dart';
 
 augment class C {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -77,113 +77,120 @@ augment class C {
 
 augment mixin M {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   var instanceVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 }
 
 augment enum E {
-  augment e0;
+  augment e1;
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
 
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
+  final instanceVariable = () {
+    void local<augmented>() {}
+//             ^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  };
+
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
@@ -191,51 +198,52 @@ augment enum E {
 
 augment extension Ext {
   static var staticVariable = () {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   };
+
   static void staticMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   static int get staticGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   static void set staticSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   void instanceMethod() {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }
 
   int get instanceGetter {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
     return 0;
   }
 
   void set instanceSetter(int _) {
-    int (augmented,) = (42,);
-//       ^^^^^^^^^
+    void local<augmented>() {}
+//             ^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   }


### PR DESCRIPTION
In case of enum `final f = () {...};` is not a constant exptession and therefore an error. Removed. 
