### PR TITLE
Fixes #2930. Fix failing Stream tests.

### DIFF
--- a/LibTest/async/Stream/Stream.fromIterable_A01_t01.dart
+++ b/LibTest/async/Stream/Stream.fromIterable_A01_t01.dart
@@ -2,9 +2,23 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Stream.fromIterable(Iterable<T> data)
-/// Creates a single-subscription stream that gets its data from data.
-/// @description Checks that created stream is single-subscription.
+/// @assertion Stream<T>.fromIterable( Iterable<T> elements )
+///
+/// Creates a stream that gets its data from `elements`.
+///
+/// The iterable is iterated when the stream receives a listener, and stops
+/// iterating if the listener cancels the subscription, or if the
+/// [Iterator.moveNext] method returns false or throws. Iteration is suspended
+/// while the stream subscription is paused.
+///
+/// If calling [Iterator.moveNext] on `elements.iterator` throws, the stream
+/// emits that error and then it closes. If reading [Iterator.current] on
+/// `elements.iterator` throws, the stream emits that error, but keeps iterating
+///
+/// Can be listened to more than once. Each listener iterates elements
+/// independently.
+///
+/// @description Checks that created stream is not a broadcast stream.
 /// @author kaigorodov
 
 import "dart:async";
@@ -12,6 +26,5 @@ import "../../../Utils/expect.dart";
 
 main() {
   Stream s = new Stream.fromIterable([1, 2, 3]);
-
   Expect.isFalse(s.isBroadcast);
 }

--- a/LibTest/async/Stream/Stream.fromIterable_A01_t02.dart
+++ b/LibTest/async/Stream/Stream.fromIterable_A01_t02.dart
@@ -2,9 +2,23 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Stream.fromIterable(Iterable<T> data)
-/// Creates a single-subscription stream that gets its data from data.
-/// @description Checks that created stream returns all the data from Iterable.
+/// @assertion Stream<T>.fromIterable( Iterable<T> elements )
+///
+/// Creates a stream that gets its data from `elements`.
+///
+/// The iterable is iterated when the stream receives a listener, and stops
+/// iterating if the listener cancels the subscription, or if the
+/// [Iterator.moveNext] method returns false or throws. Iteration is suspended
+/// while the stream subscription is paused.
+///
+/// If calling [Iterator.moveNext] on `elements.iterator` throws, the stream
+/// emits that error and then it closes. If reading [Iterator.current] on
+/// `elements.iterator` throws, the stream emits that error, but keeps iterating
+///
+/// Can be listened to more than once. Each listener iterates elements
+/// independently.
+///
+/// @description Checks that created stream returns all the data from [Iterable]
 /// @author kaigorodov
 
 import "dart:async";

--- a/LibTest/async/Stream/Stream.fromIterable_A02_t01.dart
+++ b/LibTest/async/Stream/Stream.fromIterable_A02_t01.dart
@@ -2,14 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Stream.fromIterable(Iterable<T> data)
-/// If iterating data throws an error, the stream ends immediately with that
-/// error. No done event will be sent (iteration is not complete), but no
-/// further data events will be generated either, since iteration cannot
-/// continue.
-/// @description Checks that if iterating throws an error, onError callback
+/// @assertion Stream<T>.fromIterable( Iterable<T> elements )
+///
+/// Creates a stream that gets its data from `elements`.
+///
+/// The iterable is iterated when the stream receives a listener, and stops
+/// iterating if the listener cancels the subscription, or if the
+/// [Iterator.moveNext] method returns false or throws. Iteration is suspended
+/// while the stream subscription is paused.
+///
+/// If calling [Iterator.moveNext] on `elements.iterator` throws, the stream
+/// emits that error and then it closes. If reading [Iterator.current] on
+/// `elements.iterator` throws, the stream emits that error, but keeps iterating
+///
+/// Can be listened to more than once. Each listener iterates elements
+/// independently.
+///
+/// @description Checks that if iterating throws an error, `onError` callback
 /// is run with this error. Also checks that data events are neither further
-/// generated nor fired and onDone event does not happen.
+/// generated nor fired and `onDone` event does not happen.
 /// @author ilya
 
 import "dart:async";

