### PR TITLE
#3182. Update type_inheritance_A02/3_t*.dart

### DIFF
--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01.dart
@@ -10,8 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01.dart
@@ -2,23 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration.
+/// specifies a different return type than the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'type_inheritance_A02_t01_lib.dart';
 

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
@@ -66,7 +66,7 @@ augment mixin M {
 }
 
 augment enum E {
-  augment e0;
+  e1;
   augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
@@ -10,8 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t01_lib.dart
@@ -2,68 +2,64 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration.
+/// specifies a different return type than the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A02_t01.dart';
 
-augment int get topLevelGetter => 0;
+augment int get topLevelGetter;
 //      ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-augment Object topLevelFunction() => 0;
+augment Object topLevelFunction();
 //      ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
 augment class C {
-  augment static Object get staticGetter => 0;
+  augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static int staticMethod() => 0;
+  augment static int staticMethod();
 //               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get instanceGetter => 0;
+  augment int get instanceGetter;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object instanceMethod() => 0;
+  augment Object instanceMethod();
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment mixin M {
-  augment static Object get staticGetter => 0;
+  augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static int staticMethod() => 0;
+  augment static int staticMethod();
 //               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get instanceGetter => 0;
+  augment int get instanceGetter;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object instanceMethod() => 0;
+  augment Object instanceMethod();
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -71,65 +67,65 @@ augment mixin M {
 
 augment enum E {
   augment e0;
-  augment static Object get staticGetter => 0;
+  augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static int staticMethod() => 0;
+  augment static int staticMethod();
 //               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get instanceGetter => 0;
+  augment int get instanceGetter;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object instanceMethod() => 0;
+  augment Object instanceMethod();
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension Ext {
-  augment static Object get staticGetter => 0;
+  augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static int staticMethod() => 0;
+  augment static int staticMethod();
 //               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get instanceGetter => 0;
+  augment int get instanceGetter;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object instanceMethod() => 0;
+  augment Object instanceMethod();
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension type ET {
-  augment static Object get staticGetter => 0;
+  augment static Object get staticGetter;
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static int staticMethod() => 0;
+  augment static int staticMethod();
 //               ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get instanceGetter => 0;
+  augment int get instanceGetter;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object instanceMethod() => 0;
+  augment Object instanceMethod();
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment int get id => 0;
+  augment int get id;
 //        ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object get id => 0;
+  augment Object get id;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02.dart
@@ -2,49 +2,45 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the augmented declaration.
+/// the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 import '../../Utils/expect.dart';
 part 'type_inheritance_A02_t02_lib.dart';
 
-get topLevelGetter => 0;
+get topLevelGetter;
 topLevelFunction() => 0;
 
 class C {
   static get staticGetter => 0;
-  static staticMethod() => 0;
-  get instanceGetter => 0;
+  static staticMethod();
+  get instanceGetter;
   instanceMethod() => 0;
 }
 
 mixin M {
   static get staticGetter => 0;
-  static staticMethod() => 0;
-  get instanceGetter => 0;
+  static staticMethod();
+  get instanceGetter;
   instanceMethod() => 0;
 }
 
 enum E {
   e0;
   static get staticGetter => 0;
-  static staticMethod() => 0;
-  get instanceGetter => 0;
+  static staticMethod();
+  get instanceGetter;
   instanceMethod() => 0;
 }
 
@@ -52,15 +48,15 @@ class A {}
 
 extension Ext on A {
   static get staticGetter => 0;
-  static staticMethod() => 0;
-  get instanceGetter => 0;
+  static staticMethod();
+  get instanceGetter;
   instanceMethod() => 0;
 }
 
 extension type ET(int id) {
   static get staticGetter => 0;
-  static staticMethod() => 0;
-  get instanceGetter => 0;
+  static staticMethod();
+  get instanceGetter;
   instanceMethod() => 0;
 }
 
@@ -68,25 +64,25 @@ class MA = Object with M;
 
 main() {
   Expect.equals(1, topLevelGetter);
-  Expect.equals(2, topLevelFunction());
-  Expect.equals(3, C.staticGetter);
-  Expect.equals(4, C.staticMethod());
-  Expect.equals(5, C().instanceGetter);
-  Expect.equals(6, C().instanceMethod());
-  Expect.equals(7, M.staticGetter);
-  Expect.equals(8, M.staticMethod());
-  Expect.equals(9, MA().instanceGetter);
-  Expect.equals(10, MA().instanceMethod());
-  Expect.equals(11, E.staticGetter);
-  Expect.equals(12, E.staticMethod());
-  Expect.equals(13, E.e0.instanceGetter);
-  Expect.equals(14, E.e0.instanceMethod());
-  Expect.equals(15, Ext.staticGetter);
-  Expect.equals(16, Ext.staticMethod());
-  Expect.equals(17, A().instanceGetter);
-  Expect.equals(18, A().instanceMethod());
-  Expect.equals(19, ET.staticGetter);
-  Expect.equals(20, ET.staticMethod());
-  Expect.equals(21, ET(0).instanceGetter);
-  Expect.equals(22, ET(0).instanceMethod());
+  Expect.equals(0, topLevelFunction());
+  Expect.equals(0, C.staticGetter);
+  Expect.equals(1, C.staticMethod());
+  Expect.equals(1, C().instanceGetter);
+  Expect.equals(0, C().instanceMethod());
+  Expect.equals(0, M.staticGetter);
+  Expect.equals(1, M.staticMethod());
+  Expect.equals(1, MA().instanceGetter);
+  Expect.equals(0, MA().instanceMethod());
+  Expect.equals(0, E.staticGetter);
+  Expect.equals(1, E.staticMethod());
+  Expect.equals(1, E.e0.instanceGetter);
+  Expect.equals(0, E.e0.instanceMethod());
+  Expect.equals(0, Ext.staticGetter);
+  Expect.equals(1, Ext.staticMethod());
+  Expect.equals(1, A().instanceGetter);
+  Expect.equals(0, A().instanceMethod());
+  Expect.equals(0, ET.staticGetter);
+  Expect.equals(1, ET.staticMethod());
+  Expect.equals(1, ET(0).instanceGetter);
+  Expect.equals(0, ET(0).instanceMethod());
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02.dart
@@ -10,8 +10,8 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the introductory declaration.
+/// @description Check that it is no error if an augmenting declaration
+/// specifies the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts
@@ -53,7 +53,7 @@ extension Ext on A {
   instanceMethod() => 0;
 }
 
-extension type ET(int id) {
+extension type ET(dynamic id) {
   static get staticGetter => 0;
   static staticMethod();
   get instanceGetter;
@@ -85,4 +85,5 @@ main() {
   Expect.equals(1, ET.staticMethod());
   Expect.equals(1, ET(0).instanceGetter);
   Expect.equals(0, ET(0).instanceMethod());
+  Expect.equals("42", ET("42").id);
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
@@ -2,61 +2,57 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the augmented declaration.
+/// the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A02_t02.dart';
 
 augment dynamic get topLevelGetter => 1;
-augment dynamic topLevelFunction() => 2;
+augment dynamic topLevelFunction();
 
 augment class C {
-  augment static dynamic get staticGetter => 3;
-  augment static dynamic staticMethod() => 4;
-  augment dynamic get instanceGetter => 5;
-  augment dynamic instanceMethod() => 6;
+  augment static dynamic get staticGetter;
+  augment static dynamic staticMethod() => 1;
+  augment dynamic get instanceGetter => 1;
+  augment dynamic instanceMethod();
 }
 
 augment mixin M {
-  augment static dynamic get staticGetter => 7;
-  augment static dynamic staticMethod() => 8;
-  augment dynamic get instanceGetter => 9;
-  augment dynamic instanceMethod() => 10;
+  augment static dynamic get staticGetter;
+  augment static dynamic staticMethod() => 1;
+  augment dynamic get instanceGetter => 1;
+  augment dynamic instanceMethod();
 }
 
 augment enum E {
   augment e0;
-  augment static dynamic get staticGetter => 11;
-  augment static dynamic staticMethod() => 12;
-  augment dynamic get instanceGetter => 13;
-  augment dynamic instanceMethod() => 14;
+  augment static dynamic get staticGetter;
+  augment static dynamic staticMethod() => 1;
+  augment dynamic get instanceGetter => 1;
+  augment dynamic instanceMethod();
 }
 
 augment extension Ext {
-  augment static dynamic get staticGetter => 15;
-  augment static dynamic staticMethod() => 16;
-  augment dynamic get instanceGetter => 17;
-  augment dynamic instanceMethod() => 18;
+  augment static dynamic get staticGetter;
+  augment static dynamic staticMethod() => 1;
+  augment dynamic get instanceGetter => 1;
+  augment dynamic instanceMethod();
 }
 
 augment extension type ET {
-  augment static dynamic get staticGetter => 19;
-  augment static dynamic staticMethod() => 20;
-  augment dynamic get instanceGetter => 21;
-  augment dynamic instanceMethod() => 22;
+  augment static dynamic get staticGetter;
+  augment static dynamic staticMethod() => 1;
+  augment dynamic get instanceGetter => 1;
+  augment dynamic instanceMethod();
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
@@ -36,7 +36,7 @@ augment mixin M {
 }
 
 augment enum E {
-  augment e0;
+  e1;
   augment static dynamic get staticGetter;
   augment static dynamic staticMethod() => 1;
   augment dynamic get instanceGetter => 1;

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t02_lib.dart
@@ -10,8 +10,8 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the introductory declaration.
+/// @description Check that it is no error if an augmenting declaration
+/// specifies the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts
@@ -55,4 +55,5 @@ augment extension type ET {
   augment static dynamic staticMethod() => 1;
   augment dynamic get instanceGetter => 1;
   augment dynamic instanceMethod();
+  augment dynamic get id;
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03.dart
@@ -10,8 +10,8 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the introductory declaration.
+/// @description Check that it is no error if an augmenting declaration
+/// specifies the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03.dart
@@ -2,51 +2,47 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the augmented declaration.
+/// the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 import '../../Utils/expect.dart';
 part 'type_inheritance_A02_t03_lib.dart';
 
 typedef NumAlias = num;
 
-num get topLevelGetter => 0;
+num get topLevelGetter;
 num topLevelFunction() => 0;
 
 class C {
   static num get staticGetter => 0;
-  static num staticMethod() => 0;
-  num get instanceGetter => 0;
+  static num staticMethod();
+  num get instanceGetter;
   num instanceMethod() => 0;
 }
 
 mixin M {
   static num get staticGetter => 0;
-  static num staticMethod() => 0;
-  num get instanceGetter => 0;
+  static num staticMethod();
+  num get instanceGetter;
   num instanceMethod() => 0;
 }
 
 enum E {
   e0;
   static num get staticGetter => 0;
-  static num staticMethod() => 0;
-  num get instanceGetter => 0;
+  static num staticMethod();
+  num get instanceGetter;
   num instanceMethod() => 0;
 }
 
@@ -54,15 +50,15 @@ class A {}
 
 extension Ext on A {
   static num get staticGetter => 0;
-  static num staticMethod() => 0;
-  num get instanceGetter => 0;
+  static num staticMethod();
+  num get instanceGetter;
   num instanceMethod() => 0;
 }
 
 extension type ET(num id) {
   static num get staticGetter => 0;
-  static num staticMethod() => 0;
-  num get instanceGetter => 0;
+  static num staticMethod();
+  num get instanceGetter;
   num instanceMethod() => 0;
 }
 
@@ -70,26 +66,26 @@ class MA = Object with M;
 
 main() {
   Expect.equals(1, topLevelGetter);
-  Expect.equals(2, topLevelFunction());
-  Expect.equals(3, C.staticGetter);
-  Expect.equals(4, C.staticMethod());
-  Expect.equals(5, C().instanceGetter);
-  Expect.equals(6, C().instanceMethod());
-  Expect.equals(7, M.staticGetter);
-  Expect.equals(8, M.staticMethod());
-  Expect.equals(9, MA().instanceGetter);
-  Expect.equals(10, MA().instanceMethod());
-  Expect.equals(11, E.staticGetter);
-  Expect.equals(12, E.staticMethod());
-  Expect.equals(13, E.e0.instanceGetter);
-  Expect.equals(14, E.e0.instanceMethod());
-  Expect.equals(15, Ext.staticGetter);
-  Expect.equals(16, Ext.staticMethod());
-  Expect.equals(17, A().instanceGetter);
-  Expect.equals(18, A().instanceMethod());
-  Expect.equals(19, ET.staticGetter);
-  Expect.equals(20, ET.staticMethod());
-  Expect.equals(21, ET(0).instanceGetter);
-  Expect.equals(22, ET(0).instanceMethod());
-  Expect.equals(23, ET(0).id);
+  Expect.equals(0, topLevelFunction());
+  Expect.equals(0, C.staticGetter);
+  Expect.equals(1, C.staticMethod());
+  Expect.equals(1, C().instanceGetter);
+  Expect.equals(0, C().instanceMethod());
+  Expect.equals(0, M.staticGetter);
+  Expect.equals(1, M.staticMethod());
+  Expect.equals(1, MA().instanceGetter);
+  Expect.equals(0, MA().instanceMethod());
+  Expect.equals(0, E.staticGetter);
+  Expect.equals(1, E.staticMethod());
+  Expect.equals(1, E.e0.instanceGetter);
+  Expect.equals(0, E.e0.instanceMethod());
+  Expect.equals(0, Ext.staticGetter);
+  Expect.equals(1, Ext.staticMethod());
+  Expect.equals(1, A().instanceGetter);
+  Expect.equals(0, A().instanceMethod());
+  Expect.equals(0, ET.staticGetter);
+  Expect.equals(1, ET.staticMethod());
+  Expect.equals(1, ET(0).instanceGetter);
+  Expect.equals(0, ET(0).instanceMethod());
+  Expect.equals(42, ET(42).id);
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
@@ -36,7 +36,7 @@ augment mixin M {
 }
 
 augment enum E {
-  augment e0;
+  e1;
   augment static NumAlias get staticGetter;
   augment static NumAlias staticMethod() => 1;
   augment NumAlias get instanceGetter => 1;

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
@@ -10,8 +10,8 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the introductory declaration.
+/// @description Check that it is no error if an augmenting declaration
+/// specifies the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t03_lib.dart
@@ -2,62 +2,58 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is no error if augmenting declaration specifies
-/// the same return type as the augmented declaration.
+/// the same return type as the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A02_t03.dart';
 
 augment NumAlias get topLevelGetter => 1;
-augment NumAlias topLevelFunction() => 2;
+augment NumAlias topLevelFunction();
 
 augment class C {
-  augment static NumAlias get staticGetter => 3;
-  augment static NumAlias staticMethod() => 4;
-  augment NumAlias get instanceGetter => 5;
-  augment NumAlias instanceMethod() => 6;
+  augment static NumAlias get staticGetter;
+  augment static NumAlias staticMethod() => 1;
+  augment NumAlias get instanceGetter => 1;
+  augment NumAlias instanceMethod();
 }
 
 augment mixin M {
-  augment static NumAlias get staticGetter => 7;
-  augment static NumAlias staticMethod() => 8;
-  augment NumAlias get instanceGetter => 9;
-  augment NumAlias instanceMethod() => 10;
+  augment static NumAlias get staticGetter;
+  augment static NumAlias staticMethod() => 1;
+  augment NumAlias get instanceGetter => 1;
+  augment NumAlias instanceMethod();
 }
 
 augment enum E {
   augment e0;
-  augment static NumAlias get staticGetter => 11;
-  augment static NumAlias staticMethod() => 12;
-  augment NumAlias get instanceGetter => 13;
-  augment NumAlias instanceMethod() => 14;
+  augment static NumAlias get staticGetter;
+  augment static NumAlias staticMethod() => 1;
+  augment NumAlias get instanceGetter => 1;
+  augment NumAlias instanceMethod();
 }
 
 augment extension Ext {
-  augment static NumAlias get staticGetter => 15;
-  augment static NumAlias staticMethod() => 16;
-  augment NumAlias get instanceGetter => 17;
-  augment NumAlias instanceMethod() => 18;
+  augment static NumAlias get staticGetter;
+  augment static NumAlias staticMethod() => 1;
+  augment NumAlias get instanceGetter => 1;
+  augment NumAlias instanceMethod();
 }
 
 augment extension type ET {
-  augment static NumAlias get staticGetter => 19;
-  augment static NumAlias staticMethod() => 20;
-  augment NumAlias get instanceGetter => 21;
-  augment NumAlias instanceMethod() => 22;
-  augment NumAlias get id => 23;
+  augment static NumAlias get staticGetter;
+  augment static NumAlias staticMethod() => 1;
+  augment NumAlias get instanceGetter => 1;
+  augment NumAlias instanceMethod();
+  augment NumAlias get id;
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04.dart
@@ -10,9 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration. Test a
-/// wrong top type.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration. Test a wrong top type.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04.dart
@@ -2,66 +2,62 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration. Test a
+/// specifies a different return type than the introductory declaration. Test a
 /// wrong top type.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'type_inheritance_A02_t04_lib.dart';
 
-get topLevelGetter => 0;
+get topLevelGetter;
 topLevelFunction() => 0;
 
 class C {
-  static get staticGetter => 0;
+  static get staticGetter;
   static staticMethod() => 0;
   get instanceGetter => 0;
-  instanceMethod() => 0;
+  instanceMethod();
 }
 
 mixin M {
-  static get staticGetter => 0;
+  static get staticGetter;
   static staticMethod() => 0;
   get instanceGetter => 0;
-  instanceMethod() => 0;
+  instanceMethod();
 }
 
 enum E {
   e0;
-  static get staticGetter => 0;
+  static get staticGetter;
   static staticMethod() => 0;
   get instanceGetter => 0;
-  instanceMethod() => 0;
+  instanceMethod();
 }
 
 class A {}
 
 extension Ext on A {
-  static get staticGetter => 0;
+  static get staticGetter;
   static staticMethod() => 0;
   get instanceGetter => 0;
-  instanceMethod() => 0;
+  instanceMethod();
 }
 
 extension type ET(int id) {
-  static get staticGetter => 0;
+  static get staticGetter;
   static staticMethod() => 0;
   get instanceGetter => 0;
-  instanceMethod() => 0;
+  instanceMethod();
 }
 
 main() {

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
@@ -2,24 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration. Test a
+/// specifies a different return type than the introductory declaration. Test a
 /// wrong top type.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A02_t04.dart';
 
@@ -27,7 +23,7 @@ augment Object? get topLevelGetter => 0;
 //      ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-augment Object? topLevelFunction() => 0;
+augment Object? topLevelFunction();
 //      ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -37,11 +33,11 @@ augment class C {
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static Object? staticMethod() => 0;
+  augment static Object? staticMethod();
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object? get instanceGetter => 0;
+  augment Object? get instanceGetter;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -56,11 +52,11 @@ augment mixin M {
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static Object? staticMethod() => 0;
+  augment static Object? staticMethod();
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object? get instanceGetter => 0;
+  augment Object? get instanceGetter;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -76,11 +72,11 @@ augment enum E {
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static Object? staticMethod() => 0;
+  augment static Object? staticMethod();
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object? get instanceGetter => 0;
+  augment Object? get instanceGetter;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -95,11 +91,11 @@ augment extension Ext {
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static Object? staticMethod() => 0;
+  augment static Object? staticMethod();
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object? get instanceGetter => 0;
+  augment Object? get instanceGetter;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -114,11 +110,11 @@ augment extension type ET {
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment static Object? staticMethod() => 0;
+  augment static Object? staticMethod();
 //               ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment Object? get instanceGetter => 0;
+  augment Object? get instanceGetter;
 //        ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
@@ -67,7 +67,7 @@ augment mixin M {
 }
 
 augment enum E {
-  augment e0;
+  e1;
   augment static Object? get staticGetter => 0;
 //               ^^^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t04_lib.dart
@@ -10,9 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration. Test a
-/// wrong top type.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration. Test a wrong top type.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts
@@ -20,48 +20,48 @@
 part of 'type_inheritance_A02_t04.dart';
 
 augment Object? get topLevelGetter => 0;
-//      ^^^^^^
+//      ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 augment Object? topLevelFunction();
-//      ^^^^^^
+//      ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
 augment class C {
   augment static Object? get staticGetter => 0;
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment static Object? staticMethod();
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? get instanceGetter;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? instanceMethod() => 0;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment mixin M {
   augment static Object? get staticGetter => 0;
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment static Object? staticMethod();
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? get instanceGetter;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? instanceMethod() => 0;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
@@ -69,57 +69,57 @@ augment mixin M {
 augment enum E {
   e1;
   augment static Object? get staticGetter => 0;
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment static Object? staticMethod();
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? get instanceGetter;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? instanceMethod() => 0;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension Ext {
   augment static Object? get staticGetter => 0;
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment static Object? staticMethod();
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? get instanceGetter;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? instanceMethod() => 0;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension type ET {
   augment static Object? get staticGetter => 0;
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment static Object? staticMethod();
-//               ^^^^^^
+//               ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? get instanceGetter;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
   augment Object? instanceMethod() => 0;
-//        ^^^^^^
+//        ^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05.dart
@@ -10,9 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration. Test a
-/// wrong top type.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration. Test a wrong top type.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05.dart
@@ -2,24 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration. Test a
+/// specifies a different return type than the introductory declaration. Test a
 /// wrong top type.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'type_inheritance_A02_t05_lib.dart';
 
@@ -27,30 +23,30 @@ topLevelFunction() {}
 
 class C {
   static staticMethod() {}
-  instanceMethod() {}
+  instanceMethod();
 }
 
 mixin M {
-  static staticMethod() {}
+  static staticMethod();
   instanceMethod() {}
 }
 
 enum E {
   e0;
   static staticMethod() {}
-  instanceMethod() {}
+  instanceMethod();
 }
 
 class A {}
 
 extension Ext on A {
-  static staticMethod() {}
+  static staticMethod();
   instanceMethod() {}
 }
 
 extension type ET(int id) {
   static staticMethod() {}
-  instanceMethod() {}
+  instanceMethod();
 }
 
 main() {

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
@@ -10,9 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the introductory declaration. Test a
-/// wrong top type.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different return type than the introductory
+/// declaration. Test a wrong top type.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
@@ -48,7 +48,7 @@ augment mixin M {
 }
 
 augment enum E {
-  augment e0;
+  e1;
   augment static void staticMethod();
 //               ^^^^
 // [analyzer] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A02_t05_lib.dart
@@ -2,35 +2,31 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different return type than the augmented declaration. Test a
+/// specifies a different return type than the introductory declaration. Test a
 /// wrong top type.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A02_t05.dart';
 
 
-augment void topLevelFunction() {}
+augment void topLevelFunction();
 //      ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
 augment class C {
-  augment static void staticMethod() {}
+  augment static void staticMethod();
 //               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -45,7 +41,7 @@ augment mixin M {
 //               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment void instanceMethod() {}
+  augment void instanceMethod();
 //        ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -53,7 +49,7 @@ augment mixin M {
 
 augment enum E {
   augment e0;
-  augment static void staticMethod() {}
+  augment static void staticMethod();
 //               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
@@ -68,14 +64,14 @@ augment extension Ext {
 //               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-  augment void instanceMethod() {}
+  augment void instanceMethod();
 //        ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 augment extension type ET {
-  augment static void staticMethod() {}
+  augment static void staticMethod();
 //               ^^^^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
@@ -10,8 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the introductory declaration.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different variable type than the introductory
+/// declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
@@ -2,68 +2,27 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
 /// specifies a different variable type than the augmented declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'type_inheritance_A03_t01_lib.dart';
 
-num topLevelVariable = 0;
-final num finalTopLevelVariable = 0;
-
-class C {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  num instanceVariable = 0;
-  final num finalInstanceVariable = 0;
-}
-
-mixin M {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  num instanceVariable = 0;
-  final num finalInstanceVariable = 0;
-}
-
-enum E {
-  e0;
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  final num finalInstanceVariable = 0;
-}
-
-class A {}
-
-extension Ext on A {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-}
-
-extension type ET(num id) {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
+abstract class C {
+  abstract num instanceVariable;
+  abstract final num finalInstanceVariable;
 }
 
 main() {
-  print(topLevelVariable);
-  print(finalTopLevelVariable);
   print(C);
-  print(M);
-  print(E);
-  print(A);
-  print(ET);
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the augmented declaration.
+/// specifies a different variable type than the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
@@ -10,8 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the introductory declaration.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different variable type than the introductory
+/// declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
@@ -2,115 +2,29 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
 /// specifies a different variable type than the augmented declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A03_t01.dart';
 
-augment int topLevelVariable = 0;
-//      ^^^
+augment abstract class C {
+  augment abstract Object instanceVariable;
+//                 ^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
-augment final Object finalTopLevelVariable = 0;
-//            ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
-augment class C {
-  augment static int staticVariable = 0;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment static final Object finalStaticVariable = 0;
-//                     ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment Object instanceVariable = 0;
-//        ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment final int finalInstanceVariable = 0;
-//              ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
-
-augment mixin M {
-  augment static int staticVariable = 0;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment static final Object finalStaticVariable = 0;
-//                     ^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment Object instanceVariable = 0;
-//        ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment final int finalInstanceVariable = 0;
-//              ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
-
-augment enum E {
-  augment e0;
-  augment static int staticVariable = 0;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment static final Object finalStaticVariable = 0;
-//                     ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment final int finalInstanceVariable = 0;
-//              ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
-
-augment extension Ext {
-  augment static int staticVariable = 0;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment static final Object finalStaticVariable = 0;
-//                     ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
-
-augment extension type ET {
-  augment static int staticVariable = 0;
-//               ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment static final Object finalStaticVariable = 0;
-//                     ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment final int id = 0;
-//              ^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-  augment final Object id = 0;
-//              ^^^^^^
+  augment abstract final int finalInstanceVariable;
+//                       ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t01_lib.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the augmented declaration.
+/// specifies a different variable type than the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
-/// specifies the same variable type as the augmented declaration does.
+/// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
@@ -2,84 +2,29 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
 /// specifies the same variable type as the augmented declaration does.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
-import '../../Utils/expect.dart';
 part 'type_inheritance_A03_t02_lib.dart';
 
 typedef NumAlias = num;
 
-num topLevelVariable = 0;
-final num finalTopLevelVariable = 0;
-
-class C {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  num instanceVariable = 0;
-  final num finalInstanceVariable = 0;
+abstract class C {
+  abstract num instanceVariable;
+  abstract final num finalInstanceVariable;
 }
-
-mixin M {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  num instanceVariable = 0;
-  final num finalInstanceVariable = 0;
-}
-
-enum E {
-  e0;
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-  final num finalInstanceVariable = 0;
-}
-
-class A {}
-
-extension Ext on A {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-}
-
-extension type ET(num id) {
-  static num staticVariable = 0;
-  static final num finalStaticVariable = 0;
-}
-
-class MA = Object with M;
 
 main() {
-  Expect.equals(1, topLevelVariable);
-  Expect.equals(2, finalTopLevelVariable);
-  Expect.equals(3, C.staticVariable);
-  Expect.equals(4, C.finalStaticVariable);
-  Expect.equals(5, C().instanceVariable);
-  Expect.equals(6, C().finalInstanceVariable);
-  Expect.equals(7, M.staticVariable);
-  Expect.equals(8, M.finalStaticVariable);
-  Expect.equals(9, MA().instanceVariable);
-  Expect.equals(10, MA().finalInstanceVariable);
-  Expect.equals(11, E.staticVariable);
-  Expect.equals(12, E.finalStaticVariable);
-  Expect.equals(13, E.e0.finalInstanceVariable);
-  Expect.equals(14, Ext.staticVariable);
-  Expect.equals(15, Ext.finalStaticVariable);
-  Expect.equals(16, ET.staticVariable);
-  Expect.equals(17, ET.finalStaticVariable);
-  Expect.equals(18, ET(0).id);
+  print(C);
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02.dart
@@ -10,7 +10,7 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is not an error if augmenting declaration
+/// @description Check that it is not an error if an augmenting declaration
 /// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
@@ -2,57 +2,23 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
 /// specifies the same variable type as the augmented declaration does.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A03_t02.dart';
 
-augment NumAlias topLevelVariable = 1;
-augment final NumAlias finalTopLevelVariable = 2;
-
-augment class C {
-  augment static NumAlias staticVariable = 3;
-  augment static final NumAlias finalStaticVariable = 4;
-  augment NumAlias instanceVariable = 5;
-  augment final NumAlias finalInstanceVariable = 6;
-}
-
-augment mixin M {
-  augment static NumAlias staticVariable = 7;
-  augment static final NumAlias finalStaticVariable = 8;
-  augment NumAlias instanceVariable = 9;
-  augment final NumAlias finalInstanceVariable = 10;
-}
-
-augment enum E {
-  augment e0;
-  augment static NumAlias staticVariable = 11;
-  augment static final NumAlias finalStaticVariable = 12;
-  augment final NumAlias finalInstanceVariable = 13;
-}
-
-augment extension Ext {
-  augment static NumAlias staticVariable = 14;
-  augment static final NumAlias finalStaticVariable = 15;
-}
-
-augment extension type ET {
-  augment static NumAlias staticVariable = 16;
-  augment static final NumAlias finalStaticVariable = 17;
-  augment final NumAlias id = 18;
+augment abstract class C {
+  augment abstract NumAlias instanceVariable;
+  augment abstract final NumAlias finalInstanceVariable;
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
-/// specifies the same variable type as the augmented declaration does.
+/// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t02_lib.dart
@@ -10,7 +10,7 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is not an error if augmenting declaration
+/// @description Check that it is not an error if an augmenting declaration
 /// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
-/// specifies the same variable type as the augmented declaration does.
+/// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
@@ -10,7 +10,7 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is not an error if augmenting declaration
+/// @description Check that it is not an error if an augmenting declaration
 /// specifies the same variable type as the introductory declaration does.
 /// @author sgrekhov22@gmail.com
 

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03.dart
@@ -2,81 +2,27 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is not an error if augmenting declaration
 /// specifies the same variable type as the augmented declaration does.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
-import '../../Utils/expect.dart';
 part 'type_inheritance_A03_t03_lib.dart';
 
-var topLevelVariable = "Original";
-final finalTopLevelVariable = "Original";
-
-class C {
-  static var staticVariable = "Original";
-  static final finalStaticVariable = "Original";
-  var instanceVariable = "Original";
-  final finalInstanceVariable = "Original";
+abstract class C {
+  abstract var instanceVariable;
+  abstract final finalInstanceVariable;
 }
-
-mixin M {
-  static var staticVariable = "Original";
-  static final finalStaticVariable = "Original";
-  var instanceVariable = "Original";
-  final finalInstanceVariable = "Original";
-}
-
-enum E {
-  e0;
-  static var staticVariable = "Original";
-  static final finalStaticVariable = "Original";
-  final finalInstanceVariable = "Original";
-}
-
-class A {}
-
-extension Ext on A {
-  static var staticVariable = "Original";
-  static final finalStaticVariable = "Original";
-}
-
-extension type ET(int id) {
-  static var staticVariable = "Original";
-  static final finalStaticVariable = "Original";
-}
-
-class MA = Object with M;
 
 main() {
-  Expect.equals("Augmented", topLevelVariable);
-  Expect.equals("Augmented", finalTopLevelVariable);
-  Expect.equals("Augmented", C.staticVariable);
-  Expect.equals("Augmented", C.finalStaticVariable);
-  Expect.equals("Augmented", C().instanceVariable);
-  Expect.equals("Augmented", C().finalInstanceVariable);
-  Expect.equals("Augmented", M.staticVariable);
-  Expect.equals("Augmented", M.finalStaticVariable);
-  Expect.equals("Augmented", MA().instanceVariable);
-  Expect.equals("Augmented", MA().finalInstanceVariable);
-  Expect.equals("Augmented", E.staticVariable);
-  Expect.equals("Augmented", E.finalStaticVariable);
-  Expect.equals("Augmented", E.e0.finalInstanceVariable);
-  Expect.equals("Augmented", Ext.staticVariable);
-  Expect.equals("Augmented", Ext.finalStaticVariable);
-  Expect.equals("Augmented", ET.staticVariable);
-  Expect.equals("Augmented", ET.finalStaticVariable);
+  print(C);
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
@@ -10,8 +10,9 @@
 /// compile-time error if the type denoted by the augmenting declaration is not
 /// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the introductory declaration.
+/// @description Check that it is a compile-time error if an augmenting
+/// declaration specifies a different variable type than the introductory
+/// declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
@@ -2,56 +2,29 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion An augmenting declaration may have no type annotations for a
-/// return type, variable type, parameter type, or type parameter bound type. In
-/// the last case, that includes omitting the extends keyword. For a variable or
-/// parameter, a var keyword may replace the type.
+/// @assertion If the type annotation or type parameter bound is omitted in the
+/// augmenting declaration, it is inferred to be the same as the corresponding
+/// type annotation or type parameter bound in the declaration being augmented.
 ///
-/// When applying an augmenting declaration that contains a type annotation at
-/// one of these positions, to a definition to be augmented, it's a compile-time
-/// error if the type denoted by the augmenting declaration is not the same type
-/// as the type that the augmented definition has at the corresponding position.
-/// An augmenting declaration can omit type annotations, but if it doesn't, it
-/// must repeat the type from the augmented definition.
+/// If the type annotation or type parameter bound is not omitted, then it's a
+/// compile-time error if the type denoted by the augmenting declaration is not
+/// the same type as the type in the corresponding declaration being augmented.
 ///
-/// @description Check that it is not an error if augmenting declaration
-/// specifies the same variable type as the augmented declaration does.
+/// @description Check that it is a compile-time error if augmenting declaration
+/// specifies a different variable type than the augmented declaration.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=macros
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'type_inheritance_A03_t03.dart';
 
-augment String topLevelVariable = "Augmented";
-augment final String finalTopLevelVariable = "Augmented";
-
-augment class C {
-  augment static String staticVariable = "Augmented";
-  augment static final String finalStaticVariable = "Augmented";
-  augment String instanceVariable = "Augmented";
-  augment final String finalInstanceVariable = "Augmented";
-}
-
-augment mixin M {
-  augment static String staticVariable = "Augmented";
-  augment static final String finalStaticVariable = "Augmented";
-  augment String instanceVariable = "Augmented";
-  augment final String finalInstanceVariable = "Augmented";
-}
-
-augment enum E {
-  augment e0;
-  augment static String staticVariable = "Augmented";
-  augment static final String finalStaticVariable = "Augmented";
-  augment final String finalInstanceVariable = "Augmented";
-}
-
-augment extension Ext {
-  augment static String staticVariable = "Augmented";
-  augment static final String finalStaticVariable = "Augmented";
-}
-
-augment extension type ET {
-  augment static String staticVariable = "Augmented";
-  augment static final String finalStaticVariable = "Augmented";
+augment abstract class C {
+  augment abstract String instanceVariable;
+//                 ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+  augment abstract final String finalInstanceVariable;
+//                       ^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
+++ b/LanguageFeatures/Augmentation-libraries/type_inheritance_A03_t03_lib.dart
@@ -11,7 +11,7 @@
 /// the same type as the type in the corresponding declaration being augmented.
 ///
 /// @description Check that it is a compile-time error if augmenting declaration
-/// specifies a different variable type than the augmented declaration.
+/// specifies a different variable type than the introductory declaration.
 /// @author sgrekhov22@gmail.com
 
 // SharedOptions=--enable-experiment=augmentations,enhanced-parts


### PR DESCRIPTION
The A02 tests are updated such that they satisfy the constraint that member implementations can be provided by an augmentation, but not overridden. The A03 tests are updated to test abstract instance variables (and several cases handling augmentation of other variables have been deleted because concrete variables cannot be augmented according to the new specification of augmentations).