### PR TITLE
Fixes #3186. Fix expected result in promotion_via_assignment_A03_t07.dart

### DIFF
--- a/TypeSystem/flow-analysis/promotion_via_assignment_A03_t07.dart
+++ b/TypeSystem/flow-analysis/promotion_via_assignment_A03_t07.dart
@@ -22,7 +22,7 @@ test1() {
   s as String;
   if (s is Null) {} // ignore: unnecessary_type_check
   s = null;
-  s.expectStaticType<Exactly<Null>>();
+  s.expectStaticType<Exactly<Object?>>();
 }
 
 test2() {


### PR DESCRIPTION
This PR fixes the new roll failures. There are two failures there. 
`promotion_via_assignment_A03_t07.dart` failure is fixed by this PR. There should be no promotion to `Null`.

There are also failures in `promotion_via_assignment_A03_t03.dart`. I believe that the test is ok anf failures means an issue. There should be no promotion between top types because they are not a proper subtypes of each other.
```dart
test2() {
  Object? v = 1 > 2 ? null : Object();
  if (v is Void) {} // ignore: unnecessary_type_check
  v = 1 > 2 ? null : Object(); // can't assign `void`, let's assign subtype of `void`
  // `Object?` <: `void` and `void` <: `Object?`.
  // Therefore `v` is not promoted to `void`.
  v.hashCode; // COMPILE_TIME_ERROR.USE_OF_VOID_RESULT
}

test3() {
  dynamic d = 42;
  if (d is Object?) {} // ignore: unnecessary_type_check
  d = 1 > 2 ? null: Object();
  d.testDynamic; // `d` should be `dynamic` // COMPILE_TIME_ERROR.UNCHECKED_USE_OF_NULLABLE_VALUE
}

test4() {
  dynamic d = 42;
  if (d is Void) {} // ignore: unnecessary_type_check
  d = Object();     // can't assign `void`, let's assign subtype of `void`
  // `void` <: `dynamic` and `dynamic` <: `void`.
  // Therefore `d` is not promoted to `void`.
  d.testDynamic; // COMPILE_TIME_ERROR.USE_OF_VOID_RESULT
}
```

Please confirm that the errors above should not be reported.