### PR TITLE
Fixes #3240. Wrap `AsyncExpect.data()` in `asyncStart/End()`

### DIFF
--- a/LibTest/io/WebSocket/addStream_A01_t02.dart
+++ b/LibTest/io/WebSocket/addStream_A01_t02.dart
@@ -12,17 +12,27 @@
 
 import "dart:io";
 import "dart:async";
+import "../../../LanguageFeatures/Extension-types/syntax_A13_t04.dart";
 import "../../../Utils/expect.dart";
 import "../http_utils.dart";
 
 main() {
-  asyncTest<HttpServer>((HttpServer? server) async {
-    WebSocket ws = await WebSocket.connect(
-        "ws://${server?.address.address}:${server?.port}/");
-    await ws.addStream(new Stream.fromIterable(["Hello", ",", "World"]));
-    await ws.close();
-  },
-      setup: () => spawnWebSocketServer(
-          (WebSocket ws) => AsyncExpect.data(["Hello", ",", "World"], ws)),
-      cleanup: (HttpServer? server) => server?.close());
+  asyncTest<HttpServer>(
+    (HttpServer? server) async {
+      WebSocket ws = await WebSocket.connect(
+        "ws://${server?.address.address}:${server?.port}/",
+      );
+      await ws.addStream(new Stream.fromIterable(["Hello", ",", "World"]));
+      await ws.close();
+    },
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) {
+        AsyncExpect.data(["Hello", ",", "World"], ws).then((_) {
+          asyncEnd();
+        });
+      });
+    },
+    cleanup: (HttpServer? server) => server?.close(),
+  );
 }

--- a/LibTest/io/WebSocket/addStream_A01_t04.dart
+++ b/LibTest/io/WebSocket/addStream_A01_t04.dart
@@ -24,20 +24,22 @@ List<List<int>> bytes = [
 ];
 
 main() {
-  Completer<void> checkCompleted = Completer<void>();
   asyncTest<HttpServer>(
     (HttpServer? server) async {
       WebSocket ws = await WebSocket.connect(
         "ws://${server?.address.address}:${server?.port}/",
       );
       await ws.addStream(new Stream.fromIterable(bytes));
-      await checkCompleted;
       await ws.close();
     },
-    setup: () => spawnWebSocketServer((WebSocket ws) async {
-      await AsyncExpect.data(bytes, ws);
-      checkCompleted.complete();
-    }),
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) {
+        AsyncExpect.data(bytes, ws).then((_) {
+          asyncEnd();
+        });
+      });
+    },
     cleanup: (HttpServer? server) => server?.close(),
   );
 }

--- a/LibTest/io/WebSocket/addUtf8Text_A01_t02.dart
+++ b/LibTest/io/WebSocket/addUtf8Text_A01_t02.dart
@@ -19,13 +19,22 @@ import "../http_utils.dart";
 const Utf8Codec utf8 = const Utf8Codec();
 
 main() {
-  asyncTest<HttpServer>((HttpServer? server) async {
-    WebSocket ws = await WebSocket.connect(
-        "ws://${server?.address.address}:${server?.port}/");
-    ws.addUtf8Text(utf8.encode("Hello"));
-    await ws.close();
-  },
-      setup: () => spawnWebSocketServer(
-          (WebSocket ws) => AsyncExpect.data(["Hello"], ws)),
-      cleanup: (HttpServer? server) => server?.close());
+  asyncTest<HttpServer>(
+    (HttpServer? server) async {
+      WebSocket ws = await WebSocket.connect(
+        "ws://${server?.address.address}:${server?.port}/",
+      );
+      ws.addUtf8Text(utf8.encode("Hello"));
+      await ws.close();
+    },
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) {
+        AsyncExpect.data(["Hello"], ws).then((_) {
+          asyncEnd();
+        });
+      });
+    },
+    cleanup: (HttpServer? server) => server?.close(),
+  );
 }

