### PR TITLE
Fixes #2967. Update/ignore invalid_null_aware_operator warnings

### DIFF
--- a/LanguageFeatures/Control-flow-collections/Null-aware-elements/syntax_A05_t02.dart
+++ b/LanguageFeatures/Control-flow-collections/Null-aware-elements/syntax_A05_t02.dart
@@ -58,7 +58,7 @@ main() {
     // 6: ?6
     f(null) ?? 6: ? f(null) ?? 6,  // ignore: invalid_null_aware_operator
     // null: ?7
-    f(null) ?? null: ? f(null) ?? 7,
+    f(null) ?? null: ? f(null) ?? 7, // ignore: invalid_null_aware_operator
 
     // ?8: ?null
     ?f(8) ?? null: ?f(null) ?? null,

--- a/LanguageFeatures/Control-flow-collections/Null-aware-elements/syntax_equality_A01_t01.dart
+++ b/LanguageFeatures/Control-flow-collections/Null-aware-elements/syntax_equality_A01_t01.dart
@@ -22,8 +22,6 @@
 
 // SharedOptions=--enable-experiment=null-aware-elements
 
-// TODO(sgrekhov): replace unspecified by the actual lint name
-
 import '../../../Utils/expect.dart';
 
 class A {
@@ -39,12 +37,8 @@ class C extends A {
 
   void test(int? expected) {
     var list = [
-      ?super == expected,
-//    ^
-// [analyzer] unspecified
-      ?super != expected
-//    ^
-// [analyzer] unspecified
+      ?super == expected,     // ignore: invalid_null_aware_operator
+      ?super != expected      // ignore: invalid_null_aware_operator
     ];
     if (expected != null) {
       Expect.listEquals([true, false], list);
@@ -53,28 +47,16 @@ class C extends A {
     }
 
     var set = {
-      ?super == expected,
-//    ^
-// [analyzer] unspecified
-      ?super != expected
-//    ^
-// [analyzer] unspecified
+      ?super == expected,     // ignore: invalid_null_aware_operator
+      ?super != expected      // ignore: invalid_null_aware_operator
     };
     Expect.setEquals({false, true}, set);
 
     var map1 = {
-      ?super == expected: 1,
-//    ^
-// [analyzer] unspecified
-      ?super != expected: 2,
-//    ^
-// [analyzer] unspecified
-      3: ?super == expected,
-//       ^
-// [analyzer] unspecified
-      4: ?super != expected,
-//       ^
-// [analyzer] unspecified
+      ?super == expected: 1,    // ignore: invalid_null_aware_operator
+      ?super != expected: 2,    // ignore: invalid_null_aware_operator
+      3: ?super == expected,    // ignore: invalid_null_aware_operator
+      4: ?super != expected,    // ignore: invalid_null_aware_operator
     };
     if (expected != null) {
       Expect.mapEquals({true: 1, false: 2, 3: true, 4: false}, map1);
@@ -83,12 +65,8 @@ class C extends A {
     }
 
     var map2 = {
-      ?super == expected: ?super == expected,
-//    ^
-// [analyzer] unspecified
-      ?super != expected: ?super != expected
-//    ^
-// [analyzer] unspecified
+      ?super == expected: ?super == expected, // ignore: invalid_null_aware_operator
+      ?super != expected: ?super != expected  // ignore: invalid_null_aware_operator
     };
     Expect.mapEquals({true: true, false: false}, map2);
   }
@@ -99,28 +77,28 @@ main() {
   int? e2 = 1 > 2 ? 1 : null; // null
 
   var list = [
-    ?e1 == e2,
-    ?e2 != e1
+    ?e1 == e2,      // ignore: invalid_null_aware_operator
+    ?e2 != e1       // ignore: invalid_null_aware_operator
   ];
   Expect.listEquals([false, true], list);
 
   var set = {
-    ?e1 == e2,
-    ?e2 != e1
+    ?e1 == e2,      // ignore: invalid_null_aware_operator
+    ?e2 != e1       // ignore: invalid_null_aware_operator
   };
   Expect.setEquals({false, true}, set);
 
   var map1 = {
-    ?e1 == e2: 1,
-    ?e2 != e1: 2,
-    3: ?e1 == e2,
-    4: ?e2 != e1,
+    ?e1 == e2: 1,     // ignore: invalid_null_aware_operator
+    ?e2 != e1: 2,     // ignore: invalid_null_aware_operator
+    3: ?e1 == e2,     // ignore: invalid_null_aware_operator
+    4: ?e2 != e1,     // ignore: invalid_null_aware_operator
   };
   Expect.mapEquals({false: 1, true: 2, 3: false, 4: true}, map1);
 
   var map2 = {
-    ?e1 == e2: ?e1 == e2,
-    ?e2 != e1: ?e2 != e1
+    ?e1 == e2: ?e1 == e2,   // ignore: invalid_null_aware_operator
+    ?e2 != e1: ?e2 != e1    // ignore: invalid_null_aware_operator
   };
   Expect.mapEquals({false: false, true: true}, map2);
 

--- a/LanguageFeatures/Control-flow-collections/Null-aware-elements/warnings_A01_t04.dart
+++ b/LanguageFeatures/Control-flow-collections/Null-aware-elements/warnings_A01_t04.dart
@@ -21,67 +21,67 @@ main() {
   var list = <int>[
     ? f(1) ?? 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? f(null) ?? 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? 2 > 1 ? 3 : 4
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
   ];
   Expect.listEquals([1, 2, 3], list);
 
   var set = <int>{
     ? f(1) ?? 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? f(null) ?? 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? 2 > 1 ? 3 : 4
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
   };
   Expect.setEquals({1, 2, 3}, set);
 
   var map = <int, int>{
     ? f(1) ?? 2: 1,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? f(null) ?? 2: 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? 2 > 1 ? 3 : 4: 3,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     4: ? f(1) ?? 2,
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     5: ? f(null) ?? 2,
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     6: ? 2 > 1 ? 3 : 4
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
   };
   Expect.mapEquals({
     ? f(1) ?? 2: 1,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? f(null) ?? 2: 2,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     ? 2 > 1 ? 3 : 4: 3,
 //  ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     4: ? f(1) ?? 2,
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     5: ? f(null) ?? 2,
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
     6: ? 2 > 1 ? 3 : 4
 //     ^
-// [analyzer] invalid_null_aware_operator
+// [analyzer] STATIC_WARNING.INVALID_NULL_AWARE_OPERATOR
   }, map);
 }

--- a/LanguageFeatures/Control-flow-collections/Null-aware-elements/warnings_A01_t04.dart
+++ b/LanguageFeatures/Control-flow-collections/Null-aware-elements/warnings_A01_t04.dart
@@ -13,8 +13,6 @@
 
 // SharedOptions=--enable-experiment=null-aware-elements
 
-// TODO(sgrekhov): replace unspecified by the actual lint name
-
 import '../../../Utils/expect.dart';
 
 int? f(int? v) => v;
@@ -23,55 +21,67 @@ main() {
   var list = <int>[
     ? f(1) ?? 2,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? f(null) ?? 2,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? 2 > 1 ? 3 : 4
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
   ];
   Expect.listEquals([1, 2, 3], list);
 
   var set = <int>{
     ? f(1) ?? 2,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? f(null) ?? 2,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? 2 > 1 ? 3 : 4
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
   };
   Expect.setEquals({1, 2, 3}, set);
 
   var map = <int, int>{
     ? f(1) ?? 2: 1,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? f(null) ?? 2: 2,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     ? 2 > 1 ? 3 : 4: 3,
 //  ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     4: ? f(1) ?? 2,
 //     ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     5: ? f(null) ?? 2,
 //     ^
-// [analyzer] unspecified
+// [analyzer] invalid_null_aware_operator
     6: ? 2 > 1 ? 3 : 4
-//  ^
-// [analyzer] unspecified
+//     ^
+// [analyzer] invalid_null_aware_operator
   };
   Expect.mapEquals({
     ? f(1) ?? 2: 1,
+//  ^
+// [analyzer] invalid_null_aware_operator
     ? f(null) ?? 2: 2,
+//  ^
+// [analyzer] invalid_null_aware_operator
     ? 2 > 1 ? 3 : 4: 3,
+//  ^
+// [analyzer] invalid_null_aware_operator
     4: ? f(1) ?? 2,
+//     ^
+// [analyzer] invalid_null_aware_operator
     5: ? f(null) ?? 2,
+//     ^
+// [analyzer] invalid_null_aware_operator
     6: ? 2 > 1 ? 3 : 4
+//     ^
+// [analyzer] invalid_null_aware_operator
   }, map);
 }


### PR DESCRIPTION
There are more tests that have `TODO(sgrekhov): replace unspecified by the actual lint name`. I'll update them in a separate PR