### PR TITLE
Fixes #2860. Remove accidental code from scope_A04_t01_part2.dart

### DIFF
--- a/LanguageFeatures/Parts-with-imports/scope_A04_t01_part2.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_A04_t01_part2.dart
@@ -19,8 +19,6 @@ part of 'scope_A04_t01_part1.dart';
 
 import 'scope_lib2.dart' as l;
 
-part 'scope_A04_t01_part2.dart';
-
 testPart2() {
   // From scope_lib1.dart
   Expect.equals("scope_lib1 libVar", l.libVar);


### PR DESCRIPTION
The updated tests passes.