--- a/LibTest/io/WebSocket/addUtf8Text_A01_t03.dart
+++ b/LibTest/io/WebSocket/addUtf8Text_A01_t03.dart
@@ -19,19 +19,27 @@ import "../http_utils.dart";
 const Utf8Codec utf8 = const Utf8Codec();
 
 main() {
-  asyncTest<HttpServer>((HttpServer? server) async {
-    WebSocket ws = await WebSocket.connect(
-        "ws://${server?.address.address}:${server?.port}/");
-    await AsyncExpect.data(["Hello", "client"], ws.take(2));
-    ws.addUtf8Text(utf8.encode("Hi"));
-    ws.addUtf8Text(utf8.encode("server"));
-    await ws.close();
-  },
-      setup: () => spawnWebSocketServer((WebSocket ws) async {
-            ws.addUtf8Text(utf8.encode("Hello"));
-            ws.addUtf8Text(utf8.encode("client"));
-            await AsyncExpect.data(["Hi", "server"], ws);
-            await ws.close();
-          }),
-      cleanup: (HttpServer? server) => server?.close());
+  asyncTest<HttpServer>(
+    (HttpServer? server) async {
+      WebSocket ws = await WebSocket.connect(
+        "ws://${server?.address.address}:${server?.port}/",
+      );
+      await AsyncExpect.data(["Hello", "client"], ws.take(2));
+      ws.addUtf8Text(utf8.encode("Hi"));
+      ws.addUtf8Text(utf8.encode("server"));
+      await ws.close();
+    },
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) async {
+        ws.addUtf8Text(utf8.encode("Hello"));
+        ws.addUtf8Text(utf8.encode("client"));
+        AsyncExpect.data(["Hi", "server"], ws).then((_) {
+          asyncEnd();
+        });
+        await ws.close();
+      });
+    },
+    cleanup: (HttpServer? server) => server?.close(),
+  );
 }

--- a/LibTest/io/WebSocket/add_A01_t03.dart
+++ b/LibTest/io/WebSocket/add_A01_t03.dart
@@ -14,13 +14,22 @@ import "../../../Utils/expect.dart";
 import "../http_utils.dart";
 
 main() {
-  asyncTest<HttpServer>((HttpServer? server) async {
-    WebSocket ws = await WebSocket.connect(
-        "ws://${server?.address.address}:${server?.port}/");
-    ws.add("Hello");
-    await ws.close();
-  },
-      setup: () => spawnWebSocketServer(
-          (WebSocket ws) => AsyncExpect.data(["Hello"], ws)),
-      cleanup: (HttpServer? server) => server?.close());
+  asyncTest<HttpServer>(
+    (HttpServer? server) async {
+      WebSocket ws = await WebSocket.connect(
+        "ws://${server?.address.address}:${server?.port}/",
+      );
+      ws.add("Hello");
+      await ws.close();
+    },
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) {
+        AsyncExpect.data(["Hello"], ws).then((_) {
+          asyncEnd();
+        });
+      });
+    },
+    cleanup: (HttpServer? server) => server?.close(),
+  );
 }

--- a/LibTest/io/WebSocket/add_A01_t04.dart
+++ b/LibTest/io/WebSocket/add_A01_t04.dart
@@ -9,7 +9,6 @@
 /// connection from client.
 /// @author a.semenov@unipro.ru
 
-import "dart:async";
 import "dart:io";
 import "../../../Utils/expect.dart";
 import "../http_utils.dart";
@@ -17,20 +16,22 @@ import "../http_utils.dart";
 const List<int> bytes = const [1, 2, 3];
 
 main() {
-  Completer<void> checkCompleted = Completer<void>();
   asyncTest<HttpServer>(
     (HttpServer? server) async {
       WebSocket ws = await WebSocket.connect(
         "ws://${server?.address.address}:${server?.port}/",
       );
       ws.add(bytes);
-      await checkCompleted;
       await ws.close();
     },
-    setup: () => spawnWebSocketServer((WebSocket ws) {
-      AsyncExpect.data([bytes], ws);
-      checkCompleted.complete();
-    }),
+    setup: () {
+      asyncStart();
+      return spawnWebSocketServer((WebSocket ws) {
+        AsyncExpect.data([bytes], ws).then((_) {
+          asyncEnd();
+        });
+      });
+    },
     cleanup: (HttpServer? server) => server?.close(),
   );
 }


### PR DESCRIPTION
I'm still unable to reproduce the issue, but according to the logs, the problem appears when `AsyncExpect.data()` is called in the setup part of `asyncTest()`. `AsyncExpect.data()` checks that a `Stream` contains the expected data and does so asynchronously. However, sometimes when the data arrives, the test has already finished its work, and an exception occurs. The solution is to always wrap `AsyncExpect.data()` with `asyncStart()` and `asyncEnd()` when it is used in `setup()`. This should fix the flakiness.