### PR TITLE
#3057. Add reachability tests for operators. Part 2.

### DIFF
--- a/TypeSystem/flow-analysis/reachability_A20_t26.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t26.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 % E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n % (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t27.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t27.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 % E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator %(int other) => i % other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) % (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t28.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t28.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 % E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator %(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator %(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() % 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() % 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() % 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t29.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t29.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 % E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator %(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() % (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t30.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t30.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 * E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int n;
+  C(this.n);
+  int operator %(int other) => n % other;
+}
+
+main() {
+  int i;
+  C(1) % (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t31.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t31.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 << E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n << (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t32.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t32.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 << E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator <<(int other) => i << other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) << (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t33.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t33.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 << E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator <<(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator <<(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() << 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() << 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() << 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t34.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t34.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 << E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator <<(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() << (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t35.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t35.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 << E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator <<(int other) => i << other;
+}
+
+main() {
+  int i;
+  C(1) << (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t36.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t36.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 >> E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n >> (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t37.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t37.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 >> E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator >>(int other) => i >> other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) >> (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t38.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t38.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >> E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator >>(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator >>(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() >> 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() >> 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() >> 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t39.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t39.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >> E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator >>(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() >> (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t40.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t40.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >> E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator >>(int other) => i >> other;
+}
+
+main() {
+  int i;
+  C(1) >> (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t41.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t41.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 >>> E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n >>> (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t42.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t42.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 >>> E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator >>>(int other) => i >>> other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) >>> (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t43.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t43.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >>> E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator >>>(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator >>>(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() >>> 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() >>> 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() >>> 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t44.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t44.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >>> E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator >>>(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() >>> (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t45.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t45.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 >>> E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator >>>(int other) => i >>> other;
+}
+
+main() {
+  int i;
+  C(1) >>> (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t46.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t46.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 & E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n & (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t47.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t47.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 & E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator &(int other) => i & other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) & (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t48.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t48.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 & E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator &(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator &(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() & 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() & 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() & 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t49.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t49.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 & E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator &(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() & (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t50.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t50.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 & E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator &(int other) => i & other;
+}
+
+main() {
+  int i;
+  C(1) & (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t51.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t51.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 ^ E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n ^ (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t52.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t52.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 ^ E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator ^(int other) => i ^ other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) ^ (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t53.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t53.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ^ E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator ^(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator ^(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() ^ 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() ^ 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() ^ 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t54.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t54.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ^ E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator ^(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() ^ (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t55.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t55.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 ^ E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator ^(int other) => i ^ other;
+}
+
+main() {
+  int i;
+  C(1) ^ (i = 42);
+  i; // Definitely assigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t56.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t56.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 | E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    n | (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t57.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t57.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that for an expression of the form `E1 | E2`
+/// `before(E2) = after(E1)`. Test that if `after(E1)` is unreachable then
+/// `before(E2)` is also unreachable.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator |(int other) => i | other;
+}
+
+void test<T extends Never>(T n) {
+  late int i;
+  if (2 > 1) {
+    C(n) | (i = 42);
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t58.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t58.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 | E2` is `Never` `after(N) = unreachable(after(E2))`.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator |(int other) => throw "";
+}
+
+class C2<T extends Never> {
+  Future<T> operator |(int other) async => throw "";
+}
+
+void test1() {
+  late int i;
+  if (2 > 1) {
+    C() | 2;
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+void test2() {
+  late int i;
+  if (2 > 1) {
+    C2() | 2;
+    i = 42;
+  }
+  i; // Not definitely unassigned
+}
+
+void test3() async {
+  late int i;
+  if (2 > 1) {
+    await (C2() | 2);
+    i = 42;
+  }
+  i; // Definitely unassigned
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+
+main() {
+  print(test1);
+  print(test2);
+  print(test3);
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t59.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t59.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 | E2` is `Never` then `E2` is still reachable.
+/// @author sgrekhov22@gmail.com
+
+class C<T extends Never> {
+  T operator |(int x) => throw "C";
+}
+
+main() {
+  late int i;
+  try {
+    C() | (i = 42);
+  } catch (_) {}
+  i; // Not definitely unassigned
+}

--- a/TypeSystem/flow-analysis/reachability_A20_t60.dart
+++ b/TypeSystem/flow-analysis/reachability_A20_t60.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion - Binary operator: All binary operators other than `==`, `&&`,
+/// `||`, and `??` are handled as calls to the appropriate `operator` method.
+///
+/// @description Checks that if the static type of the expression of the form
+/// `E1 | E2` static type of `E1`is not `Never` then `after(N) = after(E2)`.
+/// This is tested by detecting that `i = 42` is considered to be guaranteed to
+/// have been executed when `i;` is executed.
+/// @author sgrekhov22@gmail.com
+
+class C {
+  int i;
+  C(this.i);
+  int operator |(int other) => i | other;
+}
+
+main() {
+  int i;
+  C(1) | (i = 42);
+  i; // Definitely assigned
+}


### PR DESCRIPTION
Like the previous ones but for other operators. BTW they use type parameter of the type `<T extends Never>`.