### PR TITLE
#3057. Add tests for method invocation

### DIFF
--- a/TypeSystem/flow-analysis/reachability_A22_t01.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t01.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Method invocation: If `N` is an expression of the form
+/// `E1.m1(E2)`, then:
+/// - Let `before(E1) = before(N)`
+/// - Let `before(E2) = after(E1)`
+/// - Let `T` be the static return type of the invocation
+/// - If `T <: Never` then:
+///   - Let `after(N) = unreachable(after(E2))`.
+/// - Otherwise:
+///   - Let `after(N) = after(E2)`.
+///
+/// @description Checks that for an expression of the form `E1.m1(E2)`
+/// `before(E2) = after(E1)`.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n.foo(i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A22_t01.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t01.dart
@@ -13,7 +13,8 @@
 ///   - Let `after(N) = after(E2)`.
 ///
 /// @description Checks that for an expression of the form `E1.m1(E2)`
-/// `before(E2) = after(E1)`.
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
 void test<T extends Never>(T n) {

--- a/TypeSystem/flow-analysis/reachability_A22_t01.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t01.dart
@@ -27,7 +27,6 @@ void test<T extends Never>(T n) {
 // [cfe] unspecified
 }
 
-
 main() {
   print(test);
 }

--- a/TypeSystem/flow-analysis/reachability_A22_t02.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t02.dart
@@ -13,7 +13,8 @@
 ///   - Let `after(N) = after(E2)`.
 ///
 /// @description Checks that for an expression of the form `E1.m1(E2)`
-/// `before(E2) = after(E1)`.
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
 class C {

--- a/TypeSystem/flow-analysis/reachability_A22_t02.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t02.dart
@@ -17,7 +17,7 @@
 /// @author sgrekhov22@gmail.com
 
 class C {
-  const C(int i);
+  C(int i);
   void foo(int j) {}
 }
 
@@ -31,7 +31,6 @@ void test<T extends Never>(T n) {
 // [analyzer] unspecified
 // [cfe] unspecified
 }
-
 
 main() {
   print(test);

--- a/TypeSystem/flow-analysis/reachability_A22_t02.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t02.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Method invocation: If `N` is an expression of the form
+/// `E1.m1(E2)`, then:
+/// - Let `before(E1) = before(N)`
+/// - Let `before(E2) = after(E1)`
+/// - Let `T` be the static return type of the invocation
+/// - If `T <: Never` then:
+///   - Let `after(N) = unreachable(after(E2))`.
+/// - Otherwise:
+///   - Let `after(N) = after(E2)`.
+///
+/// @description Checks that for an expression of the form `E1.m1(E2)`
+/// `before(E2) = after(E1)`.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  const C(int i);
+  void foo(int j) {}
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n).foo(i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A22_t03.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t03.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Method invocation: If `N` is an expression of the form
+/// `E1.m1(E2)`, then:
+/// - Let `before(E1) = before(N)`
+/// - Let `before(E2) = after(E1)`
+/// - Let `T` be the static return type of the invocation
+/// - If `T <: Never` then:
+///   - Let `after(N) = unreachable(after(E2))`.
+/// - Otherwise:
+///   - Let `after(N) = after(E2)`.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1.m1(E2)` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T foo() => throw "";
+}
+
+void test() {
+  late int i;
+  if (2 > 1) {
+    C().foo();
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A22_t03.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t03.dart
@@ -18,9 +18,12 @@
 
 class C<T extends Never> {
   T foo() => throw "";
+  Future<T> bar() async {
+    throw "";
+  }
 }
 
-void test() {
+void test1() {
   late int i;
   if (2 > 1) {
     C().foo();
@@ -32,6 +35,29 @@ void test() {
 // [cfe] unspecified
 }
 
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C().bar(); // Return type is not `Never`
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await C().bar();
+    i = 42;
+  }
+  i; // Not definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
 main() {
-  print(test);
+  print(test1);
+  print(test2);
+  print(test3);
 }

--- a/TypeSystem/flow-analysis/reachability_A22_t04.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t04.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Method invocation: If `N` is an expression of the form
+/// `E1.m1(E2)`, then:
+/// - Let `before(E1) = before(N)`
+/// - Let `before(E2) = after(E1)`
+/// - Let `T` be the static return type of the invocation
+/// - If `T <: Never` then:
+///   - Let `after(N) = unreachable(after(E2))`.
+/// - Otherwise:
+///   - Let `after(N) = after(E2)`.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1.m1(E2)` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T foo(int x) => throw "foo";
+  T bar([int x = 0]) => throw "bar";
+  T baz({int x = 0}) => throw "baz";
+  T qux({required int x}) => throw "qux";
+}
+
+void test1() {
+  late int i;
+  try {
+    C().foo(i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}
+
+void test2() {
+  late int i;
+  try {
+    C().bar(i = 42);
+  } catch (_) {}
+  i;
+}
+
+void test3() {
+  late int i;
+  try {
+    C().baz(x: i = 42);
+  } catch (_) {}
+  i;
+}
+
+void test4() {
+  late int i;
+  try {
+    C().qux(x: i = 42);
+  } catch (_) {}
+  i;
+}
+
+main() {
+  test1();
+  test2();
+  test3();
+  test4();
+}

--- a/TypeSystem/flow-analysis/reachability_A22_t05.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t05.dart
@@ -12,10 +12,10 @@
 /// - Otherwise:
 ///   - Let `after(N) = after(E2)`.
 ///
-/// @description Checks that if the static type of the expression of the form
-/// `E1.m1(E2)` static type of `E1`is not `Never` then `after(N) = after(E2)`,
-/// which is tested by detecting that `i = 42` is considered to be guaranteed
-/// to have been executed when `i;` is executed.
+/// @description Checks that for an expression of the form `E1.m1(E2)`, if the
+/// static type of `E1` is not `Never` then `after(N) = after(E2)`. This is
+/// tested by detecting that `i = 42` is considered to be guaranteed to have
+/// been executed when `i;` is executed.
 /// @author sgrekhov22@gmail.com
 
 class C {

--- a/TypeSystem/flow-analysis/reachability_A22_t05.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t05.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Method invocation: If `N` is an expression of the form
+/// `E1.m1(E2)`, then:
+/// - Let `before(E1) = before(N)`
+/// - Let `before(E2) = after(E1)`
+/// - Let `T` be the static return type of the invocation
+/// - If `T <: Never` then:
+///   - Let `after(N) = unreachable(after(E2))`.
+/// - Otherwise:
+///   - Let `after(N) = after(E2)`.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1.m1(E2)` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  void foo(int x) {}
+  void bar([int x = 0]) {}
+  void baz({int x = 0}) {}
+  void qux({required int x}) {}
+}
+
+void test1() {
+  int i;
+  C().foo(i = 42);
+  i; // Definitely assigned
+}
+
+void test2() {
+  int i;
+  C().bar(i = 42);
+  i; // Definitely assigned
+}
+
+void test3() {
+  int i;
+  C().baz(x: i = 42);
+  i; // Definitely assigned
+}
+
+void test4() {
+  int i;
+  C().qux(x: i = 42);
+  i; // Definitely assigned
+}
+
+main() {
+  test1();
+  test2();
+  test3();
+  test4();
+}

--- a/TypeSystem/flow-analysis/reachability_A22_t06.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t06.dart
@@ -12,11 +12,11 @@
 /// - Otherwise:
 ///   - Let `after(N) = after(E2)`.
 ///
-/// @description Checks that if the static type of the expression of the form
-/// `E1.m1(E2)` static type of `E1`is not `Never` then `after(N) = after(E2)`,
-/// which is tested by detecting that `i = 42` is considered to be guaranteed
-/// to have been executed when `i;` is executed. Test the case when `m1` is a
-/// getter returning a function type.
+/// @description Checks that for an expression of the form `E1.m1(E2)`, if the
+/// static type of `E1` is not `Never` then `after(N) = after(E2)`. This is
+/// tested by detecting that `i = 42` is considered to be guaranteed to have
+/// been executed when `i;` is executed. Test the case when `m1` is a getter
+/// returning a function type.
 /// @author sgrekhov22@gmail.com
 
 class C {

--- a/TypeSystem/flow-analysis/reachability_A22_t06.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t06.dart
@@ -15,14 +15,15 @@
 /// @description Checks that if the static type of the expression of the form
 /// `E1.m1(E2)` static type of `E1`is not `Never` then `after(N) = after(E2)`,
 /// which is tested by detecting that `i = 42` is considered to be guaranteed
-/// to have been executed when `i;` is executed.
+/// to have been executed when `i;` is executed. Test the case when `m1` is a
+/// getter returning a function type.
 /// @author sgrekhov22@gmail.com
 
 class C {
-  void foo(int x) {}
-  void bar([int x = 0]) {}
-  void baz({int x = 0}) {}
-  void qux({required int x}) {}
+  void Function(int) get foo => (int x) {};
+  void Function([int]) get bar => ([int x = 0]) {};
+  void Function({int x}) get baz => ({int x = 0}) {};
+  void Function({required int x}) get qux => ({required int x}) {};
 }
 
 void test1() {

--- a/TypeSystem/flow-analysis/reachability_A22_t07.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t07.dart
@@ -14,7 +14,7 @@
 ///
 /// @description Checks that for an expression of the form `E1.m1(E2)`
 /// `before(E2) = after(E1)`. Test that if `m1` is a getter returning type
-/// `Never` then `before(E2)` is also unreachable.
+/// `Never` then `before(E2)` is unreachable.
 /// @author sgrekhov22@gmail.com
 
 class C<T extends Never> {

--- a/TypeSystem/flow-analysis/reachability_A22_t07.dart
+++ b/TypeSystem/flow-analysis/reachability_A22_t07.dart
@@ -12,22 +12,20 @@
 /// - Otherwise:
 ///   - Let `after(N) = after(E2)`.
 ///
-/// @description Checks that if the static type of the expression of the form
-/// `E1.m1(E2)` is `Never` `after(N) = unreachable(after(E2))`.
+/// @description Checks that for an expression of the form `E1.m1(E2)`
+/// `before(E2) = after(E1)`. Test that if `m1` is a getter returning type
+/// `Never` then `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
 class C<T extends Never> {
-  T foo() => throw "";
-  Future<T> bar() async {
-    throw "";
-  }
+  Never get foo => throw "Never";
+  T get bar => throw "Never";
 }
 
 void test1() {
   late int i;
   if (2 > 1) {
-    C().foo();
-    i = 42;
+    C().foo(i = 42); // ignore: receiver_of_type_never
   }
   i; // Definitely unassigned
 //^
@@ -38,17 +36,7 @@ void test1() {
 void test2() {
   late int i;
   if (2 > 1) {
-    C().bar(); // Return type is not `Never`
-    i = 42;
-  }
-  i; // Not definitely unassigned
-}
-
-void test3() async {
-  late int i;
-  if (2 > 1) {
-    await C().bar();
-    i = 42;
+    C().bar(i = 42);  // ignore: receiver_of_type_never
   }
   i; // Definitely unassigned
 //^
@@ -59,5 +47,4 @@ void test3() async {
 main() {
   print(test1);
   print(test2);
-  print(test3);
 }


### PR DESCRIPTION
Please review. In the [spec](https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md#expressions) we also have:

> Binary operator: All binary operators other than `==`, `&&`, `||`, and `??` are handled as calls to the appropriate operator method.

So, if these tests are Ok, then I'm going to add the similar tests for `E1 + E2` and all other operators with two operands.