### PR TITLE
Fixes #2815. Update expected warnings in binding_A03_t02.dart

### DIFF
--- a/LanguageFeatures/Wildcards/binding_A03_t02.dart
+++ b/LanguageFeatures/Wildcards/binding_A03_t02.dart
@@ -25,20 +25,20 @@ int init(int val) {
 
 test1() {
   late var _ = init(1);
-//         ^
-// [analyzer] unspecified
+//             ^^^^^^^
+// [analyzer] STATIC_WARNING.DEAD_CODE_LATE_WILDCARD_VARIABLE_INITIALIZER
 }
 
 test2() {
   late final _ = init(2);
-//           ^
-// [analyzer] unspecified
+//               ^^^^^^^
+// [analyzer] STATIC_WARNING.DEAD_CODE_LATE_WILDCARD_VARIABLE_INITIALIZER
 }
 
 test3() {
   late int _ = init(3);
-//         ^
-// [analyzer] unspecified
+//             ^^^^^^^
+// [analyzer] STATIC_WARNING.DEAD_CODE_LATE_WILDCARD_VARIABLE_INITIALIZER
 }
 
 main() {


### PR DESCRIPTION
The change suggested in #2815 just updates expected error position, but in case of `unspecified` error position is ignored. Therefore, I believe, the intention was to update error code as well. Updated.