### PR TITLE
#2979. Update NNBD static errors tests. Part 1.

### DIFF
--- a/LanguageFeatures/nnbd/static_errors_A04_t01.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t01.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test Never
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test type `Never`.
 /// @author sgrekhov@unipro.ru
-
 
 Never n;
 //    ^
@@ -25,5 +24,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t02.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t02.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test Function
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test type `Function`.
 /// @author sgrekhov@unipro.ru
-
 
 Function f;
 //       ^
@@ -25,5 +24,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t03.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t03.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test function type
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test a function type.
 /// @author sgrekhov@unipro.ru
-
 
 typedef void Foo();
 
@@ -27,5 +26,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t04.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t04.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test some class A
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test some class.
 /// @author sgrekhov@unipro.ru
-
 
 class A {}
 
@@ -35,5 +34,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t08.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t08.dart
@@ -3,14 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test FutureOr<Never>
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test type `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
-
 
 import "dart:async";
 
@@ -27,5 +26,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t09.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t09.dart
@@ -3,15 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test FutureOr<F> where F is
-/// a function type
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test type `FutureOr<F>` where `F` is a
+/// function type.
 /// @author sgrekhov@unipro.ru
-
 
 import "dart:async";
 
@@ -40,5 +39,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t10.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t10.dart
@@ -3,15 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test FutureOr<A> where A is
-/// some class
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test type `FutureOr<A>` where `A` is
+/// some class.
 /// @author sgrekhov@unipro.ru
-
 
 import "dart:async";
 
@@ -40,5 +39,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t13.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t13.dart
@@ -3,15 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is an error if a top level variable or static
-/// variable with a non-nullable type has no initializer expression unless the
-/// variable is marked with the `late` modifier. Test FutureOr<FutureOr<A>>
-/// where A is some class
+/// @description Check that it is an error if a top level or static variable
+/// with a non-nullable type has no initializer expression and is not marked
+/// with a `late` or `external `modifier. Test `FutureOr<FutureOr<A>>` where `A`
+/// is some class.
 /// @author sgrekhov@unipro.ru
-
 
 import "dart:async";
 
@@ -40,5 +39,5 @@ class C {
 }
 
 main() {
-  new C();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t21.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t21.dart
@@ -3,22 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test Never
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test type `Never`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
-late Never n;
+
+late Never n1;
+external Never n2;
 
 class C {
   static late Never n1;
   static late final Never n2;
+  external static  Never n3;
+  external static final Never n4;
 }
 
 main() {
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t22.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t22.dart
@@ -3,21 +3,24 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test Function
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test type `Function`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
 
-late Function x;
+late Function x1;
+external Function x2;
 
 class C {
   static late Function x1;
   static late final Function x2;
+  external static Function x3;
+  external static final Function x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t23.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t23.dart
@@ -3,22 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test function type
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test a function type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 typedef void Foo();
 
-late Foo x;
+late Foo x1;
+external Foo x2;
 
 class C {
   static late Foo x1;
   static late final Foo x2;
+  external static Foo x3;
+  external static final Foo x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t24.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t24.dart
@@ -3,22 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test some class A
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 class A {}
 
-late A x;
+late A x1;
+external A x2;
 
 class C {
   static late A x1;
   static late final A x2;
+  external static A x3;
+  external static final A x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t28.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t28.dart
@@ -3,21 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test FutureOr<Never>
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test type `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
-late FutureOr<Never> x;
+
+late FutureOr<Never> x1;
+external FutureOr<Never> x2;
 
 class C {
   static late FutureOr<Never> x1;
   static late final FutureOr<Never> x2;
+  external static FutureOr<Never> x3;
+  external static final FutureOr<Never> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t29.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t29.dart
@@ -3,28 +3,36 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test FutureOr<F> where F is a function
-/// type
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test `FutureOr<F>` where `F` is a function
+/// type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 typedef void Foo();
 
 late FutureOr<Function> f1;
 late FutureOr<Foo> f2;
+external FutureOr<Function> f3;
+external FutureOr<Foo> f4;
 
 class C {
   static late FutureOr<Function> x1;
   static late final FutureOr<Function> x2;
-
   static late FutureOr<Foo> x3;
   static late final FutureOr<Foo> x4;
+
+  external static FutureOr<Function> x5;
+  external static final FutureOr<Function> x6;
+  external static FutureOr<Foo> x7;
+  external static final FutureOr<Foo> x8;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t30.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t30.dart
@@ -3,23 +3,28 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test FutureOr<A> where A is some class
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test `FutureOr<A>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 class A {}
 
-late FutureOr<A> x;
+late FutureOr<A> x1;
+external FutureOr<A> x2;
 
 class C {
   static late FutureOr<A> x1;
   static late final FutureOr<A> x2;
+  external static FutureOr<A> x3;
+  external static final FutureOr<A> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t33.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t33.dart
@@ -3,24 +3,29 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is an error if a top level variable or static variable with a
-/// non-nullable type has no initializer expression unless the variable is marked
-/// with the `late` modifier.
+/// non-nullable type has no initializer expression unless the variable is
+/// marked with a `late` or `external` modifier.
 ///
-/// @description Check that it is not an error if a top level or static
-/// variable with potentially non-nullable type has no initializer expression
-/// but marked with a 'late' modifier. Test FutureOr<FutureOr<A>> where A is some
-/// class
+/// @description Check that it is not an error if a top level or static variable
+/// with a non-nullable type has no initializer expression but is marked with a
+/// `late` or `external `modifier. Test `FutureOr<FutureOr<A>>` where `A` is
+/// some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 class A {}
 
-late FutureOr<FutureOr<A>> x;
+late FutureOr<FutureOr<A>> x1;
+external FutureOr<FutureOr<A>> x2;
 
 class C {
   static late FutureOr<FutureOr<A>> x1;
   static late final FutureOr<FutureOr<A>> x2;
+  external static FutureOr<FutureOr<A>> x3;
+  external static final FutureOr<FutureOr<A>> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t01.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t01.dart
@@ -6,16 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test Never
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test type `Never`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 class C1 {
   Never n;
@@ -33,12 +33,9 @@ abstract class C2 {
   C2() {}
 //^^
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t02.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t02.dart
@@ -6,13 +6,14 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description It is an error if a class declaration declares an instance
-/// variable with a potentially non-nullable type and no initializer expression,
-/// and the class has a generative constructor where the variable is not
-/// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier. Test Function
+/// @description Check that it is an error if a class declaration declares an
+/// instance variable with a potentially non-nullable type and no initializer
+/// expression, and the class has a generative constructor where the variable is
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test type `Function`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
 
@@ -36,9 +37,7 @@ abstract class C2 {
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t03.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t03.dart
@@ -6,16 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test function type
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test a function type.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 typedef void Foo();
 
@@ -26,7 +26,6 @@ class C1 {
   C1() {}
 //^^
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-
 }
 
 abstract class C2 {
@@ -38,9 +37,7 @@ abstract class C2 {
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t04.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t04.dart
@@ -6,16 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test some class A
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test some class.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 class A {}
 
@@ -47,9 +47,7 @@ abstract class C2 {
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t06.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t06.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test some type
-/// <X extends Object>
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test type `<X extends Object>`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 class C1<X extends Object> {
   X x;
@@ -36,9 +35,7 @@ abstract class C2<X extends Object> {
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t07.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t07.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test some type
-/// <X extends Object?>
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test type `<X extends Object?>`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 class C1<X extends Object?> {
   X x;
@@ -36,9 +35,7 @@ abstract class C2<X extends Object?> {
 // [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t08.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t08.dart
@@ -6,16 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test FutureOr<Never>
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test type `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 import "dart:async";
 

--- a/LanguageFeatures/nnbd/static_errors_A05_t09.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t09.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test FutureOr<F> where
-/// F is a function type
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test `FutureOr<F>` where `F` is a function type.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 import "dart:async";
 
@@ -32,9 +31,7 @@ class C1 {
 
   C1() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
 abstract class C2 {
@@ -47,14 +44,10 @@ abstract class C2 {
 
   C2() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t10.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t10.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test FutureOr<A> where
-/// A is some class
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test `FutureOr<A>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 import "dart:async";
 
@@ -31,9 +30,7 @@ class C1 {
 // [cfe] unspecified
   C1() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
 abstract class C2 {
@@ -45,14 +42,10 @@ abstract class C2 {
 // [cfe] unspecified
   C2() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t12.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t12.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test FutureOr<T>, where
-/// <T extends Object>
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test `FutureOr<T>`, where `<T extends Object>`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 import "dart:async";
 
@@ -26,7 +25,7 @@ class C1<T extends Object> {
 // [cfe] unspecified
   C1() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
 abstract class C2<T extends Object> {
@@ -35,12 +34,10 @@ abstract class C2<T extends Object> {
 // [cfe] unspecified
   C2() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t13.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t13.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
 /// @description Check that it is an error if a class declaration declares an
 /// instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test
-/// FutureOr<FutureOr<A>> where A is some class
+/// not initialized via an initializing formal or an initializer list entry, and
+/// the variable is not marked with a `late`, `abstract` or `external` modifier.
+/// Test `FutureOr<FutureOr<A>>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 /// @issue 40951
-
 
 import "dart:async";
 
@@ -31,9 +30,7 @@ class C1 {
 // [cfe] unspecified
   C1() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
 abstract class C2 {
@@ -46,14 +43,10 @@ abstract class C2 {
 
   C2() {}
 //^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
-//^^
-// [analyzer] COMPILE_TIME_ERROR.NOT_INITIALIZED_NON_NULLABLE_INSTANCE_FIELD
+// [analyzer] unspecified
 }
 
-class C3 extends C2 {}
-
 main() {
-  new C1();
-  new C3();
+  print(C1);
+  print(C2);
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t15.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t15.dart
@@ -6,15 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is no compile-time error if an instance variable
-/// with a potentially non-nullable type has no initializer expression but
-/// initialized in a constructor via an initializing formal or an initializer
-/// list entry. Test Function types
+/// @description Check that it is no error if an instance variable with a
+/// potentially non-nullable type has no initializer expression but initialized
+/// in a constructor via an initializing formal or an initializer list entry.
+/// Test `Function` types
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 typedef void Foo();
 
 class A {

--- a/LanguageFeatures/nnbd/static_errors_A05_t16.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t16.dart
@@ -6,15 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is no compile-time error if an instance variable
-/// with a potentially non-nullable type has no initializer expression but
-/// initialized in a constructor via an initializing formal or an initializer
-/// list entry. Test some class A
+/// @description Check that it is no error if an instance variable with a
+/// potentially non-nullable type has no initializer expression but initialized
+/// in a constructor via an initializing formal or an initializer list entry.
+/// Test some class `A`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 class A {}
 
 class C1 {

--- a/LanguageFeatures/nnbd/static_errors_A05_t17.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t17.dart
@@ -6,16 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
-/// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test <T extends Object>
+/// @description Check that it is no error if an instance variable with a
+/// potentially non-nullable type has no initializer expression but initialized
+/// in a constructor via an initializing formal or an initializer list entry.
+/// Test type `<T extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 class A {}
 
 class C1<T extends Object> {

--- a/LanguageFeatures/nnbd/static_errors_A05_t18.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t18.dart
@@ -6,20 +6,22 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
-/// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier. Test FutureOr
+/// @description Check that it is no error if an instance variable with a
+/// potentially non-nullable type has no initializer expression but initialized
+/// in a constructor via an initializing formal or an initializer list entry.
+/// Test type `FutureOr`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
 
 typedef void Foo();
+
 class A {}
+
 void foo() {}
 dynamic getX() => null;
 
@@ -29,8 +31,17 @@ class C1<T extends Object> {
   FutureOr<Foo> f2;
   FutureOr<A> a1;
   FutureOr<FutureOr<A>> a2;
-  C1(FutureOr<T> t, FutureOr<Function> f1, FutureOr<Foo> f2, FutureOr<A> a1, FutureOr<FutureOr<A>> a2)
-      : this.t1 = t, this.f1 = f1, this.f2 = f2, this.a1 = a1, this.a2 = a2 {}
+  C1(
+    FutureOr<T> t,
+    FutureOr<Function> f1,
+    FutureOr<Foo> f2,
+    FutureOr<A> a1,
+    FutureOr<FutureOr<A>> a2,
+  ) : this.t1 = t,
+      this.f1 = f1,
+      this.f2 = f2,
+      this.a1 = a1,
+      this.a2 = a2 {}
 }
 
 class C2<T extends Object> {

--- a/LanguageFeatures/nnbd/static_errors_A05_t19.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t19.dart
@@ -6,17 +6,16 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
-/// expression, and the class has a generative constructor where the variable is
-/// not initialized via an initializing formal or an initializer list entry,
-/// unless the variable is marked with the late modifier.
-/// Test <T extends Object?>
+/// @description Check that it is no error if an instance variable with a
+/// potentially non-nullable type has no initializer expression but initialized
+/// in a constructor via an initializing formal or an initializer list entry.
+/// Test type `<T extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 class A {}
 
 class C1<T extends Object?> {

--- a/LanguageFeatures/nnbd/static_errors_A05_t21.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t21.dart
@@ -6,22 +6,34 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test Never
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// type `Never`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
+abstract class A {
+  abstract Never n1;
+  abstract final Never n2;
+  abstract covariant Never n3;
+}
+
 class C {
   late Never n1;
   late final Never n2;
   covariant late Never n3;
+
+  external Never n4;
+  external final Never n5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t22.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t22.dart
@@ -6,25 +6,34 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test Function
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// type `Function`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
+abstract class A {
+  abstract Function x1;
+  abstract final Function x2;
+  abstract covariant Function x3;
+}
 
 class C {
   late Function x1;
   late final Function x2;
   covariant late Function x3;
 
-  C() {}
+  external Function x4;
+  external final Function x5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t23.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t23.dart
@@ -6,26 +6,36 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test function type
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// a function type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 typedef void Foo();
+
+abstract class A {
+  abstract Foo x1;
+  abstract final Foo x2;
+  abstract covariant Foo x3;
+}
 
 class C {
   late Foo x1;
   late final Foo x2;
   covariant late Foo x3;
 
-  C() {}
+  external Foo x4;
+  external final Foo x5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t24.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t24.dart
@@ -6,26 +6,36 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test some class A
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// some class `A`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 class A {}
+
+abstract class B {
+  abstract A x1;
+  abstract final A x2;
+  abstract covariant A x3;
+}
 
 class C {
   late A x1;
   late final A x2;
   covariant late A x3;
 
-  C() {}
+  external A x4;
+  external final A x5;
 }
 
 main() {
+  print(B);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t26.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t26.dart
@@ -6,26 +6,34 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test some type
-/// <X extends Object>
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// some type `<X extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
+abstract class A<X extends Object> {
+  abstract X x1;
+  abstract final X x2;
+  abstract covariant X x3;
+}
 
 class C<X extends Object> {
   late X x1;
   late final X x2;
   covariant late X x3;
 
-  C() {}
+  external X x4;
+  external final X x5;
 }
 
 main() {
+  print(A);
   new C<String>();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t27.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t27.dart
@@ -6,26 +6,34 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test some type
-/// <X extends Object?>
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// type `<X extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
+abstract class A<X extends Object?> {
+  abstract X x1;
+  abstract final X x2;
+  abstract covariant X x3;
+}
 
 class C<X extends Object?> {
   late X x1;
   late final X x2;
   covariant late X x3;
 
-  C() {}
+  external X x4;
+  external final X x5;
 }
 
 main() {
+  print(A);
   new C<String?>();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t28.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t28.dart
@@ -6,26 +6,36 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<Never>
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// type `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
+abstract class A {
+  abstract FutureOr<Never> x1;
+  abstract final FutureOr<Never> x2;
+  abstract covariant FutureOr<Never> x3;
+}
 
 class C {
   late FutureOr<Never> x1;
   late final FutureOr<Never> x2;
   covariant late FutureOr<Never> x3;
 
-  C() {}
+  external FutureOr<Never> x4;
+  external final FutureOr<Never> x5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t29.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t29.dart
@@ -6,19 +6,27 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<F> where F is
-/// a function type
+/// the variable is marked with `late`, `abstract`, or `external` modifier.
+/// Test `FutureOr<F>` where `F` is a function type
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 typedef void Foo();
+
+abstract class A {
+  abstract FutureOr<Function> x1;
+  abstract final FutureOr<Function> x2;
+  abstract covariant FutureOr<Function> x3;
+}
 
 class C {
   late FutureOr<Function> x1;
@@ -29,9 +37,14 @@ class C {
   late final FutureOr<Foo> x5;
   covariant late FutureOr<Foo> x6;
 
-  C() {}
+  external FutureOr<Function> x7;
+  external final FutureOr<Function> x8;
+
+  external FutureOr<Foo> x9;
+  external final FutureOr<Foo> x10;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t30.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t30.dart
@@ -6,28 +6,37 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<A> where A is
-/// some class
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// `FutureOr<A>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 class A {}
 
+abstract class B {
+  abstract FutureOr<A> x1;
+  abstract final FutureOr<A> x2;
+  abstract covariant FutureOr<A> x3;
+}
 class C {
   late FutureOr<A> x1;
   late final FutureOr<A> x2;
   covariant late FutureOr<A> x3;
 
-  C() {}
+  external FutureOr<A> x4;
+  external final FutureOr<A> x5;
 }
 
 main() {
+  print(B);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t32.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t32.dart
@@ -6,27 +6,36 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<T>,
-/// where <T extends Object>
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// type `FutureOr<T>`, where `<T extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
+abstract class A<T extends Object> {
+  abstract FutureOr<T> x1;
+  abstract final FutureOr<T> x2;
+  abstract covariant FutureOr<T> x3;
+}
 
 class C<T extends Object> {
   late FutureOr<T> x1;
   late final FutureOr<T> x2;
   covariant late FutureOr<T> x3;
 
-  C() {}
+  external FutureOr<T> x4;
+  external final FutureOr<T> x5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t33.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t33.dart
@@ -6,27 +6,36 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<T>,
-/// where <T extends Object?>
+/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// `FutureOr<T>`, where `<T extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
+abstract class A<T extends Object?> {
+  abstract FutureOr<T> x1;
+  abstract final FutureOr<T> x2;
+  abstract covariant FutureOr<T> x3;
+}
 
 class C<T extends Object?> {
   late FutureOr<T> x1;
   late final FutureOr<T> x2;
   covariant late FutureOr<T> x3;
 
-  C() {}
+  external FutureOr<T> x4;
+  external final FutureOr<T> x5;
 }
 
 main() {
+  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t34.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t34.dart
@@ -6,28 +6,38 @@
 /// variable with a potentially non-nullable type and no initializer expression,
 /// and the class has a generative constructor where the variable is not
 /// initialized via an initializing formal or an initializer list entry, unless
-/// the variable is marked with the late modifier.
+/// the variable is marked with a `late`, `abstract`, or `external` modifier.
 ///
-/// @description Check that it is not an error if a class declaration declares an
-/// instance variable with a potentially non-nullable type and no initializer
+/// @description Check that it is not an error if a class declaration declares
+/// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with the 'late' modifier. Test FutureOr<FutureOr<A>>
-/// where A is some class
+/// the variable is marked with `late`, `abstract`, or `external` modifier.
+/// Test `FutureOr<FutureOr<A>>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
+
 import "dart:async";
+
 class A {}
+
+abstract class B {
+  abstract FutureOr<FutureOr<A>> x1;
+  abstract final FutureOr<FutureOr<A>> x2;
+  abstract covariant FutureOr<FutureOr<A>> x3;
+}
 
 class C {
   late FutureOr<FutureOr<A>> x1;
   late final FutureOr<FutureOr<A>> x2;
   covariant late FutureOr<FutureOr<A>> x3;
 
-  C() {}
+  external FutureOr<FutureOr<A>> x4;
+  external final FutureOr<FutureOr<A>> x5;
 }
 
 main() {
+  print(A);
   new C();
 }


### PR DESCRIPTION
- updated assertions and descriptions
- added checks for `external` and `abstract`