### PR TITLE
Fixes #3227. Use `unspecified` error expectation

### DIFF
--- a/Language/Expressions/Identifier_Reference/evaluation_property_extraction_t04.dart
+++ b/Language/Expressions/Identifier_Reference/evaluation_property_extraction_t04.dart
@@ -20,15 +20,15 @@ class C {
   test() {
     undeclared;
 //  ^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_IDENTIFIER
-// [cfe] The getter 'undeclared' isn't defined for the class 'C'.
+// [analyzer] unspecified
+// [cfe] unspecified
   }
 
   C() {
     undeclared;
 //  ^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_IDENTIFIER
-// [cfe] The getter 'undeclared' isn't defined for the class 'C'.
+// [analyzer] unspecified
+// [cfe] unspecified
   }
 
   static int times = 0;

--- a/LanguageFeatures/Extension-methods/ommited_name_t01.dart
+++ b/LanguageFeatures/Extension-methods/ommited_name_t01.dart
@@ -23,10 +23,10 @@ main() {
   List<String> list = ["Lily", "was", "here"];
   list.nnDoubleLength;
 //     ^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] The getter 'nnDoubleLength' isn't defined for the class 'List<String>'.
+// [analyzer] unspecified
+// [cfe] unspecified
   List.nnClassName;
 //     ^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'nnClassName'.
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/Extension-methods/semantics_of_extension_members_t04.dart
+++ b/LanguageFeatures/Extension-methods/semantics_of_extension_members_t04.dart
@@ -21,13 +21,13 @@ class C {
 extension ExtendedC on C {
   static String st = cStaticMember;
 //                   ^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNQUALIFIED_REFERENCE_TO_STATIC_MEMBER_OF_EXTENDED_TYPE
-// [cfe] Undefined name 'cStaticMember'.
+// [analyzer] unspecified
+// [cfe] unspecified
   void test() {
     cStaticMember;
 //  ^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNQUALIFIED_REFERENCE_TO_STATIC_MEMBER_OF_EXTENDED_TYPE
-// [cfe] The getter 'cStaticMember' isn't defined for the class 'C'.
+// [analyzer] unspecified
+// [cfe] unspecified
   }
 }
 

--- a/LanguageFeatures/Extension-methods/syntax_scope_t06.dart
+++ b/LanguageFeatures/Extension-methods/syntax_scope_t06.dart
@@ -28,10 +28,10 @@ main() {
   List<String> list = ["Lily", "was", "here"];
   list.split(1);
 //     ^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_METHOD
-// [cfe] The method 'split' isn't defined for the class 'List<String>'.
+// [analyzer] unspecified
+// [cfe] unspecified
   MyFancyList.className;
 //            ^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_EXTENSION_GETTER
-// [cfe] Member not found: 'className'.
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/Horizontal-inference/horizontal_inference_t07.dart
+++ b/LanguageFeatures/Horizontal-inference/horizontal_inference_t07.dart
@@ -23,8 +23,8 @@ main() {
   f1((t, u) {
     t.c2();
 //    ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_METHOD
-// [cfe] The method 'c2' isn't defined for the class 'C1'.
+// [analyzer] unspecified
+// [cfe] unspecified
   }, (u) {
     return 1 > 2 ? C2() : C1();
   });

--- a/LanguageFeatures/Super-mixins/mixin_members_t02.dart
+++ b/LanguageFeatures/Super-mixins/mixin_members_t02.dart
@@ -11,7 +11,6 @@
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 
-
 class I {
   static int i1 = 1;
 }
@@ -40,24 +39,24 @@ class MA extends C with M {
   test() {
     i1 == 1;
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_IDENTIFIER
-// [cfe] The getter 'i1' isn't defined for the class 'MA'.
+// [analyzer] unspecified
+// [cfe] unspecified
     j1 == 2;
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_IDENTIFIER
-// [cfe] The getter 'j1' isn't defined for the class 'MA'.
+// [analyzer] unspecified
+// [cfe] unspecified
     b1 == 3;
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_IDENTIFIER
-// [cfe] The getter 'b1' isn't defined for the class 'MA'.
+// [analyzer] unspecified
+// [cfe] unspecified
     c1 == 4;
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNQUALIFIED_REFERENCE_TO_NON_LOCAL_STATIC_MEMBER
-// [cfe] The getter 'c1' isn't defined for the class 'MA'.
+// [analyzer] unspecified
+// [cfe] unspecified
     m1 == 5;
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNQUALIFIED_REFERENCE_TO_NON_LOCAL_STATIC_MEMBER
-// [cfe] The getter 'm1' isn't defined for the class 'MA'.
+// [analyzer] unspecified
+// [cfe] unspecified
   }
 }
 
@@ -65,24 +64,24 @@ main() {
   MA ma = new MA();
   MA.i1 == 1;
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'i1'.
+// [analyzer] unspecified
+// [cfe] unspecified
   MA.j1 == 2;
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'j1'.
+// [analyzer] unspecified
+// [cfe] unspecified
   MA.b1 == 3;
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'b1'.
+// [analyzer] unspecified
+// [cfe] unspecified
   MA.c1 == 4;
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'c1'.
+// [analyzer] unspecified
+// [cfe] unspecified
   MA.m1 == 5;
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_GETTER
-// [cfe] Member not found: 'm1'.
+// [analyzer] unspecified
+// [cfe] unspecified
 
   ma.test();
 }

--- a/LanguageFeatures/int-to-double/assignment_class_member_fail_t01.dart
+++ b/LanguageFeatures/int-to-double/assignment_class_member_fail_t01.dart
@@ -25,8 +25,8 @@ class C {
 main() {
   C.s = foo();
 //      ^^^^^
-// [analyzer] COMPILE_TIME_ERROR.INVALID_ASSIGNMENT
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'double'.
+// [analyzer] unspecified
+// [cfe] unspecified
   C?.s = foo();
 //       ^^^^^
 // [analyzer] unspecified
@@ -41,8 +41,8 @@ main() {
 // [cfe] unspecified
   C.staticSetter = foo();
 //                 ^^^^^
-// [analyzer] COMPILE_TIME_ERROR.INVALID_ASSIGNMENT
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'double'.
+// [analyzer] unspecified
+// [cfe] unspecified
   C?.staticSetter = foo();
 //                  ^^^^^
 // [analyzer] unspecified
@@ -51,21 +51,21 @@ main() {
   C? c = null;
   c?.m1 = foo();
 //   ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_SETTER
-// [cfe] The setter 'm1' isn't defined for the class 'C'.
+// [analyzer] unspecified
+// [cfe] unspecified
   c?.instanceSetter = foo();
 //                    ^^^^^
-// [analyzer] COMPILE_TIME_ERROR.INVALID_ASSIGNMENT
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'double'.
+// [analyzer] unspecified
+// [cfe] unspecified
   c = new C();
   c.m1 = foo();
 //  ^^
-// [analyzer] COMPILE_TIME_ERROR.UNDEFINED_SETTER
-// [cfe] The setter 'm1' isn't defined for the class 'C'.
+// [analyzer] unspecified
+// [cfe] unspecified
   c.instanceSetter = foo();
 //                   ^^^^^
-// [analyzer] COMPILE_TIME_ERROR.INVALID_ASSIGNMENT
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'double'.
+// [analyzer] unspecified
+// [cfe] unspecified
   c?.m1 = foo();
 //   ^^
 // [analyzer] unspecified


### PR DESCRIPTION
This PR can be safely landed before https://dart-review.googlesource.com/c/sdk/+/433941