### PR TITLE
Migrate UNREACHABLE_SWITCH_CASE from Hint to Warning

### DIFF
--- a/Language/Statements/Switch/execution_case_no_default_t01.dart
+++ b/Language/Statements/Switch/execution_case_no_default_t01.dart
@@ -35,15 +35,15 @@ test(value) {
       return 3;
     case 1:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 4;
     case 1:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 5;
     case 2:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 6;
     case 4:
     case 5:

--- a/Language/Statements/Switch/execution_case_t01.dart
+++ b/Language/Statements/Switch/execution_case_t01.dart
@@ -39,15 +39,15 @@ test(value) {
       return 3;
     case 1:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 4;
     case 1:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 5;
     case 2:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return 6;
     case 4:
     case 5:

--- a/LanguageFeatures/Class-modifiers/syntax_abstract_base_mixin_class_A06_t01.dart
+++ b/LanguageFeatures/Class-modifiers/syntax_abstract_base_mixin_class_A06_t01.dart
@@ -23,7 +23,7 @@ String test1(_M c) => switch (c) {
       ImplementsM _ => "ImplementsM",
       WithM _ => "WithM"
 //            ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     };
 
 String test2(AbstractBaseMixinClass c) => switch (c) {
@@ -34,7 +34,7 @@ String test2(AbstractBaseMixinClass c) => switch (c) {
       ImplementsAbstractBaseMixinClass _ => "ImplementsAbstractBaseMixinClass",
       WithAbstractBaseMixinClass _ => "WithAbstractBaseMixinClass"
 //                                 ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     };
 
 main() {

--- a/LanguageFeatures/Class-modifiers/syntax_base_mixin_class_A05_t01.dart
+++ b/LanguageFeatures/Class-modifiers/syntax_base_mixin_class_A05_t01.dart
@@ -23,7 +23,7 @@ String test1(_M c) => switch (c) {
       ImplementsM _ => "ImplementsM",
       WithM _ => "WithM"
 //            ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     };
 
 String test2(BaseMixinClass c) => switch (c) {
@@ -34,7 +34,7 @@ String test2(BaseMixinClass c) => switch (c) {
       ImplementsBaseMixinClass _ => "ImplementsBaseMixinClass",
       WithBaseMixinClass _ => "WithBaseMixinClass"
 //                         ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     };
 
 main() {

--- a/LanguageFeatures/Extension-types/exhaustiveness_variable_A04_t01.dart
+++ b/LanguageFeatures/Extension-types/exhaustiveness_variable_A04_t01.dart
@@ -21,7 +21,7 @@ main() {
       y.expectStaticType<Exactly<int>>;
     case TO z:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       x.expectStaticType<Exactly<TO>>;
       z.expectStaticType<Exactly<TO>>;
   }
@@ -31,7 +31,7 @@ main() {
       y.expectStaticType<Exactly<ET>>;
     case TO z:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       x.expectStaticType<Exactly<ET>>;
       z.expectStaticType<Exactly<TO>>;
   }

--- a/LanguageFeatures/Patterns/map_A08_t01.dart
+++ b/LanguageFeatures/Patterns/map_A08_t01.dart
@@ -31,7 +31,7 @@ String test1(Map map) {
 // [cfe] unspecified
     _ => "default"
 //    ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
   };
 }
 

--- a/LanguageFeatures/Patterns/matching_list_A06_t01.dart
+++ b/LanguageFeatures/Patterns/matching_list_A06_t01.dart
@@ -90,7 +90,7 @@ String test1(MisbehavingList<int> ml) =>
     [_, _, ...] => "2+",
     _ => "any"
 //    ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
   };
 
 String test2(MisbehavingList<int> ml) {

--- a/LanguageFeatures/Patterns/null_assert_A03_t01.dart
+++ b/LanguageFeatures/Patterns/null_assert_A03_t01.dart
@@ -21,7 +21,7 @@ String test1(int? x) {
       return "match-1";
     case int v2!:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "match-2";
     default:
       return "no match";
@@ -47,10 +47,10 @@ String test3(int? x) =>
 // [analyzer] STATIC_WARNING.UNNECESSARY_NULL_ASSERT_PATTERN
     int v2! => "match-2",
 //          ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     _ => "no match"
 //    ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
   };
 
 main () {

--- a/LanguageFeatures/Patterns/null_check_A02_t01.dart
+++ b/LanguageFeatures/Patterns/null_check_A02_t01.dart
@@ -23,7 +23,7 @@ String test1(int? x) {
 //             ^
 // [analyzer] STATIC_WARNING.UNNECESSARY_NULL_CHECK_PATTERN
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "match-2";
     default:
       return "no match";
@@ -53,7 +53,7 @@ String test3(int? x) =>
 //        ^
 // [analyzer] STATIC_WARNING.UNNECESSARY_NULL_CHECK_PATTERN
 //          ^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
     _ => "no match"
   };
 

--- a/LanguageFeatures/Patterns/scope_A04_t01.dart
+++ b/LanguageFeatures/Patterns/scope_A04_t01.dart
@@ -27,7 +27,7 @@ void test1() {
       break;
     case 0:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       print(v);
 //          ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/shared_case_scope_A01_t01.dart
+++ b/LanguageFeatures/Patterns/shared_case_scope_A01_t01.dart
@@ -44,7 +44,7 @@ main() {
     case var a:
     case var b:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       print(a);
 //          ^
 // [analyzer] unspecified
@@ -80,7 +80,7 @@ main() {
     case var a:
     case var _:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       print(a);
 //          ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/shared_case_scope_A01_t02.dart
+++ b/LanguageFeatures/Patterns/shared_case_scope_A01_t02.dart
@@ -46,7 +46,7 @@ main() {
     case final a:
     case int a:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       print(a);
 //          ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/shared_case_scope_A01_t03.dart
+++ b/LanguageFeatures/Patterns/shared_case_scope_A01_t03.dart
@@ -62,7 +62,7 @@ main() {
     case var a as num:
     case var a as int:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       print(a);
 //          ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/switch_statement_A01_t01.dart
+++ b/LanguageFeatures/Patterns/switch_statement_A01_t01.dart
@@ -39,13 +39,13 @@ String test(int value) {
       return "constant-1";
     case 30:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "constant-2";
     case (40):
       return "parenthesized-1";
     case (40):
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "parenthesized-2";
     default:
       return "default";
@@ -58,7 +58,7 @@ String testCast(num value) {
       return "cast-1";
     case var c2 as double:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "cast-2";
     default:
       return "default";
@@ -71,7 +71,7 @@ String testNullCheck(int? value) {
       return "null-check-1";
     case var a2?:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "null-check-2";
     default:
       return "default";
@@ -84,7 +84,7 @@ String testNullAssert(int? value) {
       return "null-assert-1";
     case var a2!:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "null-assert-2";
     default:
       return "default";
@@ -97,7 +97,7 @@ String testVariable(int value) {
       return "variable-1";
     case var a2:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "variable-2";
     default:
       return "default";
@@ -114,7 +114,7 @@ String testList(List<int> list) {
       return "list-3";
     case [1, 2, 3]:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "list-4";
     default:
       return "default";
@@ -159,7 +159,7 @@ String testObject(Shape shape) {
       return "object-3";
     case Circle(sizeAsInt: 1):
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       return "object-4";
     default:
       return "default";

--- a/LanguageFeatures/Patterns/variable_A03_t02.dart
+++ b/LanguageFeatures/Patterns/variable_A03_t02.dart
@@ -51,7 +51,7 @@ void test1(Record r) {
     break;
     case (final int? e, name: final String? f):
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       e = 1;
 //    ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/variable_A03_t03.dart
+++ b/LanguageFeatures/Patterns/variable_A03_t03.dart
@@ -41,7 +41,7 @@ void test1(List l) {
       break;
     case [final int c, final String d]:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       c = 1;
 //    ^
 // [analyzer] unspecified
@@ -53,7 +53,7 @@ void test1(List l) {
     break;
     case [final int? e, final String? f]:
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       e = 1;
 //    ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Patterns/variable_A03_t05.dart
+++ b/LanguageFeatures/Patterns/variable_A03_t05.dart
@@ -46,7 +46,7 @@ void test1(Shape shape) {
     break;
     case Circle(area: final Unit? s):
 //  ^^^^
-// [analyzer] HINT.UNREACHABLE_SWITCH_CASE
+// [analyzer] WARNING.UNREACHABLE_SWITCH_CASE
       s = Unit(1);
 //    ^
 // [analyzer] unspecified


### PR DESCRIPTION
The analyzer Hints are slowly, incrementally, being migrated to being Warnings. This change is required to remove the old HintCode `UNREACHABLE_SWITCH_CASE`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
