### PR TITLE
#2559. Add extension types to augmenting types tests

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01.dart
@@ -10,8 +10,8 @@
 /// after this appending process, so you cannot have multiple `extends` on a
 /// class, or an `on` clause on an enum, etc.
 ///
-/// @description Checks that a class, mixin and enum augment may specify
-/// `implements` clause
+/// @description Checks that a class, mixin, enum and extension type
+/// augmentations may specify `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -31,13 +31,17 @@ enum E {
   e1;
 }
 
+extension type ET(I v) {}
+
 class MA = Object with M;
 
 main() {
   I c = C();
   I m = MA();
   I e = E.e1;
+  I et = ET(I());
   Expect.equals("C", c.id);
   Expect.equals("M", m.id);
   Expect.equals("E", e.id);
+  Expect.equals("ET", et.id);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01.dart
@@ -11,7 +11,7 @@
 /// class, or an `on` clause on an enum, etc.
 ///
 /// @description Checks that a class, mixin, enum and extension type
-/// augmentations may specify `implements` clause.
+/// augmentation may specify an `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01_lib.dart
@@ -11,7 +11,7 @@
 /// class, or an `on` clause on an enum, etc.
 ///
 /// @description Checks that a class, mixin, enum and extension type
-/// augmentations may specify `implements` clause.
+/// augmentation may specify an `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t01_lib.dart
@@ -10,8 +10,8 @@
 /// after this appending process, so you cannot have multiple `extends` on a
 /// class, or an `on` clause on an enum, etc.
 ///
-/// @description Checks that a class, mixin and enum augment may specify
-/// `implements` clause
+/// @description Checks that a class, mixin, enum and extension type
+/// augmentations may specify `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -29,4 +29,8 @@ augment mixin M implements I {
 augment enum E implements I {
   augment e1;
   String get id => "E";
+}
+
+augment extension type ET implements I {
+  String get id => "ET";
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02.dart
@@ -10,8 +10,8 @@
 /// after this appending process, so you cannot have multiple `extends` on a
 /// class, or an `on` clause on an enum, etc.
 ///
-/// @description Checks that a class, mixin and enum augment may specify an
-/// additional `implements` clause
+/// @description Checks that a class, mixin, enum and extension type
+/// augmentations may specify additional `implements` clauses.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -26,6 +26,10 @@ abstract class I0 {
 class I1 implements I0 {
   String get id0 => "I1";
   String get id1 => "I1";
+}
+
+interface class I2 extends I1 {
+  String get id2 => "I2";
 }
 
 class C implements I1 {
@@ -44,20 +48,29 @@ enum E implements I1 {
   String get id1 => "E";
 }
 
+extension type ET(I2 v) implements I1 {
+  String get id0 => "ET";
+  String get id1 => "ET";
+}
+
 class MA = Object with M;
 
 main() {
   I1 c1 = C();
   I1 m1 = MA();
   I1 e1 = E.e1;
+  ET et1 = ET(I2());
   Expect.equals("C", c1.id1);
   Expect.equals("M", m1.id1);
   Expect.equals("E", e1.id1);
+  Expect.equals("ET", et1.id1);
 
   I2 c2 = C();
   I2 m2 = MA();
   I2 e2 = E.e1;
+  ET et2 = ET(I2());
   Expect.equals("I2 from C", c2.id2);
   Expect.equals("I2 from M", m2.id2);
   Expect.equals("I2 from E", e2.id2);
+  Expect.equals("I2 from ET", et2.id2);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02.dart
@@ -11,7 +11,7 @@
 /// class, or an `on` clause on an enum, etc.
 ///
 /// @description Checks that a class, mixin, enum and extension type
-/// augmentations may specify additional `implements` clauses.
+/// augmentation may specify additional elements for the `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02_lib.dart
@@ -10,15 +10,15 @@
 /// after this appending process, so you cannot have multiple `extends` on a
 /// class, or an `on` clause on an enum, etc.
 ///
-/// @description Checks that a class, mixin and enum augment may specify an
-/// additional `implements` clause
+/// @description Checks that a class, mixin, enum and extension type
+/// augmentations may specify additional `implements` clauses.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
 augment library 'augmenting_types_A07_t02.dart';
 
-interface class I2 {
+abstract interface class I2 implements I0 {
   String get id2 => "I2";
 }
 
@@ -33,4 +33,8 @@ augment mixin M implements I2 {
 augment enum E implements I2 {
   augment e1;
   String get id2 => "I2 from E";
+}
+
+augment extension type ET implements I2 {
+  String get id2 => "I2 from ET";
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t02_lib.dart
@@ -11,14 +11,14 @@
 /// class, or an `on` clause on an enum, etc.
 ///
 /// @description Checks that a class, mixin, enum and extension type
-/// augmentations may specify additional `implements` clauses.
+/// augmentation may specify additional elements for the `implements` clause.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
 augment library 'augmenting_types_A07_t02.dart';
 
-abstract interface class I2 implements I0 {
+augment interface class I2 implements I0 {
   String get id2 => "I2";
 }
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t07.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t07.dart
@@ -10,9 +10,9 @@
 /// after this appending process, so you cannot have multiple `extends` on a
 /// class, or an `on` clause on an enum, etc.
 ///
-/// @description Checks that it is a compile-time error if a class, mixin or
-/// enum augment specifies an interface in an `implements` clause which already
-/// exists
+/// @description Checks that it is a compile-time error if a class, mixin, enum
+/// or extension type augment specifies an interface in an `implements` clause
+/// which already exists.
 /// @author sgrekhov22@gmail.com
 /// @issue 55456
 
@@ -38,9 +38,12 @@ enum E implements I {
   String foo() => "C1";
 }
 
+extension type ET(I i) implements I {}
+
 main() {
   print(C1);
   print(C2);
   print(M);
   print(E);
+  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t07_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A07_t07_lib.dart
@@ -41,3 +41,8 @@ augment enum E implements I {
 // [cfe] unspecified
   augment e1;
 }
+
+augment extension type ET implements I {}
+//                     ^^
+// [analyzer] unspecified
+// [cfe] unspecified

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that instance members defined in the body of an augment
-/// of a class, mixin, extension, enum or an extension type are added to an
-/// instance namespace of the corresponding type in the augmented library.
+/// of a class, mixin, extension, enum or extension type are added to the
+/// interface of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that instance members defined in the body of an augment
-/// of a class, mixin, extension, or enum are added to an instance namespace of
-/// the corresponding type in the augmented library
+/// of a class, mixin, extension, enum or an extension type are added to an
+/// instance namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -28,6 +28,8 @@ mixin M {}
 enum E {e1;}
 
 extension ExtA on A {}
+
+extension type ET(int id) {}
 
 class MA = Object with M;
 
@@ -55,4 +57,10 @@ main() {
   A().setter = "set ExtA";
   Expect.equals("set ExtA", _log);
   Expect.equals(4, A() + 4);
+
+  Expect.equals("ET", ET(0).method());
+  Expect.equals("get ET", ET(0).getter);
+  ET().setter = "set ET";
+  Expect.equals("set ET", _log);
+  Expect.equals(5, ET(42) + 5);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01_lib.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that instance members defined in the body of an augment
-/// of a class, mixin, extension, enum or an extension type are added to an
-/// instance namespace of the corresponding type in the augmented library.
+/// of a class, mixin, extension, enum or extension type are added to the
+/// interface of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t01_lib.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that instance members defined in the body of an augment
-/// of a class, mixin, extension, or enum are added to an instance namespace of
-/// the corresponding type in the augmented library
+/// of a class, mixin, extension, enum or an extension type are added to an
+/// instance namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -47,6 +47,15 @@ augment enum E {
 augment extension ExtA {
   String method() => "ExtA";
   String get getter => "get ExtA";
+  void set setter(String v) {
+    _log = v;
+  }
+  int operator +(int other) => other;
+}
+
+augment extension type ET {
+  String method() => "ET";
+  String get getter => "get ET";
   void set setter(String v) {
     _log = v;
   }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, or enum adds an instance member but there is an
-/// existing instance member with the same name
+/// class, mixin, extension, enum or an extension type adds an instance member
+/// but there is an existing instance member with the same name.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -42,9 +42,15 @@ extension ExtA on A {
   int operator +(int other) => other;
 }
 
+extension type ET(int id) {
+  int get foo => 42;
+  int operator +(int other) => other;
+}
+
 main() {
   print(A);
   print(C);
   print(M);
   print(E);
+  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds an instance member
-/// but there is an existing instance member with the same name.
+/// class, mixin, extension, enum or extension type adds an instance member but
+/// there is an existing instance member with the same name.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t02_lib.dart
@@ -8,7 +8,7 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds an instance member
+/// class, mixin, extension, enum or extension type adds an instance member
 /// but there is an existing instance member with the same name.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds an instance member
-/// but there is an existing static member with the same name.
+/// class, mixin, extension, enum or extension type adds an instance member but
+/// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 /// @issue 55452
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03.dart
@@ -8,51 +8,36 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, or enum adds an instance member but there is an
-/// existing static member with the same name
+/// class, mixin, extension, enum or an extension type adds an instance member
+/// but there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 /// @issue 55452
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmenting_types_A10_t03_lib.dart';
+import augment 'augmenting_types_A10_t03_lib1.dart';
+import augment 'augmenting_types_A10_t03_lib2.dart';
 
 class A {
   static int foo() => 42;
 }
 
-class C {
-  static int foo() => 42;
-//           ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
+class C {}
 
-mixin M {
-  static int get foo => 42;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
+mixin M {}
 
 enum E {
   e1;
-  static void set foo(String _) {}
-//                ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }
 
-extension ExtA on A {
-  static void bar() {}
-//            ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
+extension ExtA on A {}
+
+extension type ET(int id) {}
 
 main() {
   print(A);
   print(C);
   print(M);
   print(E);
+  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib1.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib1.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds an instance member
-/// but there is an existing static member with the same name.
+/// class, mixin, extension, enum or extension type adds an instance member but
+/// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 /// @issue 55452
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib1.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib1.dart
@@ -8,48 +8,34 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds a static member but
-/// there is an existing static member with the same name.
+/// class, mixin, extension, enum or an extension type adds an instance member
+/// but there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
+/// @issue 55452
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmenting_types_A10_t05.dart';
+augment library 'augmenting_types_A10_t03.dart';
 
 augment class C {
-  static int foo() => 42;
-//       ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  int foo() => 42;
 }
 
 augment mixin M {
-  static int foo() => 42;
-//           ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  int foo() => 42;
 }
 
 augment enum E {
   augment e1;
-  static int foo() => 42;
-//           ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  int foo() => 42;
 }
 
 augment extension ExtA {
-  static int get foo => 42; // No error, no conflict with A.foo()
+  int get foo => 42; // No error, no conflict with A.foo()
 
-  static void set bar(String _) {}
-//                ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  void set bar(String _) {}
 }
 
 augment extension type ET {
-  static int get foo => 42;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
+  int get foo => 42;
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib2.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib2.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds an instance member
-/// but there is an existing static member with the same name.
+/// class, mixin, extension, enum or extension type adds an instance member but
+/// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 /// @issue 55452
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib2.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t03_lib2.dart
@@ -9,69 +9,46 @@
 ///
 /// @description Checks that it is a compile-time error if an augment of a
 /// class, mixin, extension, enum or an extension type adds an instance member
-/// but there is an existing instance member with the same name.
+/// but there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
+/// @issue 55452
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmenting_types_A10_t02.dart';
+augment library 'augmenting_types_A10_t03.dart';
 
-augment abstract class C {
-  int foo();
-//    ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  int operator +(int other);
-//             ^
+augment class C {
+  static int foo() => 42;
+//           ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment mixin M {
-  int foo() => 42;
-//    ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  int operator +(int other) => other;
-//             ^
+  static int get foo => 42;
+//               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment enum E {
   augment e1;
-  int foo() => 42;
-//    ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  int operator +(int other) => other;
-//             ^
+  static void set foo(String _) {}
+//                ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension ExtA {
-  int get foo => 42; // No error, no conflict with A.foo()
-
-  void set bar(String _) {}
-//         ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  int operator -(int other) => other; // No error, no conflict with A.-()
-
-  int operator +(int other) => other;
-//             ^
+  static void bar() {}
+//            ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension type ET {
-  int foo() => 42;
-//    ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  int operator +(int other) => other;
-//             ^
+  static int get foo => 42;
+//               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that static members defined in the body of an augment of
-/// a class, mixin, extension, or enum are added to a static namespace of the
-/// corresponding type in the augmented library
+/// a class, mixin, extension, enum or an extension type are added to a static
+/// namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -28,6 +28,8 @@ mixin M {}
 enum E {e1;}
 
 extension ExtA on A {}
+
+extension type ET(int id) {}
 
 main() {
   Expect.equals("C", C.method());
@@ -49,4 +51,9 @@ main() {
   Expect.equals("get ExtA", ExtA.getter);
   ExtA.setter = "set ExtA";
   Expect.equals("set ExtA", _log);
+
+  Expect.equals("ET", ET(0).method());
+  Expect.equals("get ET", ET(0).getter);
+  ExtA.setter = "set ET";
+  Expect.equals("set ET", _log);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04.dart
@@ -8,7 +8,7 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that static members defined in the body of an augment of
-/// a class, mixin, extension, enum or an extension type are added to a static
+/// a class, mixin, extension, enum or extension type are added to a static
 /// namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04_lib.dart
@@ -7,9 +7,9 @@
 /// corresponding type in the augmented library. In other words, the
 /// augmentation can add new members to an existing type.
 ///
-/// @description Checks that static members defined in the body of an augment
-/// of a class, mixin, extension, or enum are added to the static namespace of
-/// the corresponding type in the augmented library
+/// @description Checks that static members defined in the body of an augment of
+/// a class, mixin, extension, enum or an extension type are added to a static
+/// namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -19,24 +19,40 @@ augment library 'augmenting_types_A10_t04.dart';
 augment class C {
   static String method() => "C";
   static String get getter => "get C";
-  static void set setter(String v) {}
+  static void set setter(String v) {
+    _log = "set C";
+  }
 }
 
 augment mixin M {
   static String method() => "M";
   static String get getter => "get M";
-  static void set setter(String v) {}
+  static void set setter(String v) {
+    _log = "set M";
+  }
 }
 
 augment enum E {
   augment e1;
   static String method() => "E";
   static String get getter => "get E";
-  static void set setter(String v) {}
+  static void set setter(String v) {
+    _log = "set E";
+  }
 }
 
 augment extension ExtA {
   static String method() => "ExtA";
   static String get getter => "get ExtA";
-  static void set setter(String v) {}
+  static void set setter(String v) {
+    _log = "set ExtA";
+  }
+}
+
+augment extension type ET {
+  static String method() => "ET";
+  static String get getter => "get ET";
+  static void set setter(String v) {
+    _log = "set ET";
+  }
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t04_lib.dart
@@ -8,7 +8,7 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that static members defined in the body of an augment of
-/// a class, mixin, extension, enum or an extension type are added to a static
+/// a class, mixin, extension, enum or extension type are added to a static
 /// namespace of the corresponding type in the augmented library.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05.dart
@@ -8,7 +8,7 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds a static member but
+/// class, mixin, extension, enum or extension type adds a static member but
 /// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05.dart
@@ -8,8 +8,8 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, or enum adds a static member but there is an
-/// existing static member with the same name
+/// class, mixin, extension, enum or an extension type adds a static member but
+/// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
@@ -37,9 +37,14 @@ extension ExtA on A {
   static void bar() {}
 }
 
+extension type ET(int id) {
+  static int get foo => 42;
+}
+
 main() {
   print(A);
   print(C);
   print(M);
   print(E);
+  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t05_lib.dart
@@ -8,7 +8,7 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, enum or an extension type adds a static member but
+/// class, mixin, extension, enum or extension type adds a static member but
 /// there is an existing static member with the same name.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06.dart
@@ -8,38 +8,35 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, or enum adds a static member but there is an
-/// existing instance member with the same name
+/// class, mixin, extension, enum or extension type adds a static member but
+/// there is an existing instance member with the same name.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=macros
 
-import augment 'augmenting_types_A10_t06_lib.dart';
+import augment 'augmenting_types_A10_t06_lib1.dart';
+import augment 'augmenting_types_A10_t06_lib2.dart';
 
 class A {
   int foo() => 42;
 }
 
-abstract class C {
-  int foo();
-}
+abstract class C {}
 
-mixin M {
-  int get foo => 42;
-}
+mixin M {}
 
 enum E {
   e1;
-  void set foo(String _) {}
 }
 
-extension ExtA on A {
-  void bar() {}
-}
+extension ExtA on A {}
+
+extension type ET(int id) {}
 
 main() {
   print(A);
   print(C);
   print(M);
   print(E);
+  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06_lib1.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06_lib1.dart
@@ -8,30 +8,31 @@
 /// augmentation can add new members to an existing type.
 ///
 /// @description Checks that it is a compile-time error if an augment of a
-/// class, mixin, extension, or enum adds an instance member but there is an
-/// existing static member with the same name
+/// class, mixin, extension, or enum adds a static member but there is an
+/// existing instance member with the same name
 /// @author sgrekhov22@gmail.com
-/// @issue 55452
 
 // SharedOptions=--enable-experiment=macros
 
-augment library 'augmenting_types_A10_t03.dart';
+augment library 'augmenting_types_A10_t06.dart';
 
-augment class C {
-  int foo() => 42;
+augment abstract class C {
+  int foo();
 }
 
 augment mixin M {
-  int foo() => 42;
+  int get foo => 42;
 }
 
 augment enum E {
   augment e1;
-  int foo() => 42;
+  void set foo(String _) {}
 }
 
 augment extension ExtA {
-  int get foo => 42; // No error, no conflict with A.foo()
+  void bar() {}
+}
 
-  void set bar(String _) {}
+augment extension type ET {
+  void foo() {}
 }

--- a/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06_lib2.dart
+++ b/LanguageFeatures/Augmentation-libraries/augmenting_types_A10_t06_lib2.dart
@@ -46,3 +46,10 @@ augment extension ExtA {
 // [analyzer] unspecified
 // [cfe] unspecified
 }
+
+augment extension type ET {
+  static void foo() {}
+//            ^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}


### PR DESCRIPTION
There can be questions regarding `augmenting_types_A10_t03.dart` and `augmenting_types_A10_t06.dart`.  There are scoping tests checking that it is a compile-time error if we have a static and an instance member with the same name in an introductory and augmenting scopes. To avoid duplications these tests rewritten to have these declarations in different augmenting scopes.