### PR TITLE
Fixes #2816. Don't expect DEAD_CODE warning

### DIFF
--- a/LanguageFeatures/Wildcards/local_functions_A01_t01.dart
+++ b/LanguageFeatures/Wildcards/local_functions_A01_t01.dart
@@ -12,9 +12,9 @@
 // SharedOptions=--enable-experiment=wildcard-variables
 
 test1() {
-  _() {}
-//^
-// [analyzer] unspecified
+  _() {} // Analyzer reports DEAD_CODE here, but this warning is ignored by
+         // the test runner. So, we only can check that the invocation of this
+         // function is an error (see the check below).
   _();
 //^
 // [analyzer] unspecified


### PR DESCRIPTION
There are no ways to force test runner to report this error for one particular test. We never expect `DEAD_CODE` warning in co19 tests. So, the only thing that we can to do is to remove this expectation.