### PR TITLE
#3180. Add `JSArray` tests.

### DIFF
--- a/LibTest/js_interop/JSArray/from_t01.dart
+++ b/LibTest/js_interop/JSArray/from_t01.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSArray<T> from<T extends JSAny>( JSObject arrayLike )
+/// Creates a new, shallow-copied JavaScript `Array` instance from a JavaScript
+/// iterable or array-like object.
+///
+/// @description Checks that this constructor creates a new JavaScript `Array`
+/// instance from a JavaScript array object.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  JSArray<JSNumber> a0 = JSArray<JSNumber>();
+  JSArray<JSNumber> copy0 = JSArray.from(a0);
+  Expect.notEquals(a0, copy0);
+
+  globalContext["a0"] = a0;
+  globalContext["copy0"] = copy0;
+  eval(r'''
+    var b0 = copy0.length === 0;
+    var eq0 = copy0 == a0;
+    ''');
+  Expect.isTrue((globalContext["b0"] as JSBoolean).toDart);
+  Expect.isFalse((globalContext["eq0"] as JSBoolean).toDart);
+
+  JSArray<JSNumber> a3 = JSArray<JSNumber>.withLength(3);
+  a3[0] = 0.toJS;
+  a3[1] = 1.toJS;
+  a3[2] = 2.toJS;
+  JSArray<JSNumber> copy3 = JSArray.from(a3);
+  Expect.notEquals(a3, copy3);
+  Expect.listEquals([0, 1, 2], copy3.dartify());
+
+  globalContext["a3"] = a3;
+  globalContext["copy3"] = copy3;
+  eval(r'''
+    var b3 = copy3.length === 3;
+    var eq3 = copy3 == a3;
+    ''');
+  Expect.isTrue((globalContext["b3"] as JSBoolean).toDart);
+  Expect.isFalse((globalContext["eq3"] as JSBoolean).toDart);
+}

--- a/LibTest/js_interop/JSArray/from_t02.dart
+++ b/LibTest/js_interop/JSArray/from_t02.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSArray<T> from<T extends JSAny>( JSObject arrayLike )
+/// Creates a new, shallow-copied JavaScript `Array` instance from a JavaScript
+/// iterable or array-like object.
+///
+/// @description Checks that this constructor creates a new, shallow-copied
+/// JavaScript `Array` instance from a JavaScript array object.
+/// @author sgrekhov22@gmail.com
+/// @issue 60934
+
+import 'dart:js_interop';
+import '../../../Utils/expect.dart';
+
+main() {
+  JSArray<JSArray<JSNumber>> ar = JSArray<JSArray<JSNumber>>.withLength(1);
+  JSArray<JSNumber> val = JSArray<JSNumber>.withLength(1);
+  val[0] = 42.toJS;
+  ar[0] = val;
+  JSArray<JSArray<JSNumber>> copy = JSArray.from(ar);
+  Expect.equals(val, copy[0]);
+  Expect.identical(val, copy[0]);
+}

--- a/LibTest/js_interop/JSArray/from_t02.dart
+++ b/LibTest/js_interop/JSArray/from_t02.dart
@@ -9,7 +9,6 @@
 /// @description Checks that this constructor creates a new, shallow-copied
 /// JavaScript `Array` instance from a JavaScript array object.
 /// @author sgrekhov22@gmail.com
-/// @issue 60934
 
 import 'dart:js_interop';
 import '../../../Utils/expect.dart';
@@ -21,5 +20,4 @@ main() {
   ar[0] = val;
   JSArray<JSArray<JSNumber>> copy = JSArray.from(ar);
   Expect.equals(val, copy[0]);
-  Expect.identical(val, copy[0]);
 }

--- a/LibTest/js_interop/JSArray/new_t01.dart
+++ b/LibTest/js_interop/JSArray/new_t01.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSArray<T extends JSAny?>()
+/// Creates an empty JavaScript `Array`.
+/// Equivalent to `new Array()` and more efficient than `[].jsify()`.
+///
+/// @description Checks that this constructor creates an empty array in
+/// JavaScript.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  JSArray<JSString> a1 = JSArray<JSString>();
+  Expect.equals(0, a1.length);
+  globalContext["a1"] = a1;
+  eval("var b = a1.length === 0;");
+  Expect.isTrue((globalContext["b"] as JSBoolean).toDart);
+}

--- a/LibTest/js_interop/JSArray/withLength_t01.dart
+++ b/LibTest/js_interop/JSArray/withLength_t01.dart
@@ -31,5 +31,5 @@ main() {
     var v1 = a1[0];
     ''');
   Expect.isTrue((globalContext["b1"] as JSBoolean).toDart);
-  Expect.isNull(globalContext["v1"].dartify());
+  Expect.isNull(globalContext["v1"]);
 }

--- a/LibTest/js_interop/JSArray/withLength_t01.dart
+++ b/LibTest/js_interop/JSArray/withLength_t01.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSArray<T extends JSAny?>.withLength( int length )
+/// Creates a JavaScript `Array` of size `length` with no elements.
+///
+/// @description Checks that this constructor creates a JavaScript `Array` of
+/// size `length` with no elements.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  JSArray<JSString> a0 = JSArray<JSString>.withLength(0);
+  Expect.equals(0, a0.length);
+  globalContext["a0"] = a0;
+  eval(r'''
+    var b0 = a0.length === 0;
+    ''');
+  Expect.isTrue((globalContext["b0"] as JSBoolean).toDart);
+
+  JSArray<JSString> a1 = JSArray<JSString>.withLength(1);
+  Expect.equals(1, a1.length);
+  globalContext["a1"] = a1;
+  eval(r'''
+    var b1 = a1.length === 1;
+    var v1 = a1[0];
+    ''');
+  Expect.isTrue((globalContext["b1"] as JSBoolean).toDart);
+  Expect.isNull(globalContext["v1"].dartify());
+}


### PR DESCRIPTION
`from_t0*` also check `[]=` and `[]` operators. I don't think that we need any separate tests for them.