### PR TITLE
Fixes #2878. Use `pid` as a part of an unique temp name

### DIFF
--- a/LibTest/io/file_utils.dart
+++ b/LibTest/io/file_utils.dart
@@ -135,28 +135,13 @@ Random rnd = new Random(new DateTime.now().microsecondsSinceEpoch);
 String getTempFileName({String? extension}) {
   extension = (extension == null
       ? ".tmp"
-      : (extension.startsWith(".") ? extension : "." + extension));
-  String name = rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString() +
-      extension;
-  return name;
+      : (extension.startsWith(".") ? extension : ".$extension"));
+  return "$pid-${rnd.nextInt(10000)}-${rnd.nextInt(10000)}-"
+      "${rnd.nextInt(10000)}$extension";
 }
 
-String getTempDirectoryName() {
-  String name = rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString() +
-      "-" +
-      rnd.nextInt(10000).toString();
-  return name;
-}
+String getTempDirectoryName() => "$pid-${rnd.nextInt(10000)}-"
+      "${rnd.nextInt(10000)}-${rnd.nextInt(10000)}-${rnd.nextInt(10000)}";
 
 String getPrefix() {
   String fileName =


### PR DESCRIPTION
I was unable to reproduce the issue. But if several instances of the same test should be runned concurrently to reproduce the issue, then, I think, using `pid` as a part of the name should fix it. Please review.