### PR TITLE
#3180. Add `@JS()` annotation tests. Part 2.

### DIFF
--- a/LibTest/js_interop/JS/js_A01_t13.dart
+++ b/LibTest/js_interop/JS/js_A01_t13.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that it is a compile-time error if external member of JS
+/// interop extension type uses non-valid JS interop type.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+
+class C {}
+
+@JS()
+external void f1(C v);
+//            ^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external C f2();
+//         ^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external C var1;
+//         ^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external final C var2;
+//               ^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external C get getter;
+//             ^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external void set setter(C v);
+//                ^^^^^^
+// [analyzer] unspecified
+// [web] unspecified
+
+main() {
+  print(var1);
+  print(var2);
+  print(getter);
+}

--- a/LibTest/js_interop/JS/js_A01_t14.dart
+++ b/LibTest/js_interop/JS/js_A01_t14.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that it is a compile-time error if external member of JS
+/// interop extension type uses non-valid JS interop type.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+
+@JS()
+external int f1<T extends num>(T _);
+//           ^^
+// [analyzer] unspecified
+// [web] unspecified
+
+@JS()
+external T f2<T extends Object>();
+//         ^^
+// [analyzer] unspecified
+// [web] unspecified
+
+main() {
+  f1(0);
+  f2();
+}

--- a/LibTest/js_interop/JS/js_A01_t15.dart
+++ b/LibTest/js_interop/JS/js_A01_t15.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that it is not an error if external JS interop function
+/// has a type parameter.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+@JS()
+external T f1<T extends JSAny>();
+
+@JS()
+external T f2<T extends JSObject>(T _);
+
+main() {
+  eval(r'''
+    globalThis.f1 = function() {return 1;};
+    globalThis.f2 = function(v) {return v;};
+  ''');
+  Expect.equals(1, f1<JSNumber>().toDartInt);
+  Expect.mapEquals(
+      {"a": "b"},
+      f2<JSObject>({"a": "b"}.jsify() as JSObject).dartify()
+  );
+}

--- a/LibTest/js_interop/JS/js_A02_t04.dart
+++ b/LibTest/js_interop/JS/js_A02_t04.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that JS interop extension type may have not-external
+/// members.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+@JS()
+extension type ET1(JSObject _) implements JSObject {
+  external int f1();
+  String f2(int v) => "f2($v)";
+  static String f3() => "f3";
+}
+
+extension type ET2(JSObject _) implements JSObject {
+  external int g1();
+  String g2(int v) => "g2($v)";
+  static String g3() => "g3";
+}
+
+main() {
+  eval(r'''
+    class ET1 {
+      f1() {
+        return 1;
+      }
+    }
+    class ET2 {
+      g1() {
+        return 2;
+      }
+    }
+    globalThis.et1 = new ET1();
+    globalThis.et2 = new ET2();
+  ''');
+  ET1 et1 = ET1(globalContext["et1"] as JSObject);
+  ET2 et2 = ET2(globalContext["et2"] as JSObject);
+  Expect.equals(1, et1.f1());
+  Expect.equals("f2(2)", et1.f2(2));
+  Expect.equals("f3", ET1.f3());
+  Expect.equals(2, et2.g1());
+  Expect.equals("g2(2)", et2.g2(2));
+  Expect.equals("g3", ET2.g3());
+}

