### PR TITLE
Fixes #2991. Fix typos and separate tests with `external`

### DIFF
--- a/Language/Types/Type_Void/type_void_A06_t11.dart
+++ b/Language/Types/Type_Void/type_void_A06_t11.dart
@@ -18,3 +18,4 @@ main() {
 //      ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified}
+}

--- a/LanguageFeatures/nnbd/static_errors_A04_t21.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t21.dart
@@ -8,19 +8,16 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test type `Never`.
+/// `late` modifier. Test type `Never`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
 
 late Never n1;
-external Never n2;
 
 class C {
   static late Never n1;
   static late final Never n2;
-  external static  Never n3;
-  external static final Never n4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t23.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t23.dart
@@ -8,7 +8,7 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test a function type.
+/// `late` modifier. Test a function type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -16,13 +16,10 @@
 typedef void Foo();
 
 late Foo x1;
-external Foo x2;
 
 class C {
   static late Foo x1;
   static late final Foo x2;
-  external static Foo x3;
-  external static final Foo x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t24.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t24.dart
@@ -8,7 +8,7 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test some class.
+/// `late` modifier. Test some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -16,13 +16,10 @@
 class A {}
 
 late A x1;
-external A x2;
 
 class C {
   static late A x1;
   static late final A x2;
-  external static A x3;
-  external static final A x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t28.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t28.dart
@@ -8,7 +8,7 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test type `FutureOr<Never>`.
+/// `late` modifier. Test type `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -16,13 +16,10 @@
 import "dart:async";
 
 late FutureOr<Never> x1;
-external FutureOr<Never> x2;
 
 class C {
   static late FutureOr<Never> x1;
   static late final FutureOr<Never> x2;
-  external static FutureOr<Never> x3;
-  external static final FutureOr<Never> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t29.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t29.dart
@@ -8,8 +8,7 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test `FutureOr<F>` where `F` is a function
-/// type.
+/// `late` modifier. Test `FutureOr<F>` where `F` is a function type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -20,19 +19,12 @@ typedef void Foo();
 
 late FutureOr<Function> f1;
 late FutureOr<Foo> f2;
-external FutureOr<Function> f3;
-external FutureOr<Foo> f4;
 
 class C {
   static late FutureOr<Function> x1;
   static late final FutureOr<Function> x2;
   static late FutureOr<Foo> x3;
   static late final FutureOr<Foo> x4;
-
-  external static FutureOr<Function> x5;
-  external static final FutureOr<Function> x6;
-  external static FutureOr<Foo> x7;
-  external static final FutureOr<Foo> x8;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t30.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t30.dart
@@ -8,7 +8,7 @@
 ///
 /// @description Check that it is not an error if a top level or static variable
 /// with a non-nullable type has no initializer expression but is marked with a
-/// `late` or `external `modifier. Test `FutureOr<A>` where `A` is some class.
+/// `late` modifier. Test `FutureOr<A>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -18,13 +18,10 @@ import "dart:async";
 class A {}
 
 late FutureOr<A> x1;
-external FutureOr<A> x2;
 
 class C {
   static late FutureOr<A> x1;
   static late final FutureOr<A> x2;
-  external static FutureOr<A> x3;
-  external static final FutureOr<A> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t35.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t35.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,19 +7,19 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test type `Never`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+external Never n1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static  Never n1;
+  external static final Never n2;
 }
 
 main() {
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A04_t36.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t36.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,17 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test type `Function`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+external Function x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static Function x1;
+  external static final Function x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t37.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t37.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,19 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test a function type.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+typedef void Foo();
+
+external Foo x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static Foo x1;
+  external static final Foo x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t38.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t38.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,19 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test some class.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+class A {}
+
+external A x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static A x1;
+  external static final A x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t39.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t39.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,19 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test type `FutureOr<Never>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+import "dart:async";
+
+external FutureOr<Never> x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static FutureOr<Never> x1;
+  external static final FutureOr<Never> x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t40.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t40.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,21 +7,24 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test `FutureOr<FutureOr<A>>` where `A` is some class.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external` modifier. Test `FutureOr<F>` where `F` is a function type.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-class A {}
+typedef void Foo();
 
-late FutureOr<FutureOr<A>> x1;
+external FutureOr<Function> f1;
+external FutureOr<Foo> f2;
 
 class C {
-  static late FutureOr<FutureOr<A>> x1;
-  static late final FutureOr<FutureOr<A>> x2;
+  external static FutureOr<Function> x1;
+  external static final FutureOr<Function> x2;
+  external static FutureOr<Foo> x3;
+  external static final FutureOr<Foo> x4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t41.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t41.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,21 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external `modifier. Test `FutureOr<A>` where `A` is some class.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+import "dart:async";
+
+class A {}
+
+external FutureOr<A> x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static FutureOr<A> x1;
+  external static final FutureOr<A> x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A04_t42.dart
+++ b/LanguageFeatures/nnbd/static_errors_A04_t42.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -7,17 +7,21 @@
 /// marked with a `late` or `external` modifier.
 ///
 /// @description Check that it is not an error if a top level or static variable
-/// with a non-nullable type has no initializer expression but is marked with a
-/// `late` modifier. Test type `Function`.
-/// @author sgrekhov@unipro.ru
+/// with a non-nullable type has no initializer expression but is marked with an
+/// `external `modifier. Test `FutureOr<FutureOr<A>>` where `A` is some class.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-late Function x1;
+import "dart:async";
+
+class A {}
+
+external FutureOr<FutureOr<A>> x1;
 
 class C {
-  static late Function x1;
-  static late final Function x2;
+  external static FutureOr<FutureOr<A>> x1;
+  external static final FutureOr<FutureOr<A>> x2;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t21.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t21.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// type `Never`.
+/// the variable is marked with a `late` or `abstract` modifier. Test type
+/// `Never`
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -28,9 +28,6 @@ class C {
   late Never n1;
   late final Never n2;
   covariant late Never n3;
-
-  external Never n4;
-  external final Never n5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t22.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t22.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// type `Function`.
+/// the variable is marked with a `late` or `abstract` modifier. Test type
+/// `Function`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -28,9 +28,6 @@ class C {
   late Function x1;
   late final Function x2;
   covariant late Function x3;
-
-  external Function x4;
-  external final Function x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t23.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t23.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// a function type.
+/// the variable is marked with a `late` or `abstract` modifier. Test a function
+/// type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -30,9 +30,6 @@ class C {
   late Foo x1;
   late final Foo x2;
   covariant late Foo x3;
-
-  external Foo x4;
-  external final Foo x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t24.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t24.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// some class `A`.
+/// the variable is marked with a `late` or `abstract` modifier. Test some class
+/// `A`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -30,9 +30,6 @@ class C {
   late A x1;
   late final A x2;
   covariant late A x3;
-
-  external A x4;
-  external final A x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t26.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t26.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// some type `<X extends Object>`.
+/// the variable is marked with a `late` or `abstract` modifier. Test some type
+/// `<X extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -28,9 +28,6 @@ class C<X extends Object> {
   late X x1;
   late final X x2;
   covariant late X x3;
-
-  external X x4;
-  external final X x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t27.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t27.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// type `<X extends Object?>`.
+/// the variable is marked with a `late` or `abstract` modifier. Test type
+/// `<X extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -28,9 +28,6 @@ class C<X extends Object?> {
   late X x1;
   late final X x2;
   covariant late X x3;
-
-  external X x4;
-  external final X x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t28.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t28.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// type `FutureOr<Never>`.
+/// the variable is marked with a `late` or `abstract` modifier. Test type
+/// `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -30,9 +30,6 @@ class C {
   late FutureOr<Never> x1;
   late final FutureOr<Never> x2;
   covariant late FutureOr<Never> x3;
-
-  external FutureOr<Never> x4;
-  external final FutureOr<Never> x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t29.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t29.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier.
-/// Test `FutureOr<F>` where `F` is a function type
+/// the variable is marked with a `late` or `abstract` modifier. Test
+/// `FutureOr<F>` where `F` is a function type.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -36,12 +36,6 @@ class C {
   late FutureOr<Foo> x4;
   late final FutureOr<Foo> x5;
   covariant late FutureOr<Foo> x6;
-
-  external FutureOr<Function> x7;
-  external final FutureOr<Function> x8;
-
-  external FutureOr<Foo> x9;
-  external final FutureOr<Foo> x10;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t30.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t30.dart
@@ -12,7 +12,7 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
+/// the variable is marked with a `late` or `abstract` modifier. Test
 /// `FutureOr<A>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
@@ -31,9 +31,6 @@ class C {
   late FutureOr<A> x1;
   late final FutureOr<A> x2;
   covariant late FutureOr<A> x3;
-
-  external FutureOr<A> x4;
-  external final FutureOr<A> x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t32.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t32.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier. Test
-/// type `FutureOr<T>`, where `<T extends Object>`.
+/// the variable is marked with a `late` or `abstract` modifier. Test type
+/// `FutureOr<T>`, where `<T extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -30,9 +30,6 @@ class C<T extends Object> {
   late FutureOr<T> x1;
   late final FutureOr<T> x2;
   covariant late FutureOr<T> x3;
-
-  external FutureOr<T> x4;
-  external final FutureOr<T> x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t34.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t34.dart
@@ -12,8 +12,8 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with `late`, `abstract`, or `external` modifier.
-/// Test `FutureOr<FutureOr<A>>` where `A` is some class.
+/// the variable is marked with a `late` or `abstract` modifier. Test
+/// `FutureOr<FutureOr<A>>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 // Requirements=nnbd-strong
@@ -32,9 +32,6 @@ class C {
   late FutureOr<FutureOr<A>> x1;
   late final FutureOr<FutureOr<A>> x2;
   covariant late FutureOr<FutureOr<A>> x3;
-
-  external FutureOr<FutureOr<A>> x4;
-  external final FutureOr<FutureOr<A>> x5;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A05_t35.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t35.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,16 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test type `Never`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
-
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external Never n1;
+  external final Never n2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t36.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t36.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,16 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test type `Function`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
-
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external Function x1;
+  external final Function x2;
 }
 
 main() {
-  print(A);
   new C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t37.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t37.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,18 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test a function type.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
+typedef void Foo();
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external Foo x1;
+  external final Foo x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t38.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t38.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,18 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test some class `A`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
+class A {}
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external A x1;
+  external final A x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t39.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t39.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,17 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test some type
+/// `<X extends Object>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
-
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C<X extends Object> {
+  external X x1;
+  external final X x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C<String>();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t40.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t40.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,17 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test type
+/// `<X extends Object?>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
-import "dart:async";
-
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C<X extends Object?> {
+  external X x1;
+  external final X x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C<String?>();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t41.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t41.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,19 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test type
+/// `FutureOr<Never>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external FutureOr<Never> x4;
+  external final FutureOr<Never> x5;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t42.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t42.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,24 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an`external` modifier. Test `FutureOr<F>` where
+/// `F` is a function type.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
+typedef void Foo();
 
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external FutureOr<Function> x1;
+  external final FutureOr<Function> x2;
+
+  external FutureOr<Foo> x3;
+  external final FutureOr<Foo> x4;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t43.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t43.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,21 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an`external` modifier. Test `FutureOr<A>` where
+/// `A` is some class.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
+class A {}
 
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external FutureOr<A> x1;
+  external final FutureOr<A> x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t44.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t44.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,19 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test type `FutureOr<T>`,
+/// where `<T extends Object>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C<T extends Object> {
+  external FutureOr<T> x1;
+  external final FutureOr<T> x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t45.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t45.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,19 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test `FutureOr<T>`,
+/// where `<T extends Object?>`.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
-
 class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+  external FutureOr<T> x1;
+  external final FutureOr<T> x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A05_t46.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t46.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -12,27 +12,21 @@
 /// an instance variable with a potentially non-nullable type and no initializer
 /// expression, and the class has a generative constructor where the variable is
 /// not initialized via an initializing formal or an initializer list entry, but
-/// the variable is marked with a `late` or `abstract` modifier. Test
-/// `FutureOr<T>`, where `<T extends Object?>`.
-/// @author sgrekhov@unipro.ru
+/// the variable is marked with an `external` modifier. Test
+/// `FutureOr<FutureOr<A>>` where `A` is some class.
+/// @author sgrekhov22@gmail.com
 
 // Requirements=nnbd-strong
 
 import "dart:async";
 
-abstract class A<T extends Object?> {
-  abstract FutureOr<T> x1;
-  abstract final FutureOr<T> x2;
-  abstract covariant FutureOr<T> x3;
-}
+class A {}
 
-class C<T extends Object?> {
-  late FutureOr<T> x1;
-  late final FutureOr<T> x2;
-  covariant late FutureOr<T> x3;
+class C {
+  external FutureOr<FutureOr<A>> x1;
+  external final FutureOr<FutureOr<A>> x2;
 }
 
 main() {
-  print(A);
-  new C();
+  C();
 }

--- a/LanguageFeatures/nnbd/static_errors_A06_t28.dart
+++ b/LanguageFeatures/nnbd/static_errors_A06_t28.dart
@@ -11,7 +11,7 @@
 /// @description Check that it is not an error if a mixin declaration or a class
 /// declaration with no generative constructors declares an instance variable
 /// without an initializing expression which is final but it is marked with
-/// `late`, `abstract` or `external`.
+/// `late` or `abstract`.
 /// @author sgrekhov22@gmail.com
 
 abstract class C<T> {
@@ -21,9 +21,6 @@ abstract class C<T> {
   abstract final v4;
   abstract final Object v5;
   abstract final T v6;
-  external final v7;
-  external final Object v8;
-  external final T v9;
 }
 
 mixin M<T extends Object> {
@@ -33,9 +30,6 @@ mixin M<T extends Object> {
   abstract final v4;
   abstract final Object v5;
   abstract final T v6;
-  external final v7;
-  external final Object v8;
-  external final T v9;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A06_t30.dart
+++ b/LanguageFeatures/nnbd/static_errors_A06_t30.dart
@@ -10,20 +10,22 @@
 ///
 /// @description Check that it is not an error if a mixin declaration or a class
 /// declaration with no generative constructors declares an instance variable
-/// without an initializing expression which is final but it is marked with
-/// `external`.
+/// without an initializing expression whose type is potentially non-nullable
+/// but it is marked with `late` or `abstract`.
 /// @author sgrekhov22@gmail.com
 
-class C<T> {
-  external final v1;
-  external final Object v2;
-  external final T v3;
+abstract class C<T extends Object?> {
+  late Object v1;
+  late T v2;
+  abstract Object v3;
+  abstract T v4;
 }
 
-mixin M<T extends Object> {
-  external final v1;
-  external final Object v2;
-  external final T v3;
+mixin M<T extends Object?> {
+  late Object v1;
+  late T v2;
+  abstract Object v3;
+  abstract T v4;
 }
 
 main() {

--- a/LanguageFeatures/nnbd/static_errors_A06_t31.dart
+++ b/LanguageFeatures/nnbd/static_errors_A06_t31.dart
@@ -10,20 +10,18 @@
 ///
 /// @description Check that it is not an error if a mixin declaration or a class
 /// declaration with no generative constructors declares an instance variable
-/// without an initializing expression which is final but it is marked with
-/// `external`.
+/// without an initializing expression whose type is potentially non-nullable
+/// but it is marked with `external`.
 /// @author sgrekhov22@gmail.com
 
-class C<T> {
-  external final v1;
-  external final Object v2;
-  external final T v3;
+abstract class C<T extends Object?> {
+  external Object v1;
+  external T v2;
 }
 
-mixin M<T extends Object> {
-  external final v1;
-  external final Object v2;
-  external final T v3;
+mixin M<T extends Object?> {
+  external Object v1;
+  external T v2;
 }
 
 main() {


### PR DESCRIPTION
Non-JS `external` members are not supported on web. So `external` moved to separate files which will be turned-off in `.status` files