### PR TITLE
#3180. Update existing interop tests

### DIFF
--- a/LibTest/js_interop/JS/js_A01_t10.dart
+++ b/LibTest/js_interop/JS/js_A01_t10.dart
@@ -15,16 +15,13 @@
 import 'dart:js_interop';
 
 class C {
-  external int f1();
 }
 
 mixin M {
-  external int f1();
 }
 
 enum E {
   e0;
-  external int f1();
 }
 
 @JS()

--- a/LibTest/js_interop/interop_A01_t12.dart
+++ b/LibTest/js_interop/interop_A01_t12.dart
@@ -11,6 +11,7 @@
 /// @description Check that default values of an external constructor of a JS
 /// interop type are ignored.
 /// @author sgrekhov22@gmail.com
+/// @issue 61289
 
 import 'dart:js_interop';
 import '../../Utils/expect.dart';

--- a/LibTest/js_interop/interop_A07_t02.dart
+++ b/LibTest/js_interop/interop_A07_t02.dart
@@ -13,6 +13,7 @@
 /// @description Check that default values of optional positional parameters
 /// are omitted.
 /// @author sgrekhov22@gmail.com
+/// @issue 61289
 
 import 'dart:js_interop';
 import '../../Utils/expect.dart';

--- a/LibTest/js_interop/staticInterop_A01_t03.dart
+++ b/LibTest/js_interop/staticInterop_A01_t03.dart
@@ -41,9 +41,6 @@ extension Ext on C {
 //        ^^^
 // [analyzer] unspecified
 // [web] unspecified
-  external String getString();
-  external int getNumber();
-  external bool getBool();
 }
 
 main() {


### PR DESCRIPTION
- Removed code that produced unwanted errors (external methods without `@JS` annotation)
- Add issue numbers
- Add runtime checks for the test that has compile-time warnings (no way to catch these warnings now)