### PR TITLE
#3182. Update assertions text

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t02.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t03.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t04.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t04.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t05.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t07.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t07.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t08.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t08.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t09.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t09.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t10.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t10.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t12.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t12.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t13.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t13.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t14.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t14.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t16.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t16.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t16_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t16_lib.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t19.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t19.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t19_part.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t19_part.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t20.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t20.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A01_t21.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A01_t21.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t02.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t03.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t04.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t04.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t05.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t06.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t06.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t07.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t07.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t08.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t08.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t09.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t09.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t10.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t10.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t11.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t11.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t12.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t12.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t13.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t13.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t14.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t14.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t15.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t15.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t16.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t16.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t17.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t17.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t18.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t18.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t19.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t19.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t20.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t20.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t21.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t21.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t22.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t22.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t23.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t23.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t26.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t26.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t26_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t26_lib.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t27.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t27.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t27_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t27_lib.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t28.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t28.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t28_part.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t28_part.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t29.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t29.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t29_part.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t29_part.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_constructors_A10_t30.dart
+++ b/LanguageFeatures/Augmentations/augmenting_constructors_A10_t30.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It is a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t02.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t03.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t04.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t04.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t05.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t06.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t06.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t07.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t07.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t08.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t08.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t09.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t09.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t10.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t10.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t11.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t11.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t12.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t12.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t13.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t13.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t14.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t14.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t15.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t15.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t16.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t16.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t17.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t17.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t18.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t18.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t19.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t19.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t20.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t20.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t21.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t21.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t22.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t22.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t23.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t23.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t23_lib1.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t23_lib1.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t23_lib2.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t23_lib2.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t24.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t24.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t24_lib1.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t24_lib1.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t24_lib2.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t24_lib2.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t25.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t25.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t26.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t26.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t27.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t27.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t28.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t28.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t28_lib.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t28_lib.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t29.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t29.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_functions_A04_t32.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A04_t32.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting function does not match the signature of

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t01.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t02.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t03.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t03.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t04.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t04.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t05.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t05.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t06.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t06.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t07.dart
+++ b/LanguageFeatures/Augmentations/augmenting_variables_getters_setters_A02_t07.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion We say that an augmenting function or constructor's signature
-/// matches if:
+/// matches an introductory signature if:
 /// - It has the same number of type parameters with the same type parameter
 ///   names (same identifiers) and bounds (after type annotation inheritance),
 ///   if any (same types, even if they may not be written exactly the same in
@@ -11,17 +11,15 @@
 ///   prefix).
 /// - The return type (if not omitted) is the same as the augmented
 ///   declaration's return type.
-/// - It has the same number of positional and optional parameters as the
-///   augmented declaration.
+/// - It has the same number of positional parameters as the introductory
+///   declaration, and the same number of those are optional.
 /// - It has the same set of named parameter names as the augmented declaration.
-/// - For all corresponding pairs of parameters:
-///   - They have the same type (if not omitted in the augmenting declaration).
-///   - They have the same `required` and `covariant` modifiers.
-/// - For all positional parameters:
-///   - The augmenting function's parameter name is `_`, or
-///   - The augmenting function's parameter name is the same as the name of the
-///     corresponding positional parameter in every preceding declaration that
-///     doesn't have `_` as its name.
+/// - For each corresponding pair of parameters:
+///   - They have the same name. This is trivial for named parameters, but may
+///     fail to hold for positional parameters.
+///   - They have the same type (or the augmenting declaration omits the type).
+///   - They both have the modifier `covariant`, or none of them have it.
+///   - They both have the modifier `required`. or none of them have it.
 /// ...
 /// It's a compile-time error if:
 /// - The signature of the augmenting getter or setter does not match the

--- a/LanguageFeatures/Augmentations/type_annotation_inheritance_A03_t02.dart
+++ b/LanguageFeatures/Augmentations/type_annotation_inheritance_A03_t02.dart
@@ -19,7 +19,7 @@ abstract class C implements A {
   void set instanceVariable(String _);
 }
 
-augment class C {
+augment abstract class C {
   augment abstract var instanceVariable;
 //                     ^^^^^^^^^^^^^^^^
 // [analyzer] unspecified


### PR DESCRIPTION
This PR ontains change of assertion text according to the updated specification. The only change in the code is a typo fixed in the `type_annotation_inheritance_A03_t02.dart`