### PR TITLE
#3180. Add `NullRejectionException` tests

### DIFF
--- a/LibTest/js_interop/NullRejectionException/nullRejectionException_t01.dart
+++ b/LibTest/js_interop/NullRejectionException/nullRejectionException_t01.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Exception for when the promise is rejected with a `null` or
+/// `undefined` value.
+///
+/// @description Checks that this exception occurs when the promise is rejected
+/// with a `null` value.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  eval(r'''
+    globalThis.promise = new Promise(function(resolve, reject) {
+      reject(null);
+    });
+  ''');
+  JSPromise promise = globalContext["promise"] as JSPromise;
+  asyncStart();
+  promise.toDart.then((v) {
+    Expect.fail("NullRejectionException expected");
+  }).onError((e, st) {
+    Expect.isTrue(e is NullRejectionException);
+    Expect.isFalse((e as NullRejectionException).isUndefined);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/NullRejectionException/nullRejectionException_t02.dart
+++ b/LibTest/js_interop/NullRejectionException/nullRejectionException_t02.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Exception for when the promise is rejected with a `null` or
+/// `undefined` value.
+///
+/// @description Checks that this exception occurs when the promise is rejected
+/// with an `undefined` value.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  eval(r'''
+    globalThis.promise = new Promise(function(resolve, reject) {
+      reject(undefined);
+    });
+  ''');
+  JSPromise promise = globalContext["promise"] as JSPromise;
+  asyncStart();
+  promise.toDart.then((v) {
+    Expect.fail("NullRejectionException expected");
+  }).onError((e, st) {
+    Expect.isTrue(e is NullRejectionException);
+    Expect.isTrue((e as NullRejectionException).isUndefined);
+    asyncEnd();
+  });
+}


### PR DESCRIPTION
There is also a public constructor `NullRejectionException.new` but I didn't find a way how it can be used. @srujzs do you know it? Does it makes sense to make it public?