### PR TITLE
#3315. Fix tests that use obsolete `var` syntax. Part 19.

### DIFF
--- a/Language/Expressions/Identifier_Reference/undeclared_identifier_t04.dart
+++ b/Language/Expressions/Identifier_Reference/undeclared_identifier_t04.dart
@@ -13,7 +13,7 @@
 import '../../../Utils/expect.dart';
 
 class A {
-  static set bar(var x) {
+  static set bar(x) {
     dynamic o = "";
     try {
       x == o.undeclared;

--- a/LibTest/typed_data/Float32List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float32List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<double> list, bool test(double element)) {
 
 main() {
   var a0 = [1.0, 3.0, 7.0, 4.0, 5.0, 6.0];
-  check(a0, (var element) => element == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4.0);
-  check(a0, (var element) => element < 4.0);
-  check(a0, (var element) => element == 4.0);
+  check(a0, (element) => element == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4.0);
+  check(a0, (element) => element < 4.0);
+  check(a0, (element) => element == 4.0);
 }

--- a/LibTest/typed_data/Float32List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float32List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying test.
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<double> list, bool test(double element)) {
 
 main() {
   var a0=[1.0, 3.0, 7.0, 4.0, 5.0, 6.0];
-  check(a0, (var element) => element == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4.0);
-  check(a0, (var element) => element < 4.0);
-  check(a0, (var element) => element == 4.0);
+  check(a0, (element) => element == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4.0);
+  check(a0, (element) => element < 4.0);
+  check(a0, (element) => element == 4.0);
 }

--- a/LibTest/typed_data/Float32x4List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float32x4List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -48,10 +48,10 @@ void check(List<Float32x4> list, bool test(Float32x4 element)) {
 main() {
   List<Float32x4> a0 =
     [pack(1.0), pack(3.0), pack(7.0), pack(4.0), pack(5.0), pack(6.0)];
-  check(a0, (var element) => element.x == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element.x > 4.0);
-  check(a0, (var element) => element.x < 4.0);
-  check(a0, (var element) => element.x == 4.0);
+  check(a0, (element) => element.x == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element.x > 4.0);
+  check(a0, (element) => element.x < 4.0);
+  check(a0, (element) => element.x == 4.0);
 }

--- a/LibTest/typed_data/Float32x4List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float32x4List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -51,10 +51,10 @@ void check(List<Float32x4> list, bool test(Float32x4 element)) {
 main() {
   List<Float32x4> a0 =
     [pack(1.0), pack(3.0), pack(7.0), pack(4.0), pack(5.0), pack(6.0)];
-  check(a0, (var element) => element.x == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element.x > 4.0);
-  check(a0, (var element) => element.x < 4.0);
-  check(a0, (var element) => element.x == 4.0);
+  check(a0, (element) => element.x == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element.x > 4.0);
+  check(a0, (element) => element.x < 4.0);
+  check(a0, (element) => element.x == 4.0);
 }

--- a/LibTest/typed_data/Float64List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float64List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are removed,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<double> list, bool test(double element)) {
 
 main() {
   var a0 = [1.0, 3.0, 7.0, 4.0, 5.0, 6.0];
-  check(a0, (var element) => element == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4.0);
-  check(a0, (var element) => element < 4.0);
-  check(a0, (var element) => element == 4.0);
+  check(a0, (element) => element == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4.0);
+  check(a0, (element) => element < 4.0);
+  check(a0, (element) => element == 4.0);
 }

--- a/LibTest/typed_data/Float64List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Float64List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<double> list, bool test(double element)) {
 
 main() {
   var a0 = [1.0, 3.0, 7.0, 4.0, 5.0, 6.0];
-  check(a0, (var element) => element == 1.0);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4.0);
-  check(a0, (var element) => element < 4.0);
-  check(a0, (var element) => element == 4.0);
+  check(a0, (element) => element == 1.0);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4.0);
+  check(a0, (element) => element < 4.0);
+  check(a0, (element) => element == 4.0);
 }

--- a/LibTest/typed_data/Int16List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int16List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an Iterable that skips leading elements while test is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are removed,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int16List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int16List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying test.
+///
 /// @description Checks that all first elements that satisfy test are
 /// retained, and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int32List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int32List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are
 /// removed, and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int32List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int32List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0=[1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int64List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int64List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int64List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int64List/takeWhile_A01_t01.dart
@@ -3,13 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
-/// Returns a lazy [Iterable]  of the leading elements satisfying test.
+/// Creates a lazy iterable of the leading elements satisfying `test`.
 ///
-/// that stops once [test] is not satisfied anymore.
-/// @description Checks that all first elements that satisfy test are retained,
+/// The filtering happens lazily. Every new iterator of the returned iterable
+/// starts iterating over the elements of this.
+///
+/// The elements can be computed by stepping through [iterator] until an element
+/// is found where `test(element)` is false. At that point, the returned
+/// iterable stops (its `moveNext()` returns `false`).
+///
+/// @description Checks that all first elements that satisfy `test` are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -45,10 +50,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int64List/takeWhile_A02_t01.dart
+++ b/LibTest/typed_data/Int64List/takeWhile_A02_t01.dart
@@ -3,12 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
-/// ...
-/// The filtering happens lazily.
+/// Creates a lazy iterable of the leading elements satisfying `test`.
+///
+/// The filtering happens lazily. Every new iterator of the returned iterable
+/// starts iterating over the elements of this.
+///
+/// The elements can be computed by stepping through [iterator] until an element
+/// is found where `test(element)` is false. At that point, the returned
+/// iterable stops (its `moveNext()` returns `false`).
+///
 /// @description Checks that [test] is not invoked until returned [Iterable] is
 /// not iterated.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";

--- a/LibTest/typed_data/Int64List/takeWhile_A03_t01.dart
+++ b/LibTest/typed_data/Int64List/takeWhile_A03_t01.dart
@@ -3,13 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
-/// ...
-/// Every new [Iterator] of the returned [Iterable] starts iterating over the
-/// elements of [this].
+/// Creates a lazy iterable of the leading elements satisfying `test`.
+///
+/// The filtering happens lazily. Every new iterator of the returned iterable
+/// starts iterating over the elements of this.
+///
+/// The elements can be computed by stepping through [iterator] until an element
+/// is found where `test(element)` is false. At that point, the returned
+/// iterable stops (its `moveNext()` returns `false`).
+///
 /// @description Checks that every new [Iterator] of the returned [Iterable]
 /// iterates over all elements of [this].
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";

--- a/LibTest/typed_data/Int64List/takeWhile_A04_t01.dart
+++ b/LibTest/typed_data/Int64List/takeWhile_A04_t01.dart
@@ -2,15 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Iterable<E> skipWhile(bool test(E value))
-/// ...
-/// The elements can be computed by stepping through iterator until an element is
-/// found where test(element) is false. At that point, the returned iterable
-/// stops (its moveNext() returns false).
+/// @assertion Iterable<E> takeWhile(bool test(E value))
+/// Creates a lazy iterable of the leading elements satisfying `test`.
+///
+/// The filtering happens lazily. Every new iterator of the returned iterable
+/// starts iterating over the elements of this.
+///
+/// The elements can be computed by stepping through [iterator] until an element
+/// is found where `test(element)` is false. At that point, the returned
+/// iterable stops (its `moveNext()` returns `false`).
+///
 /// @description Checks that once an element does not satisfy the [test] every
 /// later element is skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";

--- a/LibTest/typed_data/Int8List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int8List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are removed,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Int8List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Int8List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying test.
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint16List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint16List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E element))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint16List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint16List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are
 /// retained, and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4 );
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4 );
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint32List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint32List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint32List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint32List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E value))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -42,10 +42,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint64List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint64List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips leading elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint64List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint64List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E vaue))
 /// Returns a lazy [Iterable] of the leading elements satisfying test.