--- a/LibTest/async/Stream/elementAt_A01_t01.test.dart
+++ b/LibTest/async/Stream/elementAt_A01_t01.test.dart
@@ -2,9 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> elementAt(int index)
-///    Returns the value of the indexth data event of this stream.
-///    Stops listening to the stream after the indexth data event has been received.
+/// @assertion Future<T> elementAt( int index )
+/// Returns the value of the indexth data event of this stream.
+///
+/// Stops listening to this stream after the indexth data event has been
+/// received.
+///
+/// Internally the method cancels its subscription after these elements. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this method.
+///
+/// If an error event occurs before the value is found, the future completes
+/// with this error.
+///
+/// If a done event occurs before the value is found, the future completes with
+/// a [RangeError].
+///
 /// @description Checks that the future returns the value of the indexth data
 /// event of this stream.
 /// @author kaigorodov

--- a/LibTest/async/Stream/elementAt_A01_t03.test.dart
+++ b/LibTest/async/Stream/elementAt_A01_t03.test.dart
@@ -2,9 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> elementAt(int index)
+/// @assertion Future<T> elementAt( int index )
 /// Returns the value of the indexth data event of this stream.
-/// Stops listening to the stream after the indexth data event has been received.
+///
+/// Stops listening to this stream after the indexth data event has been
+/// received.
+///
+/// Internally the method cancels its subscription after these elements. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this method.
+///
+/// If an error event occurs before the value is found, the future completes
+/// with this error.
+///
+/// If a done event occurs before the value is found, the future completes with
+/// a [RangeError].
+///
 /// @description Checks that it stops listening to the stream after a value has
 /// been found.
 /// @author ilya

--- a/LibTest/async/Stream/elementAt_A02_t01.test.dart
+++ b/LibTest/async/Stream/elementAt_A02_t01.test.dart
@@ -2,9 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> elementAt(int index)
+/// @assertion Future<T> elementAt( int index )
+/// Returns the value of the indexth data event of this stream.
+///
+/// Stops listening to this stream after the indexth data event has been
+/// received.
+///
+/// Internally the method cancels its subscription after these elements. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this method.
+///
 /// If an error event occurs before the value is found, the future completes
 /// with this error.
+///
+/// If a done event occurs before the value is found, the future completes with
+/// a [RangeError].
+///
 /// @description Checks that if an error event occurs before the value is found,
 /// the future will end with this error.
 /// @author kaigorodov

--- a/LibTest/async/Stream/elementAt_A03_t01.test.dart
+++ b/LibTest/async/Stream/elementAt_A03_t01.test.dart
@@ -2,9 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> elementAt(int index)
-/// If a done event occurs before the value is found, the future completes with a
-/// RangeError.
+/// @assertion Future<T> elementAt( int index )
+/// Returns the value of the indexth data event of this stream.
+///
+/// Stops listening to this stream after the indexth data event has been
+/// received.
+///
+/// Internally the method cancels its subscription after these elements. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this method.
+///
+/// If an error event occurs before the value is found, the future completes
+/// with this error.
+///
+/// If a done event occurs before the value is found, the future completes with
+/// a [RangeError].
+///
 /// @description Checks that if a done event occurs before the value is found,
 /// the future completes with a RangeError.
 /// @author kaigorodov

--- a/LibTest/async/Stream/first_A01_t01.test.dart
+++ b/LibTest/async/Stream/first_A01_t01.test.dart
@@ -2,8 +2,24 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> first
-/// Returns the first element of the stream.
+/// @assertion Future<T> get first
+/// The first element of this stream.
+///
+/// Stops listening to this stream after the first element has been received.
+///
+/// Internally the method cancels its subscription after the first element. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this getter.
+///
+/// If an error event occurs before the first data event, the returned future is
+/// completed with that error.
+///
+/// If this stream is empty (a done event occurs before the first data event),
+/// the returned future completes with an error.
+///
+/// Except for the type of the error, this method is equivalent to
+/// [this.elementAt(0)].
+///
 /// @description Checks that the first element is returned.
 /// @author kaigorodov
 

