### PR TITLE
#3180. Add JSExport tests. Part 2.

### DIFF
--- a/LibTest/js_interop/JSExport/jsExport_A01_t06.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t06.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Annotation to allow Dart classes to be wrapped with a JS object
+/// using `dart:js_interop`'s `createJSInteropWrapper`.
+///
+/// When an instance of a class annotated with this annotation is passed to
+/// `createJSInteropWrapper`, the method returns a JS object that contains a
+/// property for each of the class' instance members. When called, these
+/// properties forward to the instance's corresponding members.
+///
+/// @description Checks that when an instance of an enum is annotated with
+/// `@JSExport()` and passed to `createJSInteropWrapper`, the method returns a
+/// JS object that contains a property for each of the enum's instance members.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+@JSExport()
+enum E {
+  e0(0);
+
+  final int id;
+  const E(this.id);
+
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+void main() {
+  var jsE = createJSInteropWrapper<E>(E.e0);
+  globalContext["jsE"] = jsE;
+  eval(r'''
+    globalThis.v1 = globalThis.jsE.id;
+    globalThis.v2 = globalThis.jsE.method('x');
+    globalThis.v3 = globalThis.jsE.getter;
+    globalThis.jsE.setter = false;
+  ''');
+  Expect.equals(0, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("setter(false);", log);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Annotation to allow Dart classes to be wrapped with a JS object
+/// using `dart:js_interop`'s `createJSInteropWrapper`.
+///
+/// When an instance of a class annotated with this annotation is passed to
+/// `createJSInteropWrapper`, the method returns a JS object that contains a
+/// property for each of the class' instance members. When called, these
+/// properties forward to the instance's corresponding members.
+///
+/// @description Checks that when an instance of an extension type is annotated
+/// with `@JSExport()` and passed to `createJSInteropWrapper`, the method
+/// returns a JS object that contains a property for each of the representation
+/// type's instance members.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+@JSExport()
+class C {
+  int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+@JSExport()
+extension type ET(C c) implements C {
+  String etMethod(String v) => "etMethod($v);";
+  String get etGetter => "Some etGetter";
+  void set etSetter(bool value) {
+    log = "etSetter($value);";
+  }
+}
+
+void main() {
+  var jsET = createJSInteropWrapper<C>(ET(C()));
+  globalContext["jsET"] = jsET;
+  eval(r'''
+    globalThis.v1 = globalThis.jsET.variable;
+    globalThis.v2 = globalThis.jsET.method('x');
+    globalThis.v3 = globalThis.jsET.getter;
+    globalThis.jsET.setter = false;
+
+    globalThis.v4 = globalThis.jsET.c;
+    globalThis.v5 = globalThis.jsET.etMethod;
+    globalThis.v6 = globalThis.jsET.etGetter;
+    globalThis.v7 = globalThis.jsET.etSetter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("setter(false);", log);
+
+  Expect.isNull(globalContext["v4"]);
+  Expect.isNull(globalContext["v5"]);
+  Expect.isNull(globalContext["v6"]);
+  Expect.isNull(globalContext["v7"]);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
@@ -10,10 +10,10 @@
 /// property for each of the class' instance members. When called, these
 /// properties forward to the instance's corresponding members.
 ///
-/// @description Checks that when an instance of an extension type is annotated
-/// with `@JSExport()` and passed to `createJSInteropWrapper`, the method
-/// returns a JS object that contains a property for each of the representation
-/// type's instance members.
+/// @description Checks that when an extension type is annotated with
+/// `@JSExport()` and passed to `createJSInteropWrapper`, the method returns a
+/// JS object that contains a property for each of the representation type's
+/// instance members.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:js_interop';
@@ -43,7 +43,7 @@ extension type ET(C c) implements C {
 }
 
 void main() {
-  var jsET = createJSInteropWrapper<C>(ET(C()));
+  var jsET = createJSInteropWrapper<ET>(ET(C()));
   globalContext["jsET"] = jsET;
   eval(r'''
     globalThis.v1 = globalThis.jsET.variable;

--- a/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t07.dart
@@ -10,59 +10,33 @@
 /// property for each of the class' instance members. When called, these
 /// properties forward to the instance's corresponding members.
 ///
-/// @description Checks that when an extension type is annotated with
-/// `@JSExport()` and passed to `createJSInteropWrapper`, the method returns a
-/// JS object that contains a property for each of the representation type's
-/// instance members.
+/// @description Checks that it is a warning when an extension type is annotated
+/// with `@JSExport()`.
 /// @author sgrekhov22@gmail.com
+/// @issue 61082
 
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-import '../../../Utils/expect.dart';
-import '../js_utils.dart';
-
-String log = "";
 
 @JSExport()
 class C {
   int variable = 42;
   String method(String v) => "method($v);";
-  String get getter => "Some getter";
+  String get getter => "getter";
   void set setter(bool value) {
-    log = "setter($value);";
   }
 }
 
 @JSExport()
 extension type ET(C c) implements C {
+//             ^^
+// [analyzer] unspecified
+// [web] unspecified
   String etMethod(String v) => "etMethod($v);";
-  String get etGetter => "Some etGetter";
+  String get etGetter => "etGetter";
   void set etSetter(bool value) {
-    log = "etSetter($value);";
   }
 }
 
 void main() {
-  var jsET = createJSInteropWrapper<ET>(ET(C()));
-  globalContext["jsET"] = jsET;
-  eval(r'''
-    globalThis.v1 = globalThis.jsET.variable;
-    globalThis.v2 = globalThis.jsET.method('x');
-    globalThis.v3 = globalThis.jsET.getter;
-    globalThis.jsET.setter = false;
-
-    globalThis.v4 = globalThis.jsET.c;
-    globalThis.v5 = globalThis.jsET.etMethod;
-    globalThis.v6 = globalThis.jsET.etGetter;
-    globalThis.v7 = globalThis.jsET.etSetter;
-  ''');
-  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
-  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
-  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
-  Expect.equals("setter(false);", log);
-
-  Expect.isNull(globalContext["v4"]);
-  Expect.isNull(globalContext["v5"]);
-  Expect.isNull(globalContext["v6"]);
-  Expect.isNull(globalContext["v7"]);
+  print(ET);
 }

--- a/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Annotation to allow Dart classes to be wrapped with a JS object
+/// using `dart:js_interop`'s `createJSInteropWrapper`.
+///
+/// When an instance of a class annotated with this annotation is passed to
+/// `createJSInteropWrapper`, the method returns a JS object that contains a
+/// property for each of the class' instance members. When called, these
+/// properties forward to the instance's corresponding members.
+///
+/// @description Checks that when an instance of an extension for a class `C` is
+/// annotated with `@JSExport()` and the an instance of 1C` passed to
+/// `createJSInteropWrapper`, the method returns a JS object that contains a
+/// property for each of the `C` instance members, but for those ones that were
+/// added by the extension.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+@JSExport()
+class C {
+  int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+@JSExport()
+extension Ext on C {
+  String extMethod(String v) => "extMethod($v);";
+  String get extGetter => "Some extGetter";
+  void set extSetter(bool value) {
+    log = "extSetter($value);";
+  }
+}
+
+void main() {
+  var jsC = createJSInteropWrapper<C>(C());
+  globalContext["jsC"] = jsC;
+  eval(r'''
+    globalThis.v1 = globalThis.jsC.variable;
+    globalThis.v2 = globalThis.jsC.method('x');
+    globalThis.v3 = globalThis.jsC.getter;
+    globalThis.jsC.setter = false;
+
+    globalThis.v4 = globalThis.jsC.extMethod;
+    globalThis.v5 = globalThis.jsC.extGetter;
+    globalThis.v6 = globalThis.jsC.extSetter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("setter(false);", log);
+
+  Expect.isNull(globalContext["v4"]);
+  Expect.isNull(globalContext["v5"]);
+  Expect.isNull(globalContext["v6"]);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
@@ -10,57 +10,33 @@
 /// property for each of the class' instance members. When called, these
 /// properties forward to the instance's corresponding members.
 ///
-/// @description Checks that when an extension for a class `C` is annotated with
-/// `@JSExport()` and an instance of `C` passed to `createJSInteropWrapper`, the
-/// method returns a JS object that contains a property for each of the `C`
-/// instance members, but for those ones that were added by the extension.
+/// @description Checks that it is a warning when an extension is annotated with
+/// `@JSExport()`.
 /// @author sgrekhov22@gmail.com
+/// @issue 61082
 
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-import '../../../Utils/expect.dart';
-import '../js_utils.dart';
-
-String log = "";
 
 @JSExport()
 class C {
   int variable = 42;
   String method(String v) => "method($v);";
-  String get getter => "Some getter";
+  String get getter => "getter";
   void set setter(bool value) {
-    log = "setter($value);";
   }
 }
 
 @JSExport()
 extension Ext on C {
+//        ^^^
+// [analyzer] unspecified
+// [web] unspecified
   String extMethod(String v) => "extMethod($v);";
-  String get extGetter => "Some extGetter";
+  String get extGetter => "extGetter";
   void set extSetter(bool value) {
-    log = "extSetter($value);";
   }
 }
 
 void main() {
-  var jsC = createJSInteropWrapper<C>(C());
-  globalContext["jsC"] = jsC;
-  eval(r'''
-    globalThis.v1 = globalThis.jsC.variable;
-    globalThis.v2 = globalThis.jsC.method('x');
-    globalThis.v3 = globalThis.jsC.getter;
-    globalThis.jsC.setter = false;
-
-    globalThis.v4 = globalThis.jsC.extMethod;
-    globalThis.v5 = globalThis.jsC.extGetter;
-    globalThis.v6 = globalThis.jsC.extSetter;
-  ''');
-  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
-  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
-  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
-  Expect.equals("setter(false);", log);
-
-  Expect.isNull(globalContext["v4"]);
-  Expect.isNull(globalContext["v5"]);
-  Expect.isNull(globalContext["v6"]);
+  print(C);
 }

--- a/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A01_t08.dart
@@ -10,11 +10,10 @@
 /// property for each of the class' instance members. When called, these
 /// properties forward to the instance's corresponding members.
 ///
-/// @description Checks that when an instance of an extension for a class `C` is
-/// annotated with `@JSExport()` and the an instance of 1C` passed to
-/// `createJSInteropWrapper`, the method returns a JS object that contains a
-/// property for each of the `C` instance members, but for those ones that were
-/// added by the extension.
+/// @description Checks that when an extension for a class `C` is annotated with
+/// `@JSExport()` and an instance of `C` passed to `createJSInteropWrapper`, the
+/// method returns a JS object that contains a property for each of the `C`
+/// instance members, but for those ones that were added by the extension.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:js_interop';

--- a/LibTest/js_interop/JSExport/jsExport_A02_t01.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t01.dart
@@ -6,9 +6,9 @@
 /// those members or you can annotate the entire class, which will include all
 /// of its instance members.
 ///
-/// @description Checks that if a specific instance members are annotated with
+/// @description Checks that if specific instance members are annotated with
 /// `@JSExport()` and then the object is passed to `createJSInteropWrapper`,
-/// then the method returns a JS object that contains a property for that
+/// then the method returns a JS object that contains a property for those
 /// instance members only.
 /// @author sgrekhov22@gmail.com
 

--- a/LibTest/js_interop/JSExport/jsExport_A02_t01.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t01.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion You can either annotate specific instance members to only wrap
+/// those members or you can annotate the entire class, which will include all
+/// of its instance members.
+///
+/// @description Checks that if a specific instance members are annotated with
+/// `@JSExport()` and then the object is passed to `createJSInteropWrapper`,
+/// then the method returns a JS object that contains a property for that
+/// instance members only.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+class C {
+  @JSExport()
+  int annotatedVariable = 42;
+  @JSExport()
+  String annotatedMethod(String v) => "annotatedMethod($v);";
+  @JSExport()
+  String get annotatedGetter => "Some annotatedGetter";
+  @JSExport()
+  void set annotatedSetter(bool value) {
+    log = "annotatedSetter($value);";
+  }
+
+  int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+void main() {
+  var c = C();
+  var jsC = createJSInteropWrapper<C>(c);
+  globalContext["jsC"] = jsC;
+  eval(r'''
+    globalThis.v1 = globalThis.jsC.annotatedVariable;
+    globalThis.v2 = globalThis.jsC.annotatedMethod('x');
+    globalThis.v3 = globalThis.jsC.annotatedGetter;
+    globalThis.jsC.annotatedSetter = false;
+    
+    globalThis.v4 = globalThis.jsC.variable;
+    globalThis.v5 = globalThis.jsC.method;
+    globalThis.v6 = globalThis.jsC.getter;
+    globalThis.v7 = globalThis.jsC.setter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("annotatedMethod(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some annotatedGetter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("annotatedSetter(false);", log);
+
+  Expect.isNull(globalContext["v4"]);
+  Expect.isNull(globalContext["v5"]);
+  Expect.isNull(globalContext["v6"]);
+  Expect.isNull(globalContext["v7"]);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A02_t02.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t02.dart
@@ -7,8 +7,8 @@
 /// in the JS object by providing a `name` in the `@JSExport` annotation on the
 /// member.
 ///
-/// @description Checks that if a class is annotated with  a `@JSExport` then
-/// its instance members still can be annotated.
+/// @description Checks that if a class is annotated with `@JSExport` then its
+/// instance members can still be annotated.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:js_interop';

--- a/LibTest/js_interop/JSExport/jsExport_A02_t02.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t02.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion By default, the property will have the same name as the
+/// corresponding instance member. You can change the property name of a member
+/// in the JS object by providing a `name` in the `@JSExport` annotation on the
+/// member.
+///
+/// @description Checks that if a class is annotated with  a `@JSExport` then
+/// its instance members still can be annotated.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+@JSExport()
+class C {
+  @JSExport()
+  int annotatedVariable = 42;
+  @JSExport()
+  String annotatedMethod(String v) => "annotatedMethod($v);";
+  @JSExport()
+  String get annotatedGetter => "Some annotatedGetter";
+  @JSExport()
+  void set annotatedSetter(bool value) {
+    log = "annotatedSetter($value);";
+  }
+
+  int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+void main() {
+  var c = C();
+  var jsC = createJSInteropWrapper<C>(c);
+  globalContext["jsC"] = jsC;
+  eval(r'''
+    globalThis.v1 = globalThis.jsC.annotatedVariable;
+    globalThis.v2 = globalThis.jsC.annotatedMethod('x');
+    globalThis.v3 = globalThis.jsC.annotatedGetter;
+    globalThis.jsC.annotatedSetter = false;
+    
+    globalThis.v4 = globalThis.jsC.variable;
+    globalThis.v5 = globalThis.jsC.method('y');
+    globalThis.v6 = globalThis.jsC.getter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("annotatedMethod(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some annotatedGetter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("annotatedSetter(false);", log);
+
+  eval("globalThis.jsC.setter = false;");
+  Expect.equals(42, (globalContext["v4"] as JSNumber).toDartInt);
+  Expect.equals("method(y);", (globalContext["v5"] as JSString).toDart);
+  Expect.equals("Some getter", (globalContext["v6"] as JSString).toDart);
+  Expect.equals("setter(false);", log);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A02_t03.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t03.dart
@@ -6,9 +6,9 @@
 /// those members or you can annotate the entire class, which will include all
 /// of its instance members.
 ///
-/// @description Checks that if a specific instance members are annotated with
+/// @description Checks that if specific instance members are annotated with
 /// `@JSExport()` and then the object is passed to `createJSInteropWrapper`,
-/// then the method returns a JS object that contains a property for that
+/// then the method returns a JS object that contains a property for those
 /// instance members only. Test enum.
 /// @author sgrekhov22@gmail.com
 

--- a/LibTest/js_interop/JSExport/jsExport_A02_t03.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t03.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion You can either annotate specific instance members to only wrap
+/// those members or you can annotate the entire class, which will include all
+/// of its instance members.
+///
+/// @description Checks that if a specific instance members are annotated with
+/// `@JSExport()` and then the object is passed to `createJSInteropWrapper`,
+/// then the method returns a JS object that contains a property for that
+/// instance members only. Test enum.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+enum E {
+  e0;
+
+  @JSExport()
+  final int annotatedVariable = 42;
+  @JSExport()
+  String annotatedMethod(String v) => "annotatedMethod($v);";
+  @JSExport()
+  String get annotatedGetter => "Some annotatedGetter";
+  @JSExport()
+  void set annotatedSetter(bool value) {
+    log = "annotatedSetter($value);";
+  }
+
+  final int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+void main() {
+  var jsE = createJSInteropWrapper<E>(E.e0);
+  globalContext["jsE"] = jsE;
+  eval(r'''
+    globalThis.v1 = globalThis.jsE.annotatedVariable;
+    globalThis.v2 = globalThis.jsE.annotatedMethod('x');
+    globalThis.v3 = globalThis.jsE.annotatedGetter;
+    globalThis.jsE.annotatedSetter = false;
+    
+    globalThis.v4 = globalThis.jsE.variable;
+    globalThis.v5 = globalThis.jsE.method;
+    globalThis.v6 = globalThis.jsE.getter;
+    globalThis.v7 = globalThis.jsE.setter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("annotatedMethod(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some annotatedGetter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("annotatedSetter(false);", log);
+
+  Expect.isNull(globalContext["v4"]);
+  Expect.isNull(globalContext["v5"]);
+  Expect.isNull(globalContext["v6"]);
+  Expect.isNull(globalContext["v7"]);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A02_t04.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t04.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion You can either annotate specific instance members to only wrap
+/// those members or you can annotate the entire class, which will include all
+/// of its instance members.
+///
+/// @description Checks that it is a compile-time error to annotate with
+/// `JSExport()` an extension type instance members.
+/// @author sgrekhov22@gmail.com
+/// @issue 61076
+
+import 'dart:js_interop';
+
+@JSExport()
+class C {
+  final int variable = 42;
+}
+
+extension type ET(@JSExport() C c) implements C {
+//                ^^^^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+  @JSExport()
+  String etMethod(String v) => "etMethod($v);";
+//       ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+  @JSExport()
+
+  String get etGetter => "Some etGetter";
+//           ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+  @JSExport()
+  void set etSetter(bool value) {
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+  }
+}
+
+void main() {
+  print(ET);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A02_t04.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t04.dart
@@ -6,8 +6,8 @@
 /// those members or you can annotate the entire class, which will include all
 /// of its instance members.
 ///
-/// @description Checks that it is a compile-time error to annotate with
-/// `JSExport()` an extension type instance members.
+/// @description Checks that it is a compile-time error to annotate extension
+/// type instance members with `JSExport()`.
 /// @author sgrekhov22@gmail.com
 /// @issue 61076
 

--- a/LibTest/js_interop/JSExport/jsExport_A02_t05.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t05.dart
@@ -6,8 +6,8 @@
 /// those members or you can annotate the entire class, which will include all
 /// of its instance members.
 ///
-/// @description Checks that it is a compile-time error to annotate with
-/// `JSExport()` an extension instance members.
+/// @description Checks that it is a compile-time error to annotate extension
+/// members with `JSExport()`.
 /// @author sgrekhov22@gmail.com
 /// @issue 61076
 
@@ -20,20 +20,20 @@ class C {
 
 extension Ext on C {
   @JSExport()
-  String etMethod(String v) => "etMethod($v);";
-//       ^^^^^^^^
+  String extMethod(String v) => "extMethod($v);";
+//       ^^^^^^^^^
 // [analyzer] unspecified
 // [web] unspecified
 
   @JSExport()
-  String get etGetter => "Some etGetter";
-//           ^^^^^^^^
+  String get extGetter => "extGetter";
+//           ^^^^^^^^^
 // [analyzer] unspecified
 // [web] unspecified
 
   @JSExport()
-  void set etSetter(bool value) {
-//         ^^^^^^^^
+  void set extSetter(bool value) {
+//         ^^^^^^^^^
 // [analyzer] unspecified
 // [web] unspecified
   }

--- a/LibTest/js_interop/JSExport/jsExport_A02_t05.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A02_t05.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion You can either annotate specific instance members to only wrap
+/// those members or you can annotate the entire class, which will include all
+/// of its instance members.
+///
+/// @description Checks that it is a compile-time error to annotate with
+/// `JSExport()` an extension instance members.
+/// @author sgrekhov22@gmail.com
+/// @issue 61076
+
+import 'dart:js_interop';
+
+@JSExport()
+class C {
+  final int variable = 42;
+}
+
+extension Ext on C {
+  @JSExport()
+  String etMethod(String v) => "etMethod($v);";
+//       ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+  @JSExport()
+  String get etGetter => "Some etGetter";
+//           ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+  @JSExport()
+  void set etSetter(bool value) {
+//         ^^^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+  }
+}
+
+void main() {
+  print(C);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A03_t01.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A03_t01.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion By default, the property will have the same name as the
+/// corresponding instance member. You can change the property name of a member
+/// in the JS object by providing a `name` in the `@JSExport` annotation on the
+/// member.
+///
+/// @description Checks that providing a `name` in the `@JSExport` changes the
+/// name of the corresponding instance member.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+String log = "";
+
+class C {
+  @JSExport("variable")
+  int annotatedVariable = 42;
+  @JSExport("method")
+  String annotatedMethod(String v) => "method($v);";
+  @JSExport("getter")
+  String get annotatedGetter => "Some getter";
+  @JSExport("setter")
+  void set annotatedSetter(bool value) {
+    log = "setter($value);";
+  }
+}
+
+void main() {
+  var c = C();
+  var jsC = createJSInteropWrapper<C>(c);
+  globalContext["jsC"] = jsC;
+  eval(r'''
+    globalThis.v1 = globalThis.jsC.variable;
+    globalThis.v2 = globalThis.jsC.method('x');
+    globalThis.v3 = globalThis.jsC.getter;
+    globalThis.jsC.setter = false;
+
+    globalThis.v4 = globalThis.jsC.annotatedVariable;
+    globalThis.v5 = globalThis.jsC.annotatedMethod;
+    globalThis.v6 = globalThis.jsC.annotatedGetter;
+    globalThis.v7 = globalThis.jsC.annotatedSetter;
+  ''');
+  Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
+  Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
+  Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
+  Expect.equals("setter(false);", log);
+
+  Expect.isNull(globalContext["v4"]);
+  Expect.isNull(globalContext["v5"]);
+  Expect.isNull(globalContext["v6"]);
+  Expect.isNull(globalContext["v7"]);
+}

--- a/LibTest/js_interop/JSExport/jsExport_A03_t01.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A03_t01.dart
@@ -44,15 +44,16 @@ void main() {
     globalThis.v4 = globalThis.jsC.annotatedVariable;
     globalThis.v5 = globalThis.jsC.annotatedMethod;
     globalThis.v6 = globalThis.jsC.annotatedGetter;
-    globalThis.v7 = globalThis.jsC.annotatedSetter;
   ''');
   Expect.equals(42, (globalContext["v1"] as JSNumber).toDartInt);
   Expect.equals("method(x);", (globalContext["v2"] as JSString).toDart);
   Expect.equals("Some getter", (globalContext["v3"] as JSString).toDart);
   Expect.equals("setter(false);", log);
 
+  log = "";
+  eval("globalThis.jsC.annotatedSetter = false;");
   Expect.isNull(globalContext["v4"]);
   Expect.isNull(globalContext["v5"]);
   Expect.isNull(globalContext["v6"]);
-  Expect.isNull(globalContext["v7"]);
+  Expect.equals("", log);
 }

--- a/LibTest/js_interop/JSExport/jsExport_A03_t02.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A03_t02.dart
@@ -7,15 +7,18 @@
 /// in the JS object by providing a `name` in the `@JSExport` annotation on the
 /// member.
 ///
-/// @description Checks that the `createJSInteropWrapper` throws if an argument
-/// is a class annotated with  a `@JSExport` annotation with a specified `name`.
+/// @description Checks that if a class is annotated with  a `@JSExport`
+/// annotation with non empty `name`.
 /// @author sgrekhov22@gmail.com
+/// @issue 61084
 
 import 'dart:js_interop';
-import '../../../Utils/expect.dart';
 
 @JSExport("D")
 class C {
+//    ^
+// [analyzer] unspecified
+// [web] unspecified
   int variable = 42;
   String method(String v) => "method($v);";
   String get getter => "Some getter";
@@ -23,8 +26,5 @@ class C {
 }
 
 void main() {
-  var c = C();
-  Expect.throws(() {
-    createJSInteropWrapper<C>(c);
-  });
+  print(C);
 }

--- a/LibTest/js_interop/JSExport/jsExport_A03_t02.dart
+++ b/LibTest/js_interop/JSExport/jsExport_A03_t02.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion By default, the property will have the same name as the
+/// corresponding instance member. You can change the property name of a member
+/// in the JS object by providing a `name` in the `@JSExport` annotation on the
+/// member.
+///
+/// @description Checks that the `createJSInteropWrapper` throws if an argument
+/// is a class annotated with  a `@JSExport` annotation with a specified `name`.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import '../../../Utils/expect.dart';
+
+@JSExport("D")
+class C {
+  int variable = 42;
+  String method(String v) => "method($v);";
+  String get getter => "Some getter";
+  void set setter(bool value) {}
+}
+
+void main() {
+  var c = C();
+  Expect.throws(() {
+    createJSInteropWrapper<C>(c);
+  });
+}


### PR DESCRIPTION
There are some tests in this PR that check the `@JSExport` annotation when applied to extension types and extensions. The current behavior is that this annotation is a no-op when applied to an extension type or extension, and it produces a compile-time error when a member of an extension type or extension is annotated with this annotation. The tests are written accordingly. Please review.