### PR TITLE
Fixes #3030. Add additional test checking non const in a const constructor initializer list

### DIFF
--- a/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t01.dart
+++ b/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t01.dart
@@ -11,10 +11,10 @@
 /// constant constructor were treated as compile-time constants that were
 /// guaranteed to evaluate to an integer, boolean or string value as required
 /// by their immediately enclosing superexpression.
+///
 /// @description Checks that it is a compile-time error when a constant
 /// constructor's initializer list contains non-constant list literal.
 /// @author iefremov
-
 
 class A {
   final x;
@@ -25,7 +25,5 @@ class A {
 }
 
 main() {
-  const A(1);
-//      ^
-// [analyzer] unspecified
+  print(A);
 }

--- a/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t02.dart
+++ b/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t02.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Any expression that appears within the initializer list of a
+/// constant constructor must be a potentially constant expression, or a
+/// compile-time error occurs.
+///
+/// A potentially constant expression is an expression E that would be a valid
+/// constant expression if all formal parameters of E's immediately enclosing
+/// constant constructor were treated as compile-time constants that were
+/// guaranteed to evaluate to an integer, boolean or string value as required
+/// by their immediately enclosing superexpression.
+///
+/// @description Checks that it is a compile-time error when a constant
+/// constructor's initializer list contains a function call.
+/// @author iefremov
+
+f1() {}
+int f2() => 2;
+int get f3 => 3;
+
+class A {
+  final x;
+  const A() : x = f1();
+//                ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  const A.foo() : x = f2();
+//                    ^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  const A.bar() : x = f3;
+//                    ^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(A);
+}

--- a/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t03.dart
+++ b/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t03.dart
@@ -11,23 +11,24 @@
 /// constant constructor were treated as compile-time constants that were
 /// guaranteed to evaluate to an integer, boolean or string value as required
 /// by their immediately enclosing superexpression.
+///
 /// @description Checks that it is a compile-time error when a constant
-/// constructor's initializer list contains a function call.
+/// constructor's initializer list contains an non-constant instance creation
+/// expression.
 /// @author iefremov
 
-
-f() {}
-
 class A {
+  const A();
+}
+
+class C {
   final x;
-  const A() : x = f();
-//                ^^^
+  const C() : x = new A();
+//                ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  const A();
-//      ^
-// [analyzer] unspecified
+  print(C);
 }

--- a/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t04.dart
+++ b/Language/Classes/Constructors/Constant_Constructors/not_a_constant_in_initializer_list_t04.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -11,21 +11,34 @@
 /// constant constructor were treated as compile-time constants that were
 /// guaranteed to evaluate to an integer, boolean or string value as required
 /// by their immediately enclosing superexpression.
+///
 /// @description Checks that it is a compile-time error when a constant
-/// constructor's initializer list contains an instance creation expression.
-/// @author iefremov
-
+/// constructor's initializer list contains a use of a non-constant.
+/// @author sgrekhov22@gmail.com
+/// @issue 59804
 
 class A {
-  final x;
-  const A() : x = new List.from([]);
-//                ^^^
+  final int id;
+  const A(this.id);
+  static A answer = const A(42);
+}
+
+final A zero = const A(0);
+
+class C {
+  final A a;
+  const C(this.a);
+  const C.fromAnswer() : a = A.answer;
+//                           ^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+
+  const C.fromGlobal() : a = zero;
+//                           ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  const A();
-//      ^
-// [analyzer] unspecified
+  print(C);
 }


### PR DESCRIPTION
Github shows a wrong diff as if `..._02` was renamed to `...t03` and `...t03` to `...t02`. Hope that it won't be a problem for the review.