--- a/LibTest/async/Stream/first_A02_t01.test.dart
+++ b/LibTest/async/Stream/first_A02_t01.test.dart
@@ -2,13 +2,26 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> first
+/// @assertion Future<T> get first
+/// The first element of this stream.
+///
+/// Stops listening to this stream after the first element has been received.
+///
+/// Internally the method cancels its subscription after the first element. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this getter.
+///
+/// If an error event occurs before the first data event, the returned future is
+/// completed with that error.
+///
 /// If this stream is empty (a done event occurs before the first data event),
-/// the resulting future completes with a StateError.
+/// the returned future completes with an error.
+///
 /// Except for the type of the error, this method is equivalent to
-/// this.elementAt(0).
-/// @description Checks that future completes with a StateError when this
-/// stream is empty.
+/// [this.elementAt(0)].
+///
+/// @description Checks that future completes with an error when this stream is
+/// empty.
 /// @author kaigorodov
 
 library first_A02_t01;
@@ -16,5 +29,5 @@ library first_A02_t01;
 import "../../../Utils/expect.dart";
 
 void test(CreateStreamFunction create) {
-  AsyncExpect.error((e) => e is StateError, create([]).first);
+  AsyncExpect.error((e) => e is Error, create([]).first);
 }

--- a/LibTest/async/Stream/first_A02_t02.test.dart
+++ b/LibTest/async/Stream/first_A02_t02.test.dart
@@ -2,13 +2,26 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> first
+/// @assertion Future<T> get first
+/// The first element of this stream.
+///
+/// Stops listening to this stream after the first element has been received.
+///
+/// Internally the method cancels its subscription after the first element. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this getter.
+///
+/// If an error event occurs before the first data event, the returned future is
+/// completed with that error.
+///
 /// If this stream is empty (a done event occurs before the first data event),
-/// the resulting future completes with a StateError.
+/// the returned future completes with an error.
+///
 /// Except for the type of the error, this method is equivalent to
-/// this.elementAt(0).
+/// [this.elementAt(0)].
+///
 /// @description Checks that for non-empty stream, this.first is equivalent to
-/// this.elementAt(0).
+/// [this.elementAt(0)].
 /// @author kaigorodov
 
 library first_A02_t02;

--- a/LibTest/async/Stream/first_A03_t01.test.dart
+++ b/LibTest/async/Stream/first_A03_t01.test.dart
@@ -2,9 +2,24 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<T> first
-/// If an error event occurs before the first data event, the resulting future
-/// is completed with that error.
+/// @assertion Future<T> get first
+/// The first element of this stream.
+///
+/// Stops listening to this stream after the first element has been received.
+///
+/// Internally the method cancels its subscription after the first element. This
+/// means that single-subscription (non-broadcast) streams are closed and cannot
+/// be reused after a call to this getter.
+///
+/// If an error event occurs before the first data event, the returned future is
+/// completed with that error.
+///
+/// If this stream is empty (a done event occurs before the first data event),
+/// the returned future completes with an error.
+///
+/// Except for the type of the error, this method is equivalent to
+/// [this.elementAt(0)].
+///
 /// @description Checks that if error event occurs before the first data event,
 /// the future completes with that error.
 /// @author ilya

--- a/LibTest/async/Stream/isEmpty_A01_t01.test.dart
+++ b/LibTest/async/Stream/isEmpty_A01_t01.test.dart
@@ -2,12 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<bool> isEmpty
+/// @assertion Future<bool> get isEmpty
 /// Whether this stream contains any elements.
+///
 /// Waits for the first element of this stream, then completes the returned
-/// future with `true`.
-/// If the stream ends without emitting any elements, the returned future is
-/// completed with `false`.
+/// future with `false`. If this stream ends without emitting any elements, the
+/// returned future is completed with `true`.
+///
+/// If the first event is an error, the returned future is completed with that
+/// error.
+///
+/// This operation listens to this stream, and a non-broadcast stream cannot be
+/// reused after checking whether it is empty.
+///
 /// @description Checks that the method returns whether this stream contains any
 /// elements.
 /// @author kaigorodov

--- a/LibTest/async/Stream/isEmpty_A02_t01.test.dart
+++ b/LibTest/async/Stream/isEmpty_A02_t01.test.dart
@@ -2,13 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<bool> isEmpty
+/// @assertion Future<bool> get isEmpty
 /// Whether this stream contains any elements.
