### PR TITLE
#3182. Update assertions in augmenting_types_A02_*.dart

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t01.dart
@@ -13,7 +13,7 @@
 /// a `class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t01_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t01_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t01_lib.dart
@@ -13,7 +13,7 @@
 /// a `class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t01.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t02.dart
@@ -13,7 +13,7 @@
 /// a `base class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t02_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t02_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t02_lib.dart
@@ -13,7 +13,7 @@
 /// a `base class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t02.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t03.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t03.dart
@@ -13,7 +13,7 @@
 /// an `interface class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t03_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t03_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t03_lib.dart
@@ -13,7 +13,7 @@
 /// an `interface class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t03.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t04.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t04.dart
@@ -13,7 +13,7 @@
 /// a `final class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t04_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t04_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t04_lib.dart
@@ -13,7 +13,7 @@
 /// a `final class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t04.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t05.dart
@@ -13,7 +13,7 @@
 /// a `sealed class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t05_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t05_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t05_lib.dart
@@ -13,7 +13,7 @@
 /// a `sealed class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t05.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t06.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t06.dart
@@ -13,7 +13,7 @@
 /// an `abstract class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t06_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t06_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t06_lib.dart
@@ -13,7 +13,7 @@
 /// an `abstract class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t06.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t07.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t07.dart
@@ -13,7 +13,7 @@
 /// an `abstract base class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t07_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t07_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t07_lib.dart
@@ -13,7 +13,7 @@
 /// an `abstract base class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t07.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t08.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t08.dart
@@ -13,7 +13,7 @@
 /// an `abstract interface class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t08_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t08_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t08_lib.dart
@@ -13,7 +13,7 @@
 /// an `abstract interface class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t08.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t09.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t09.dart
@@ -13,7 +13,7 @@
 /// an `abstract final class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t09_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t09_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t09_lib.dart
@@ -13,7 +13,7 @@
 /// an `abstract final class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t09.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t10.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t10.dart
@@ -13,7 +13,7 @@
 /// a `mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t10_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t10_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t10_lib.dart
@@ -13,7 +13,7 @@
 /// a `mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t10.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t11.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t11.dart
@@ -13,7 +13,7 @@
 /// a `base mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t11_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t11_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t11_lib.dart
@@ -13,7 +13,7 @@
 /// a `base mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t11.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t12.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t12.dart
@@ -13,7 +13,7 @@
 /// a `abstract mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t12_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t12_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t12_lib.dart
@@ -13,7 +13,7 @@
 /// a `abstract mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t12.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t13.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t13.dart
@@ -13,7 +13,7 @@
 /// an `abstract base mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t13_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t13_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t13_lib.dart
@@ -13,7 +13,7 @@
 /// an `abstract base mixin class`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t13.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t14.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t14.dart
@@ -13,7 +13,7 @@
 /// a `mixin`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t14_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t14_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t14_lib.dart
@@ -13,7 +13,7 @@
 /// a `mixin`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t14.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t15.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t15.dart
@@ -13,7 +13,7 @@
 /// a `base mixin`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part 'augmenting_types_A02_t15_lib.dart';
 

--- a/LanguageFeatures/Augmentations/augmenting_types_A02_t15_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_types_A02_t15_lib.dart
@@ -13,7 +13,7 @@
 /// a `base mixin`.
 /// @author sgrekhov22@gmail.com
 
-// SharedOptions=--enable-experiment=augmentations
+// SharedOptions=--enable-experiment=augmentations,enhanced-parts
 
 part of 'augmenting_types_A02_t15.dart';
 


### PR DESCRIPTION
To avoid issues caused by the secondary errors each class modifier now is tested separatedly.