### PR TITLE
#2825. Fix async functions call in scope_A06_t02.dart

### DIFF
--- a/LanguageFeatures/Parts-with-imports/scope_A06_t02.dart
+++ b/LanguageFeatures/Parts-with-imports/scope_A06_t02.dart
@@ -29,7 +29,7 @@
 import '../../Utils/expect.dart';
 part 'scope_A06_t02_part1.dart';
 
-main() {
-  testPart1();
-  testPart2();
+main() async {
+  await testPart1();
+  await testPart2();
 }


### PR DESCRIPTION
Both testPart1() and testPart2() are asynchronous functions, and the test must await their completion. Otherwise, it may result in a false-positive outcome when running in browser environments. 