### PR TITLE
#2119. Fix use of `assertStatementsEnabled`

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_constructors_A02_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A02_t05.dart
@@ -65,11 +65,11 @@ main() {
   Expect.equals(1, E.e0.x);
   Expect.equals(2, E.e1.x);
   ET.c1(0);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("1", log);
   }
   ET.c2(0);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("2", log);
   }
 }

--- a/LanguageFeatures/Primary-constructors/static_processing_A06_t02.dart
+++ b/LanguageFeatures/Primary-constructors/static_processing_A06_t02.dart
@@ -62,7 +62,7 @@ extension type ET4({required String x}) {
 main() {
   var et1 = ET1("parameter");
   Expect.equals("parameter", et1.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }
@@ -71,7 +71,7 @@ main() {
 
   var et2 = ET2("parameter");
   Expect.equals("parameter", et2.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }
@@ -80,7 +80,7 @@ main() {
 
   et2 = ET2();
   Expect.equals("default", et2.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }
@@ -89,7 +89,7 @@ main() {
 
   var et3 = ET3(x: "parameter");
   Expect.equals("parameter", et3.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }
@@ -98,7 +98,7 @@ main() {
 
   et3 = ET3();
   Expect.equals("default", et3.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }
@@ -107,7 +107,7 @@ main() {
 
   var et4 = ET4(x: "parameter");
   Expect.equals("parameter", et4.x);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("parameter", log);
     log = "";
   }

--- a/LanguageFeatures/Primary-constructors/static_processing_A24_t01.dart
+++ b/LanguageFeatures/Primary-constructors/static_processing_A24_t01.dart
@@ -60,7 +60,7 @@ main() {
   Expect.equals(-2, C2(2).z);
 
   ET(1);
-  if (assertStatementsEnabled()) {
+  if (assertStatementsEnabled) {
     Expect.equals("1", log);
   }
   Expect.equals(1, E1.e0.x);

--- a/LanguageFeatures/Primary-constructors/static_processing_A25_t01.dart
+++ b/LanguageFeatures/Primary-constructors/static_processing_A25_t01.dart
@@ -59,7 +59,7 @@ extension type ET2(int v) {
     log = "initializer list";
     return true;
   }()) {
-    if (assertStatementsEnabled()) {
+    if (assertStatementsEnabled) {
       Expect.equals("initializer list", log);
     }
     log = "$v";

--- a/LanguageFeatures/Primary-constructors/static_processing_A25_t02.dart
+++ b/LanguageFeatures/Primary-constructors/static_processing_A25_t02.dart
@@ -59,7 +59,7 @@ extension type ET2.someName(int v) {
     log = "initializer list";
     return true;
   }()) {
-    if (assertStatementsEnabled()) {
+    if (assertStatementsEnabled) {
       Expect.equals("initializer list", log);
     }
     log = "$v";


### PR DESCRIPTION
`assertStatementsEnabled` is a final bool variable, not a function