### PR TITLE
Fixes #2857. Fix names conflict in scope_A02_t03_part2.dart

### DIFF
--- a/LanguageFeatures/Parts-with-imports/scope_A02_t03_part2.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_A02_t03_part2.dart
@@ -19,7 +19,7 @@
 part of 'scope_A02_t03_part1.dart';
 
 import 'scope_lib1.dart';
-import 'parts_lib.dart';
+import 'scope_lib5.dart';
 
 testPart2() {
   // From scope_lib1.dart
@@ -34,6 +34,6 @@ testPart2() {
   Expect.equals("scope_lib1 LibET", LibET.id);
   // From scope_lib2.dart
   Expect.equals("scope_lib2", libId);
-  // From parts_lib.dart
-  Expect.equals(0, counter);
+  // From scope_lib5.dart
+  Expect.equals("scope_lib5 Lib5Class", Lib5Class.id);
 }

--- a/LanguageFeatures/Parts-with-imports/scope_lib5.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_lib5.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Common library for `scope*` tests.
+///
+/// @description Common library for `scope*` tests.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=enhanced-parts
+
+class Lib5Class {
+  static final id = "scope_lib5 Lib5Class";
+}


### PR DESCRIPTION
Updated tests passes on the freshly built SDK.