### PR TITLE
#2825. Add more grammar and terminology tests

### DIFF
--- a/LanguageFeatures/Parts-with-imports/grammar_A05_t01.dart
+++ b/LanguageFeatures/Parts-with-imports/grammar_A05_t01.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We extend the grammar of part files to allow import, export and
+/// part file directives. We allow part files directives to use a configurable
+/// URI like the other two. We restrict the part of directive to only allow the
+/// string version.
+///
+/// -- Changed "<uri>" to "<configurableUri>".
+/// <partDirective> ::= <metadata> `part' <configurableUri> `;'
+///
+/// -- Removed "<dottedIdentifier>" as option, retaining only "<uri>".
+/// <partHeader> ::= <metadata> `part' `of' <uri> `;'
+///
+/// -- Added "<importOrExport>* <partDirective>*"
+/// <partDeclaration> ::=
+///   <partHeader> <importOrExport>* <partDirective>*
+///   (<metadata> <topLevelDeclaration>)* <EOF>
+///
+/// The grammar change is small, mainly adding import, export and part
+/// directives to part files.
+///
+/// @description Checks that it is a compile-time error if a part file contains
+/// an unnamed library directive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part 'grammar_A05_t01_lib.dart';
+//    ^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/grammar_A05_t01_lib.dart
+++ b/LanguageFeatures/Parts-with-imports/grammar_A05_t01_lib.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We extend the grammar of part files to allow import, export and
+/// part file directives. We allow part files directives to use a configurable
+/// URI like the other two. We restrict the part of directive to only allow the
+/// string version.
+///
+/// -- Changed "<uri>" to "<configurableUri>".
+/// <partDirective> ::= <metadata> `part' <configurableUri> `;'
+///
+/// -- Removed "<dottedIdentifier>" as option, retaining only "<uri>".
+/// <partHeader> ::= <metadata> `part' `of' <uri> `;'
+///
+/// -- Added "<importOrExport>* <partDirective>*"
+/// <partDeclaration> ::=
+///   <partHeader> <importOrExport>* <partDirective>*
+///   (<metadata> <topLevelDeclaration>)* <EOF>
+///
+/// The grammar change is small, mainly adding import, export and part
+/// directives to part files.
+///
+/// @description Checks that it is a compile-time error if a part file contains
+/// an unnamed library directive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+library;
+
+/**/part of 'grammar_A05_t01.dart';
+//  ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified

--- a/LanguageFeatures/Parts-with-imports/grammar_A05_t02.dart
+++ b/LanguageFeatures/Parts-with-imports/grammar_A05_t02.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We extend the grammar of part files to allow import, export and
+/// part file directives. We allow part files directives to use a configurable
+/// URI like the other two. We restrict the part of directive to only allow the
+/// string version.
+///
+/// -- Changed "<uri>" to "<configurableUri>".
+/// <partDirective> ::= <metadata> `part' <configurableUri> `;'
+///
+/// -- Removed "<dottedIdentifier>" as option, retaining only "<uri>".
+/// <partHeader> ::= <metadata> `part' `of' <uri> `;'
+///
+/// -- Added "<importOrExport>* <partDirective>*"
+/// <partDeclaration> ::=
+///   <partHeader> <importOrExport>* <partDirective>*
+///   (<metadata> <topLevelDeclaration>)* <EOF>
+///
+/// The grammar change is small, mainly adding import, export and part
+/// directives to part files.
+///
+/// @description Checks that it is a compile-time error if a part file contains
+/// a normal library directive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+library grammar_A05_t02;
+part 'grammar_A05_t02_lib.dart';
+//    ^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/grammar_A05_t02_lib.dart
+++ b/LanguageFeatures/Parts-with-imports/grammar_A05_t02_lib.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We extend the grammar of part files to allow import, export and
+/// part file directives. We allow part files directives to use a configurable
+/// URI like the other two. We restrict the part of directive to only allow the
+/// string version.
+///
+/// -- Changed "<uri>" to "<configurableUri>".
+/// <partDirective> ::= <metadata> `part' <configurableUri> `;'
+///
+/// -- Removed "<dottedIdentifier>" as option, retaining only "<uri>".
+/// <partHeader> ::= <metadata> `part' `of' <uri> `;'
+///
+/// -- Added "<importOrExport>* <partDirective>*"
+/// <partDeclaration> ::=
+///   <partHeader> <importOrExport>* <partDirective>*
+///   (<metadata> <topLevelDeclaration>)* <EOF>
+///
+/// The grammar change is small, mainly adding import, export and part
+/// directives to part files.
+///
+/// @description Checks that it is a compile-time error if a part file contains
+/// a normal library directive.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+library grammar_A05_t02;
+
+part of 'grammar_A05_t02.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A04_t01.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A04_t01.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It’s a compile-time error if a part file is a sub-part of itself.
+/// That is, if the includes relation has a cycle.
 ///
 /// @description Check that it is a compile-time error if a part file is a
 /// sub-part of itself.

--- a/LanguageFeatures/Parts-with-imports/terminology_A04_t01_part1.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A04_t01_part1.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It’s a compile-time error if a part file is a sub-part of itself.
+/// That is, if the includes relation has a cycle.
 ///
 /// @description Check that it is a compile-time error if a part file is a
 /// sub-part of itself.

--- a/LanguageFeatures/Parts-with-imports/terminology_A04_t01_part2.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A04_t01_part2.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It’s a compile-time error if a `part` directive denotes a file
-/// which is not a part file.
+/// @assertion It’s a compile-time error if a part file is a sub-part of itself.
+/// That is, if the includes relation has a cycle.
 ///
-/// @description Check that it is a compile-time error if a `part` directive
-/// denotes a file which is not a part file.
+/// @description Check that it is a compile-time error if a part file is a
+/// sub-part of itself.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=enhanced-parts

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t01.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t01.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` directive
+/// refers to a Dart file which is not a library.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+import 'terminology_A05_t01_lib1.dart';
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t01_lib1.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t01_lib1.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t01_lib2.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t01_lib2.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t01_lib2.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` directive
+/// refers to a Dart file which is not a library.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part 'terminology_A05_t01_lib1.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t02.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t02.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part 'terminology_A05_t02_lib1.dart';
+part 'terminology_A05_t02_lib2.dart';
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t02_lib1.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t02_lib1.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t02.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t02_lib2.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t02_lib2.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `import` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t02.dart';
+
+import 'terminology_A05_t02_lib1.dart';
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t03.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t03.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `export` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part 'terminology_A05_t03_lib.dart';
+export 'terminology_A05_t03_lib.dart';
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t03_lib.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t03_lib.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `export` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t03.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t04.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t04.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `export` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part 'terminology_A05_t04_lib1.dart';
+part 'terminology_A05_t04_lib2.dart';
+
+main() {
+}

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t04_lib1.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t04_lib1.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `export` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t04.dart';

--- a/LanguageFeatures/Parts-with-imports/terminology_A05_t04_lib2.dart
+++ b/LanguageFeatures/Parts-with-imports/terminology_A05_t04_lib2.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A Dart file is either a library file or a part file, each having
+/// its own grammar.
+///
+/// @description Checks that it is a compile-time error if an `export` refers to
+/// an entity which is not a library
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=macros
+
+part of 'terminology_A05_t04.dart';
+
+export 'terminology_A05_t04_lib1.dart';
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified


### PR DESCRIPTION
This PR maily contains tests that were moved from `Augmentation-libraries` folder, because statements that they check now part of "Parts with imports" feature.