### PR TITLE
#3057. Add reachability tests for operators. Part 1.

### DIFF
--- a/TypeSystem/flow-analysis/reachability_A20_t06.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t06.dart
@@ -5,7 +5,7 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 - E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
@@ -13,7 +13,7 @@
 void test<T extends Never>(T n) {
   late int i;
   if (2 > 1) {
-    n + (i = 42);
+    n - (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t07.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t07.dart
@@ -5,15 +5,21 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 - E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
+class C {
+  int i;
+  C(this.i);
+  int operator -(int other) => i - other;
+}
+
 void test<T extends Never>(T n) {
   late int i;
   if (2 > 1) {
-    n + (i = 42);
+    C(n) - (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t08.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t08.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 - E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator -(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator -(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() - 0;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() - 0;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() - 0);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t09.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t09.dart
@@ -5,22 +5,18 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 - E2` is `Never` then `E2` is still reachable.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C<T extends Never> {
+  T operator -(int x) => throw "C";
 }
 
 main() {
-  print(test);
+  late int i;
+  try {
+    C() - (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t10.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t10.dart
@@ -5,22 +5,20 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 - E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C {
+  int n;
+  C(this.n);
+  int operator -(int other) => n - other;
 }
 
 main() {
-  print(test);
+  int i;
+  C(1) - (i = 42);
+  i; // Definitely assigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t11.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t11.dart
@@ -5,7 +5,7 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 * E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
@@ -13,7 +13,7 @@
 void test<T extends Never>(T n) {
   late int i;
   if (2 > 1) {
-    n + (i = 42);
+    n * (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t12.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t12.dart
@@ -5,15 +5,21 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 * E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
+class C {
+  int i;
+  C(this.i);
+  int operator *(int other) => i * other;
+}
+
 void test<T extends Never>(T n) {
   late int i;
   if (2 > 1) {
-    n + (i = 42);
+    C(n) * (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t13.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t13.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 * E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator *(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator *(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() * 1;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() * 0;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() * 0);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t14.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t14.dart
@@ -5,22 +5,18 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 * E2` is `Never` then `E2` is still reachable.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C<T extends Never> {
+  T operator *(int x) => throw "C";
 }
 
 main() {
-  print(test);
+  late int i;
+  try {
+    C() * (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t15.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t15.dart
@@ -5,22 +5,20 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 * E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C {
+  int n;
+  C(this.n);
+  int operator *(int other) => n * other;
 }
 
 main() {
-  print(test);
+  int i;
+  C(1) * (i = 42);
+  i; // Definitely assigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t16.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t16.dart
@@ -5,15 +5,15 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 / E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
 void test<T extends Never>(T n) {
-  late int i;
+  late num i;
   if (2 > 1) {
-    n + (i = 42);
+    n / (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t17.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t17.dart
@@ -5,15 +5,21 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 / E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
+class C {
+  num i;
+  C(this.i);
+  num operator /(num other) => i / other;
+}
+
 void test<T extends Never>(T n) {
-  late int i;
+  late num i;
   if (2 > 1) {
-    n + (i = 42);
+    C(n) / (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t18.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t18.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 / E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator /(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator /(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() / 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() / 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() / 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t19.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t19.dart
@@ -5,22 +5,18 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 / E2` is `Never` then `E2` is still reachable.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C<T extends Never> {
+  T operator /(num x) => throw "C";
 }
 
 main() {
-  print(test);
+  late num i;
+  try {
+    C() / (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t20.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t20.dart
@@ -5,22 +5,20 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 / E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C {
+  num n;
+  C(this.n);
+  num operator /(int other) => n / other;
 }
 
 main() {
-  print(test);
+  int i;
+  C(1) / (i = 42);
+  i; // Definitely assigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t21.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t21.dart
@@ -5,15 +5,15 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 ~/ E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
 void test<T extends Never>(T n) {
-  late int i;
+  late num i;
   if (2 > 1) {
-    n + (i = 42);
+    n ~/ (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t22.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t22.dart
@@ -5,15 +5,21 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
+/// @description Checks that for an expression of the form `E1 ~/ E2`
 /// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
 /// `before(E2)` is also unreachable.
 /// @author sgrekhov22@gmail.com
 
+class C {
+  num i;
+  C(this.i);
+  num operator ~/(num other) => i ~/ other;
+}
+
 void test<T extends Never>(T n) {
-  late int i;
+  late num i;
   if (2 > 1) {
-    n + (i = 42);
+    C(n) ~/ (i = 42);
   }
   i; // Definitely unassigned
 //^

--- a/TypeSystem/flow-analysis/reachability_A20_t23.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t23.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ~/ E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator ~/(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator ~/(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() ~/ 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() ~/ 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() ~/ 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t24.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t24.dart
@@ -5,22 +5,18 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ~/ E2` is `Never` then `E2` is still reachable.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C<T extends Never> {
+  T operator ~/(num x) => throw "C";
 }
 
 main() {
-  print(test);
+  late num i;
+  try {
+    C() ~/ (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
 }

--- a/TypeSystem/flow-analysis/reachability_A20_t25.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t25.dart
@@ -5,22 +5,20 @@
 /// @assertion - Binary operator: All binary operators other than `==`, `&&`,
 /// `||`, and `??` are handled as calls to the appropriate `operator` method.
 ///
-/// @description Checks that for an expression of the form `E1 + E2`
-/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
-/// `before(E2)` is also unreachable.
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ~/ E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
 /// @author sgrekhov22@gmail.com
 
-void test<T extends Never>(T n) {
-  late int i;
-  if (2 > 1) {
-    n + (i = 42);
-  }
-  i; // Definitely unassigned
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+class C {
+  num n;
+  C(this.n);
+  num operator ~/(int other) => n ~/ other;
 }
 
 main() {
-  print(test);
+  int i;
+  C(1) ~/ (i = 42);
+  i; // Definitely assigned
 }


### PR DESCRIPTION
The same tests as for the `+` operator (#3097), but for other operators.