### PR TITLE
Fixes #2938. Remove string literals identity check

### DIFF
--- a/Utils/tests/Expect/notIdentical_A01_t01.dart
+++ b/Utils/tests/Expect/notIdentical_A01_t01.dart
@@ -18,7 +18,6 @@ class C {
 }
 
 main() {
-  Expect.notIdentical("x", String.fromCharCode("x".codeUnitAt(0)));
   Expect.notIdentical(Object(), Object());
   Expect.notIdentical(Object(), const Object());
   Expect.notIdentical(C(42), C(42));


### PR DESCRIPTION
The test failed on web. Let's don't check identity of string literals here.