### PR TITLE
Fixes #2858. Fix syntax error in scope_A03_t02_part1.dart

### DIFF
--- a/LanguageFeatures/Parts-with-imports/scope_A03_t02_part1.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_A03_t02_part1.dart
@@ -28,7 +28,7 @@ import 'scope_lib2.dart' deferred as d;
 // [analyzer] unspecified
 // [cfe] unspecified
 
-part 'scope_A03_t02_part2.dart'
+part 'scope_A03_t02_part2.dart';
 
 testPart1() {
   print("Part 1");


### PR DESCRIPTION
The updated tests pass in a freshly built SDK