### PR TITLE
Fixes #2859. Hide public extension methods if an import is deferred

### DIFF
--- a/LanguageFeatures/Parts-with-imports/scope_A03_t03_part1.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_A03_t03_part1.dart
@@ -19,7 +19,7 @@
 
 part of 'scope_A03_t03.dart';
 
-import 'scope_lib1.dart' deferred as d;
+import 'scope_lib1.dart' deferred as d hide LibExt;
 
 part 'scope_A03_t03_part2.dart';
 


### PR DESCRIPTION
The updated test works in the latest SDK. @eernstg is it expected that extension types can be loaded defferedly?