### PR TITLE
#3182. Add tests for external js interop functions

### DIFF
--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A01_t01.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A01_t01.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Checks that an external js interop function can be augmented.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+external int f1();
+
+@JS()
+augment int f1();
+
+@JS()
+external int f2(int v);
+
+augment f2(v);
+
+main() {
+  eval(r'''
+    globalThis.f1 = function() {return 1;};
+    globalThis.f2 = function(v) {return v;};
+  ''');
+  Expect.equals(1, f1());
+  Expect.equals(2, f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A01_t02.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A01_t02.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Checks that an abstract function can be augmented by an
+/// external js interop function.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+int f1();
+
+@JS('foo')
+augment external int f1();
+
+@JS('bar')
+int f2(int v);
+
+augment external f2(v);
+
+main() {
+  eval(r'''
+    globalThis.foo = function() {return 1;};
+    globalThis.bar = function(v) {return v;};
+  ''');
+  Expect.equals(1, f1());
+  Expect.equals(2, f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t01.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t01.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type with external methods
+/// can be augmented.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  external int f1();
+  external int f2(int v);
+}
+
+augment extension type ET {
+  augment int f1();
+  augment f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      constructor(x) {
+        this.v = x;
+      }
+      f1() {
+        return this.v;
+      }
+      f2(v) {
+        return v;
+      }
+    }
+    globalThis.et = new ET(1);
+  ''');
+
+  ET et = ET(globalContext["et"] as JSObject);
+  Expect.equals(1, et.f1());
+  Expect.equals(2, et.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t02.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t02.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type can be augmented by the
+/// augmenting declaration with external methods.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  int f1();
+  int f2(int v);
+}
+
+augment extension type ET {
+  augment external int f1();
+  augment external f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      constructor(x) {
+        this.v = x;
+      }
+      f1() {
+        return this.v;
+      }
+      f2(v) {
+        return v;
+      }
+    }
+    globalThis.et = new ET(1);
+  ''');
+
+  ET et = ET(globalContext["et"] as JSObject);
+  Expect.equals(1, et.f1());
+  Expect.equals(2, et.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t03.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t03.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type with external methods
+/// can be augmented.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  external int f1();
+  external int f2(int v);
+}
+
+augment extension type ET {
+  @JS('foo')
+  augment int f1();
+  @JS('bar')
+  augment f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      constructor(x) {
+        this.v = x;
+      }
+      foo() {
+        return this.v;
+      }
+      bar(v) {
+        return v;
+      }
+    }
+    globalThis.et = new ET(1);
+  ''');
+
+  ET et = ET(globalContext["et"] as JSObject);
+  Expect.equals(1, et.f1());
+  Expect.equals(2, et.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t04.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A02_t04.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type can be augmented by the
+/// augmenting declaration with external methods.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  int f1();
+  int f2(int v);
+}
+
+augment extension type ET {
+  @JS('foo')
+  augment external int f1();
+  @JS('bar')
+  augment external f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      constructor(x) {
+        this.v = x;
+      }
+      foo() {
+        return this.v;
+      }      
+      bar(v) {
+        return v;
+      }
+    }
+    globalThis.et = new ET(1);
+  ''');
+
+  ET et = ET(globalContext["et"] as JSObject);
+  Expect.equals(1, et.f1());
+  Expect.equals(2, et.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t01.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t01.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type with external
+/// static methods can be augmented.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  external static int f1();
+  external static int f2(int v);
+}
+
+augment extension type ET {
+  augment static int f1();
+  augment static f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      static f1() {
+        return 1;
+      }
+      static f2(v) {
+        return v;
+      }
+    }
+    globalThis.ET = ET;
+  ''');
+
+  Expect.equals(1, ET.f1());
+  Expect.equals(2, ET.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t02.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t02.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type with static methods can
+/// be augmented by the augmenting declaration with external static methods.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  static int f1();
+  static int f2(int v);
+}
+
+augment extension type ET {
+  augment external static int f1();
+  augment external static f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      static f1() {
+        return 1;
+      }
+      static f2(v) {
+        return v;
+      }
+    }
+    globalThis.ET = ET;
+  ''');
+
+  Expect.equals(1, ET.f1());
+  Expect.equals(2, ET.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t03.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t03.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type with external
+/// static methods can be augmented.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  external static int f1();
+  external static int f2(int v);
+}
+
+augment extension type ET {
+  @JS('foo')
+  augment static int f1();
+  @JS('bar')
+  augment static f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      static foo() {
+        return 1;
+      }
+      static bar(v) {
+        return v;
+      }
+    }
+    globalThis.ET = ET;
+  ''');
+
+  Expect.equals(1, ET.f1());
+  Expect.equals(2, ET.f2(2));
+}

--- a/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t04.dart
+++ b/LanguageFeatures/Augmentations/js_interop/augmenting_functions_A03_t04.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A top-level function, static method, instance method, operator,
+/// getter, or setter may be augmented to provide a body or add metadata.
+///
+/// @description Check that a js interop extension type can be augmented by the
+/// augmenting declaration with external static methods.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import '../../../LibTest/js_interop/js_utils.dart';
+import '../../../Utils/expect.dart';
+
+@JS()
+extension type ET(JSObject _) implements JSObject {
+  static int f1();
+  static int f2(int v);
+}
+
+augment extension type ET {
+  @JS('foo')
+  augment external static int f1();
+  @JS('bar')
+  augment external static f2(v);
+}
+
+main() {
+  eval(r'''
+    class ET {
+      static foo() {
+        return 1;
+      }
+      static bar(v) {
+        return v;
+      }
+    }
+    globalThis.ET = ET;
+  ''');
+
+  Expect.equals(1, ET.f1());
+  Expect.equals(2, ET.f2(2));
+}


### PR DESCRIPTION
These tests checks that external js interop functions can be augmented. In particular they should prove that metadata can be added by an anugmentation and this metadata works. 

Similar tests for variables, getters, setters and class-like declarations will be added later in separate PR's. 

Please review.