+///
 /// @description Checks that all leading elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint8ClampedList/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint8ClampedList/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E value))
 /// Returns an [Iterable] that skips elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are skipped,
 /// and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint8ClampedList/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint8ClampedList/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E element))
 /// Returns a lazy iterable of the leading elements satisfying [test].
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint8List/skipWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint8List/skipWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> skipWhile(bool test(E element))
 /// Returns an [Iterable] that skips elements while [test] is satisfied.
+///
 /// @description Checks that all first elements that satisfy test are
 /// removed, and elements after that are retained.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -40,10 +40,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }

--- a/LibTest/typed_data/Uint8List/takeWhile_A01_t01.dart
+++ b/LibTest/typed_data/Uint8List/takeWhile_A01_t01.dart
@@ -4,10 +4,10 @@
 
 /// @assertion Iterable<E> takeWhile(bool test(E element))
 /// Returns a lazy [iterable] of the leading elements satisfying test.
+///
 /// @description Checks that all first elements that satisfy test are retained,
 /// and elements after that are skipped.
 /// @author msyabro
-
 
 import "dart:typed_data";
 import "../../../Utils/expect.dart";
@@ -43,10 +43,10 @@ void check(List<int> list, bool test(int element)) {
 
 main() {
   var a0 = [1, 3, 7, 4, 5, 6];
-  check(a0, (var element) => element == 1);
-  check(a0, (var element) => true);
-  check(a0, (var element) => false);
-  check(a0, (var element) => element > 4);
-  check(a0, (var element) => element < 4);
-  check(a0, (var element) => element == 4);
+  check(a0, (element) => element == 1);
+  check(a0, (element) => true);
+  check(a0, (element) => false);
+  check(a0, (element) => element > 4);
+  check(a0, (element) => element < 4);
+  check(a0, (element) => element == 4);
 }


### PR DESCRIPTION
The last part!