+///
 /// Waits for the first element of this stream, then completes the returned
-/// future with `true`.
-/// If the stream ends without emitting any elements, the returned future is
-/// completed with `false`.
-/// @description Checks that only first element of the stream is examined
+/// future with `false`. If this stream ends without emitting any elements, the
+/// returned future is completed with `true`.
+///
+/// If the first event is an error, the returned future is completed with that
+/// error.
+///
+/// This operation listens to this stream, and a non-broadcast stream cannot be
+/// reused after checking whether it is empty.
+///
+/// @description Checks that only the first element of the stream is examined.
 /// @author a.semenov@unipro.ru
 
 library isEmpty_A02_t01;

--- a/LibTest/async/Stream/isEmpty_A03_t01.test.dart
+++ b/LibTest/async/Stream/isEmpty_A03_t01.test.dart
@@ -2,9 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<bool> isEmpty
+/// @assertion Future<bool> get isEmpty
+/// Whether this stream contains any elements.
+///
+/// Waits for the first element of this stream, then completes the returned
+/// future with `false`. If this stream ends without emitting any elements, the
+/// returned future is completed with `true`.
+///
 /// If the first event is an error, the returned future is completed with that
 /// error.
+///
+/// This operation listens to this stream, and a non-broadcast stream cannot be
+/// reused after checking whether it is empty.
+///
 /// @description Checks that returned future is completed with the first error,
 /// that appears in the stream
 /// @issue 29730

--- a/LibTest/async/Stream/isEmpty_A04_t01.test.dart
+++ b/LibTest/async/Stream/isEmpty_A04_t01.test.dart
@@ -2,11 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Future<bool> isEmpty
-/// This operation listens to the stream, and a non-broadcast stream cannot
-/// be reused after checking whether it is empty.
-/// @description Checks that stream subscription is canceled after result
-/// is known.
+/// @assertion Future<bool> get isEmpty
+/// Whether this stream contains any elements.
+///
+/// Waits for the first element of this stream, then completes the returned
+/// future with `false`. If this stream ends without emitting any elements, the
+/// returned future is completed with `true`.
+///
+/// If the first event is an error, the returned future is completed with that
+/// error.
+///
+/// This operation listens to this stream, and a non-broadcast stream cannot be
+/// reused after checking whether it is empty.
+///
+/// @description Checks that stream subscription is canceled after checking
+/// whether the stream is empty.
 /// @author a.semenov@unipro.ru
 
 library isEmpty_A04_t01;
@@ -14,20 +24,29 @@ library isEmpty_A04_t01;
 import "dart:async";
 import "../../../Utils/expect.dart";
 
-void check(Stream s, bool expected) {
+void check(Stream s, int max) {
+  int count = 0;
+  s = s.map((event) {
+    count++;
+    if (count > max) {
+      Expect.fail("Stream should be cancelled");
+    }
+    return event;
+  });
   asyncStart();
   s.isEmpty.then((bool actual) {
-    Expect.equals(expected, actual);
-    if (!s.isBroadcast) {
-      Expect.throws(() => s.listen((_) {}));
-    }
-    asyncEnd();
+    Expect.equals(count, max);
+    // Wait for some time to make sure that there is no more events
+    Future.delayed(Duration(seconds: 1), () {
+      Expect.equals(count, max);
+      asyncEnd();
+    });
   });
 }
 
 void test(CreateStreamFunction create) {
-  check(create([]), true);
-  check(create([1, 2, 3, null]), false);
-  check(create(new Iterable.generate(0, (int index) => 1)), true);
-  check(create(new Iterable.generate(10, (int index) => 1)), false);
+  check(create([]), 0);
+  check(create([1, 2, 3, null]), 1);
+  check(create(new Iterable.generate(0, (int index) => 1)), 0);
+  check(create(new Iterable.generate(10, (int index) => 1)), 1);
 }


### PR DESCRIPTION
This also fixes https://github.com/dart-lang/sdk/issues/49264. Updated tests use `Stream.map` to check that the subscription was cancelled and there are no new events. The updated tests pass.