### PR TITLE
#3180. Add tests for `JSPromiseToFuture` and `JSPromiseToFuture`

### DIFF
--- a/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t01.dart
+++ b/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t01.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSPromise<T> get toJS
+/// A [JSPromise] that either resolves with the result of the completed [Future]
+/// or rejects with an object that contains its error.
+///
+/// The rejected object contains the original error as a [JSBoxedDartObject] in
+/// the property `error` and the original stack trace as a [String] in the
+/// property `stack`.
+///
+/// @description Checks that [JSPromise] created by this property completes with
+/// the value with which the [Future] was completed.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+final completer = Completer<String>();
+
+void complete(String value) {
+  completer.complete(value);
+}
+
+main() {
+  globalContext["complete"] = complete.toJS;
+  Future<JSString> future = Future.delayed(Duration(milliseconds: 100), () {
+    return "Success".toJS;
+  });
+  JSPromise promise = future.toJS;
+  globalContext["promise"] = promise;
+  eval(r'''
+    globalThis.promise.then((v) => {
+      globalThis.result = v;
+      globalThis.complete(v);
+    });
+  ''');
+  asyncStart();
+  completer.future.then((_) {
+    Expect.equals("Success", (globalContext["result"] as JSString).toDart);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t02.dart
+++ b/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t02.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSPromise<T> get toJS
+/// A [JSPromise] that either resolves with the result of the completed [Future]
+/// or rejects with an object that contains its error.
+///
+/// The rejected object contains the original error as a [JSBoxedDartObject] in
+/// the property `error` and the original stack trace as a [String] in the
+/// property `stack`.
+///
+/// @description Checks that [JSPromise] created by this property completes with
+/// the value with which the [Future] was completed. Test a [Future] created by
+/// [Future.value] constructor.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+final completer = Completer<String>();
+
+void complete(String value) {
+  completer.complete(value);
+}
+
+main() {
+  globalContext["complete"] = complete.toJS;
+  Future<JSString> future = Future.value("Success".toJS);
+  JSPromise promise = future.toJS;
+  globalContext["promise"] = promise;
+  eval(r'''
+    globalThis.promise.then((v) => {
+      globalThis.result = v;
+      globalThis.complete(v);
+    });
+  ''');
+  asyncStart();
+  completer.future.then((_) {
+    Expect.equals("Success", (globalContext["result"] as JSString).toDart);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t03.dart
+++ b/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A01_t03.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSPromise<T> get toJS
+/// A [JSPromise] that either resolves with the result of the completed [Future]
+/// or rejects with an object that contains its error.
+///
+/// The rejected object contains the original error as a [JSBoxedDartObject] in
+/// the property `error` and the original stack trace as a [String] in the
+/// property `stack`.
+///
+/// @description Checks that if the [Future] completes with an error then
+/// `onRejected` callback of JavaScript `Promise.then()` is called.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+final completer = Completer<String>();
+
+void complete(String value) {
+  completer.complete(value);
+}
+
+main() {
+  globalContext["complete"] = complete.toJS;
+  Future<JSNumber> future = Future.error("The error");
+  JSPromise promise = future.toJS;
+  globalContext["promise"] = promise;
+  eval(r'''
+    globalThis.promise.then((v) => {
+      globalThis.result = "onFulfilled";
+      globalThis.complete("");
+    }, (e) => {
+      globalThis.result = "onRejected";
+      globalThis.complete("");
+    });
+  ''');
+  asyncStart();
+  completer.future.then((_) {
+    Expect.equals("onRejected", (globalContext["result"] as JSString).toDart);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A02_t01.dart
+++ b/LibTest/js_interop/FutureOfJSAnyToJSPromise/toJS_A02_t01.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion JSPromise<T> get toJS
+/// A [JSPromise] that either resolves with the result of the completed [Future]
+/// or rejects with an object that contains its error.
+///
+/// The rejected object contains the original error as a [JSBoxedDartObject] in
+/// the property `error` and the original stack trace as a [String] in the
+/// property `stack`.
+///
+/// @description Checks that if the [Future] completes with an error then the
+/// rejected object contains the original error as a [JSBoxedDartObject] in the
+/// property `error` and the original stack trace as a [String] in the property
+/// `stack`.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+final completer = Completer<String>();
+
+void complete(String value) {
+  completer.complete(value);
+}
+
+extension type Error(JSObject _) implements JSObject {
+  @JS()
+  external JSBoxedDartObject get error;
+  @JS()
+  external String get stack;
+}
+
+main() {
+  globalContext["complete"] = complete.toJS;
+  Future<JSNumber> future = Future.error(
+    "The error",
+    StackTrace.fromString("Stack trace"),
+  );
+  JSPromise promise = future.toJS;
+  globalContext["promise"] = promise;
+  eval(r'''
+    globalThis.promise.then((v) => {
+      globalThis.result = v;
+      globalThis.complete("");
+    }, (e) => {
+      globalThis.error = e;
+      globalThis.complete("");
+    });
+  ''');
+  asyncStart();
+  completer.future.then((_) {
+    Error error = globalContext["error"] as Error;
+    Expect.equals("The error", error.error.toDart);
+    Expect.equals("Stack trace", error.stack);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/JSPromise/promise_t02.dart
+++ b/LibTest/js_interop/JSPromise/promise_t02.dart
@@ -28,7 +28,6 @@ main() {
   ''');
   JSFunction foo = globalContext["foo"] as JSFunction;
   JSPromise<JSString> promise = JSPromise<JSString>(foo);
-  globalContext["promise"] = promise;
   var fp = promise.toDart;
   Expect.isTrue(fp is Future<JSString>);
   asyncStart();

--- a/LibTest/js_interop/JSPromiseToFuture/toDart_t01.dart
+++ b/LibTest/js_interop/JSPromiseToFuture/toDart_t01.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<T> get toDart
+/// A [Future] that either completes with the result of the resolved [JSPromise]
+/// or propagates the error that the [JSPromise] rejected with.
+///
+/// @description Checks that a [Future] returned by this property completes with
+/// the value with which the JS Promise was resolved.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  eval(r'''
+    globalThis.promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve("Success");
+      }, 100);
+    });
+  ''');
+  JSPromise<JSString> promise = globalContext["promise"] as JSPromise<JSString>;
+  Future<JSString> future = promise.toDart;
+  asyncStart();
+  future.then((v) {
+    Expect.equals("Success", v.toDart);
+    asyncEnd();
+  });
+}

--- a/LibTest/js_interop/JSPromiseToFuture/toDart_t02.dart
+++ b/LibTest/js_interop/JSPromiseToFuture/toDart_t02.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<T> get toDart
+/// A [Future] that either completes with the result of the resolved [JSPromise]
+/// or propagates the error that the [JSPromise] rejected with.
+///
+/// @description Checks that a [Future] returned by this property completes with
+/// with an error with which the JS Promise was rejected.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+main() {
+  eval(r'''
+    globalThis.promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject("Reason");
+      }, 100);
+    });
+  ''');
+  JSPromise<JSString> promise = globalContext["promise"] as JSPromise<JSString>;
+  Future<JSString> future = promise.toDart;
+  future.then(
+        (v) {
+      Expect.fail("The feature should be completed with an error");
+    },
+    onError: (e) {
+      Expect.equals("Reason", (e as JSString).toDart);
+      asyncEnd();
+    },
+  );
+}

--- a/LibTest/js_interop/JSPromiseToFuture/toDart_t03.dart
+++ b/LibTest/js_interop/JSPromiseToFuture/toDart_t03.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion Future<T> get toDart
+/// A [Future] that either completes with the result of the resolved [JSPromise]
+/// or propagates the error that the [JSPromise] rejected with.
+///
+/// @description Checks that a [Future] returned by this property completes with
+/// with an error with which the JS Promise was rejected.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../Utils/expect.dart';
+import '../js_utils.dart';
+
+@JS("Error")
+extension type Error(JSObject _) implements JSObject {
+  @JS("toString")
+  external String toDartString();
+}
+
+main() {
+  eval(r'''
+    globalThis.promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error("Something went wrong!"));
+      }, 100);
+    });
+  ''');
+  JSPromise<JSString> promise = globalContext["promise"] as JSPromise<JSString>;
+  Future<JSString> future = promise.toDart;
+  asyncStart();
+  future.then(
+    (v) {
+      Expect.fail("The feature should be completed with an error");
+    },
+    onError: (e) {
+      // JS Error adds "Error:" before the message. Therefore let's check the
+      // end of the string
+      Expect.isTrue(
+        (e as Error).toDartString().endsWith("Something went wrong!"),
+      );
+      asyncEnd();
+    },
+  );
+}


### PR DESCRIPTION
Tests for `FutureOfVoidToJSPromise` will be in a separate PR