### PR TITLE
#3122. Expect an error in case of non-constant in a constant expression

### DIFF
--- a/LanguageFeatures/Static-access-shorthand/constant_expression_A10_t17.dart
+++ b/LanguageFeatures/Static-access-shorthand/constant_expression_A10_t17.dart
@@ -45,9 +45,15 @@ main() {
 //                    ^
 // [analyzer] unspecified
 // [cfe] unspecified
-  const M m = 2 < 1 ? .one : .two; //`false ? variable : const` is a constant
+  const M m = 2 < 1 ? .one : .two;
+//                    ^
+// [analyzer] unspecified
+// [cfe] unspecified
 
-  const E e = 2 > 1 ? .one : .two; // `true ? const : variable` is a constant
+  const E e = 2 > 1 ? .one : .two;
+//                           ^
+// [analyzer] unspecified
+// [cfe] unspecified
 
   const ET et = 2 < 1 ? .one : .two;
 //                             ^


### PR DESCRIPTION
The previous change in this test was wrong.  `static M one = const MC(1);` is not a potentially constant and therefore cannot be used in a constant expression.