--- a/LibTest/js_interop/JS/js_A02_t05.dart
+++ b/LibTest/js_interop/JS/js_A02_t05.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that JS interop extension type may have not-external
+/// members.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+@JS()
+extension type ET1(JSObject _) implements JSObject {
+  external int f1();
+  String f2(int v) => "f2($v)";
+  static String f3() => "f3";
+}
+
+extension type ET2(JSObject _) implements JSObject {
+  external int g1();
+  String g2(int v) => "g2($v)";
+  static String g3() => "g3";
+}
+
+main() {
+  eval(r'''
+    class ET1 {
+      f1() {
+        return 1;
+      }
+      f2() {
+        return "JS f2";
+      }
+      static f3() {
+        return "JS f3";
+      }
+    }
+    class ET2 {
+      g1() {
+        return 2;
+      }
+      g2() {
+        return "JS g2";
+      }
+      static g3() {
+        return "JS g3";
+      }
+    }
+    globalThis.et1 = new ET1();
+    globalThis.et2 = new ET2();
+  ''');
+  ET1 et1 = ET1(globalContext["et1"] as JSObject);
+  ET2 et2 = ET2(globalContext["et2"] as JSObject);
+  Expect.equals(1, et1.f1());
+  Expect.equals("f2(2)", et1.f2(2));
+  Expect.equals("f3", ET1.f3());
+  Expect.equals(2, et2.g1());
+  Expect.equals("g2(2)", et2.g2(2));
+  Expect.equals("g3", ET2.g3());
+}

--- a/LibTest/js_interop/JS/js_A02_t06.dart
+++ b/LibTest/js_interop/JS/js_A02_t06.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that it is a compile-time error if an extension type is
+/// annotated with `@JS()` but its representation type is not a valid JS interop
+/// type.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+
+@JS()
+extension type ET1<T extends JSAny>(T _) implements JSAny {
+//                                  ^
+// [analyzer] unspecified
+// [web] unspecified
+}
+
+@JS()
+extension type ET2(int _) implements num {
+//                 ^^^
+// [analyzer] unspecified
+// [web] unspecified
+}
+
+main() {
+  print(ET1);
+  print(ET2);
+}

--- a/LibTest/js_interop/JS/js_A02_t07.dart
+++ b/LibTest/js_interop/JS/js_A02_t07.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that JS interop extension type may have type parameter.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+@JS()
+extension type ET1<T extends JSAny>(JSObject _) implements JSObject {
+  external T f1();
+}
+
+@JS()
+extension type ET2<T extends JSObject>(JSObject _) implements JSObject {
+  external T g1();
+}
+
+main() {
+  eval(r'''
+    class ET1 {
+      f1() {
+        return 1;
+      }
+    }
+    class ET2 {
+      g1() {
+        return ["two"];
+      }
+    }
+    globalThis.et1 = new ET1();
+    globalThis.et2 = new ET2();
+  ''');
+  ET1<JSNumber> et1 = globalContext["et1"] as ET1<JSNumber>;
+  Expect.equals(1, et1.f1().toDartInt);
+
+  ET2<JSArray> et2 = globalContext["et2"] as ET2<JSArray>;
+  if (isWasm) {
+    var arr = et2.g1().toDart; // List<JSValue?>
+    Expect.equals(1, arr.length);
+    // JSValue cannot be converted to String on Wasm.
+    // Let's check its string representation
+    Expect.equals("two", arr[0].toString());
+  } else {
+    Expect.listEquals(["two"], et2.g1().toDart);
+  }
+}

--- a/LibTest/js_interop/JS/js_A02_t08.dart
+++ b/LibTest/js_interop/JS/js_A02_t08.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion An annotation on a JavaScript interop declaration.
+///
+/// This annotation defines a given library, top-level external declaration, or
+/// extension type as a JavaScript interop declaration.
+///
+/// @description Check that it is a compile-time error if external member of JS
+/// interop extension type uses non-valid JS interop type.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+
+@JS()
+extension type ET1<T extends num>(JSObject _) implements JSObject {
+  external void f1(T _);
+//                 ^
+// [analyzer] unspecified
+// [web] unspecified
+}
+
+extension type ET2<T extends String>(JSObject _) implements JSObject {
+  external T g1();
+//         ^
+// [analyzer] unspecified
+// [web] unspecified
+}
+
+main() {
+  print(ET1);
+  print(ET2);
+}


### PR DESCRIPTION
As usual, the tests in this PR are written under the assumption that the current behavior is intended. If that’s not the case, I assume @srujzs will point it out during the review, and I’ll update the tests accordingly.