### PR TITLE
Fixes #3297. Add tests about redirecting factory constructor inference

### DIFF
--- a/Language/Classes/Constructors/Factories/inference_A01_t01.dart
+++ b/Language/Classes/Constructors/Factories/inference_A01_t01.dart
@@ -7,8 +7,8 @@
 /// otherwise the return type `M<T1,..., Tn>` where `T1,...,Tn` are the type
 /// parameters of the enclosing class.
 ///
-/// @description Checks that return type of the factory constructor can be
-/// inferred.
+/// @description Checks that the redirectee type of the factory constructor can
+/// be inferred.
 /// @author sgrekhov22@gmail.com
 
 import 'inference_lib.dart';

--- a/Language/Classes/Constructors/Factories/inference_A01_t01.dart
+++ b/Language/Classes/Constructors/Factories/inference_A01_t01.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The return type of a factory whose signature is of the form
+/// `factory M` or the form `factory M.id` is `M` if `M` is not a generic type;
+/// otherwise the return type `M<T1,..., Tn>` where `T1,...,Tn` are the type
+/// parameters of the enclosing class.
+///
+/// @description Checks that return type of the factory constructor can be
+/// inferred.
+/// @author sgrekhov22@gmail.com
+
+import 'inference_lib.dart';
+
+void main() {
+  const c1 = C0<String>.ok('data');
+  print(c1);
+
+  const c2 = C0.ok('data');
+  print(c2);
+}

--- a/Language/Classes/Constructors/Factories/inference_lib.dart
+++ b/Language/Classes/Constructors/Factories/inference_lib.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The return type of a factory whose signature is of the form
+/// `factory M` or the form `factory M.id` is `M` if `M` is not a generic type;
+/// otherwise the return type `M<T1,..., Tn>` where `T1,...,Tn` are the type
+/// parameters of the enclosing class.
+/// @author sgrekhov22@gmail.com
+
+sealed class C0<T extends Object> {
+  const C0._();
+  const factory C0.ok(T value) = D._;
+}
+
+class D<T extends Object> extends C0<T> {
+  final T value;
+  const D._(this.value) : super._();
+}


### PR DESCRIPTION
A strange issue. Sometimes the error was disappiering after renaming of the class. No error with the new SDK.