### PR TITLE
#2559. Update assertions in augmenting types tests.

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t01.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t01_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t02.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t02_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t03.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `interface class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `interface class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t03_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `interface class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `interface class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t04.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `final class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `final class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t04_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `final class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `final class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t05.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `sealed class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `sealed class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t05_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `sealed class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `sealed class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t06.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t06.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t06_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t06_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t07.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t07.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract base class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract base class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t07_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t07_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract base class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract base class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t08.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t08.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract interface class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract interface class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t08_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t08_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract interface class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract interface class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t09.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t09.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract final class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract final class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t09_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t09_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract final class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract final class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t10.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t10.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t10_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t10_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t11.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t11.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t11_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t11_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t12.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t12.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t12_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t12_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t13.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t13.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract base mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract base mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t13_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t13_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `abstract base mixin class` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `abstract base mixin class`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t14.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t14.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `mixin` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `mixin`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t14_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t14_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `mixin` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `mixin`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t15.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t15.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base mixin` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base mixin`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t15_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A02_t15_lib.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile-time error if:
-/// ...
-/// - The augmenting type and corresponding type do not have all the same
-///   modifiers (final, sealed, mixin, etc).
+/// - The augmenting declaration and augmented declaration do not have all the
+///   same modifiers: `abstract`, `base`, `final`, `interface`, `sealed` and
+///   `mixin` for `class` declarations, and `base` for `mixin` declarations.
 ///
 /// @description Checks that it is a compile-time error if an augmenting type
-/// and corresponding type do not have all the same modifiers (final, sealed,
-/// mixin, etc). Test `base mixin` in the main library
+/// and corresponding type do not have all the same modifiers. Test  augmenting
+/// `base mixin`.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros


### PR DESCRIPTION
This PR only updates assertions and descriptions for `augmenting_types_A02_*.dart` tests.