### PR TITLE
Fixes #3086. Update context type for expected value

### DIFF
--- a/LanguageFeatures/Static-access-shorthand/non_ambiguity_A01_t02.dart
+++ b/LanguageFeatures/Static-access-shorthand/non_ambiguity_A01_t02.dart
@@ -28,7 +28,7 @@ extension on bool {
 
 main() {
   bool e1 = 2 > 1; // true
-  var e2 = "value";
+  var e2 = C(2);
   Object o = <C>{C(1)};
   if (o is Set<C>) {
     o = {e1? .id: e2};


### PR DESCRIPTION
I believe that with this change the context type of `e1? .id: e2` expression should be `C`.