### PR TITLE
#3315. Fix tests that use obsolete `var` syntax. Part 20.

### DIFF
--- a/Language/Classes/Abstract_Instance_Members/override_less_positional_parameters_t02.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_less_positional_parameters_t02.dart
@@ -13,16 +13,16 @@
 /// @author iefremov
 
 abstract class A {
-  f([var x, var y, var z]);
+  f([x, y, z]);
 }
 
 class C extends A {
-  f([var x, var y]) {}
+  f([x, y]) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new C().f(1, 2);
+  print(C);
 }

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t01.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t01.dart
@@ -6,25 +6,24 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that a compile error is produced when the overriding
 /// abstract method has fewer named parameters than the instance method being
 /// overridden (2 vs 3) and neither have any required parameters.
 /// @author rodionov
 
-
 class A {
-  f({var x, var y, var z}) {}
+  f({x, y, z}) {}
 }
 
 class C extends A {
-  f({var x, var z});
+  f({x, z});
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(x: 1, y: 2, z: 3);
-
-  new C().f(x: 1, z: 2);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t02.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t02.dart
@@ -6,18 +6,18 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that a compile error is not produced when the overriding
 /// non-abstract instance method has more named parameters than the abstract
 /// method being overridden and neither have any required parameters.
 /// @author rodionov
 
-
 abstract class A {
-  f({var x, var z});
+  f({x, z});
 }
 
 class C extends A {
-  f({var x, var y, var z}) {}
+  f({x, y, z}) {}
 }
 
 main() {

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t04.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t04.dart
@@ -6,23 +6,24 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that no compile error is produced when the overriding
 /// abstract method has the same set of named parameters as the non-abstract
-/// instance method being overriden, but in a different order.
+/// instance method being overridden, but in a different order.
 /// @author rodionov
 
 import "../../../Utils/expect.dart";
 
 class A {
-  f({var x, var y}) { return x+y; }
+  f({x, y}) => x + y;
 }
 
 abstract class C extends A {
-  f({var y, var x});
+  f({y, x});
 }
 
 class D extends C {
-  f({var x, var y}) { return x-y; }
+  f({x, y}) => x - y;
 }
 
 main() {

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t05.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t05.dart
@@ -6,26 +6,24 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that a compile error is produced when the overriding
 /// non-abstract instance method has fewer named parameters than the abstract
 /// method being overridden.
 /// @author rodionov
 
-
 abstract class A {
-  f({var x, var y, var z});
+  f({x, y, z});
 }
 
 class C extends A {
-  f({var x, var z}) {}
+  f({x, z}) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  A c = new C();
-  c.f(x: 1, z: 2);
-
-  c.f(x: 1, y: 2, z: 3);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t06.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t06.dart
@@ -6,28 +6,24 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that a compile error is produced when the overriding
 /// instance method has almost the same set of named parameters as the abstract
 /// method being overriden, except for one that has a different name.
 /// @author rodionov
 
-
 abstract class A {
-  f({var x, var y, var z});
+  f({x, y, z});
 }
 
 class C extends A {
-  f({var x, var yy, var z}) {}
+  f({x, yy, z}) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  C c = new C();
-  A a = c;
-
-  a.f(x: 1, y: 2, z: 3);
-
-  c.f(x: 1, yy: 2, z: 3);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t07.dart
+++ b/Language/Classes/Abstract_Instance_Members/override_no_named_parameters_t07.dart
@@ -6,24 +6,25 @@
 /// to methods apply to abstract methods.
 /// It is a compile error if an instance method m1 overrides an instance member
 /// m2 and m1 does not declare all the named parameters declared by m2.
+///
 /// @description Checks that a compile error is produced when the overriding
 /// abstract method has fewer named parameters than the instance method being
 /// overridden (2 vs 3) and neither have any required parameters. Test type alias
 /// @author sgrekhov@unipro.ru
 
 class A {
-  f({var x, var y, var z}) {}
+  f({x, y, z}) {}
 }
 typedef AAlias = A;
 
 class C extends AAlias {
-  f({var x, var z});
+  f({x, z});
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(x: 1, y: 2, z: 3);
-  new C().f(x: 1, z: 2);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Constructors/Constant_Constructors/syntax_t01.dart
+++ b/Language/Classes/Constructors/Constant_Constructors/syntax_t01.dart
@@ -9,12 +9,11 @@
 /// @description Checks various correct constant constructor signatures.
 /// @author iefremov
 
-
 class A<T> {
   const A();
   const A.$();
   const A.abyrvalg();
-  const A.abrakadabra(T t, var x, [String o = "", var p]);
+  const A.abrakadabra(T t, x, [String o = "", p]);
 }
 
 main() {

--- a/Language/Classes/Constructors/Generative_Constructors/formal_parameter_t08.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/formal_parameter_t08.dart
@@ -7,20 +7,18 @@
 /// id is the name of an instance variable of the immediately enclosing class.
 /// It is a compile-time error if id is not the name of an instance variable of
 /// the immediately enclosing class.
+///
 /// @description Checks that it is a compile-time error if formal parameter of
 /// a constructor is declared as a constant variable.
 /// @author msyabro
 
-
 class C {
-  C.formal(p1, var p2, int p3, final p4, const p5, $()) {}
-//                                       ^^^^^
+  C.formal(p1, int p2, const p3, $()) {}
+//                     ^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
-dynamic testme() => null;
-
 main() {
-  new C.formal(1, 2, 3, 4, 5, testme);
+  print(C);
 }

--- a/Language/Classes/Constructors/Generative_Constructors/syntax_t01.dart
+++ b/Language/Classes/Constructors/Generative_Constructors/syntax_t01.dart
@@ -5,16 +5,15 @@
 /// @assertion constructorSignature:
 ///   identifier (‘.’ identifier)? formalParameterList
 /// ;
+///
 /// @description Checks valid constructor declarations.
 /// @author vasya
 
-
 class C {
-  C(String s, var x, [Object? o, var z = const []]);
+  C(String s, x, [Object? o, z = const []]);
   C.c1();
-  C.c2(String s, var x, [Object? o, var z = const []]) {}
+  C.c2(String s, x, [Object? o, z = const []]) {}
 }
-
 
 main() {
   new C("", null, 1);

--- a/Language/Classes/Instance_Methods/Operators/arity_0_t02.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_0_t02.dart
@@ -10,7 +10,7 @@
 /// @author vasya
 
 class C {
-  operator ~(var v) {}
+  operator ~(v) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t02.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t02.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator <(var val, var val2) {}
+  operator <(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t03.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t03.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator >(var val, var val2) {}
+  operator >(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t08.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t08.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator ~/(var val, var val2) {}
+  operator ~/(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t09.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t09.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator /(var val, var val2) {}
+  operator /(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t11.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t11.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator %(var val, var val2) {}
+  operator %(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t12.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t12.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator &(var val, var val2) {}
+  operator &(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t13.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t13.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator <<(var val, var val2) {}
+  operator <<(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t14.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t14.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator >>(var val, var val2) {}
+  operator >>(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t15.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t15.dart
@@ -11,7 +11,7 @@
 /// @author vasya
 
 class C {
-  operator [](var index, var val) {}
+  operator [](index, val) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t17.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t17.dart
@@ -11,7 +11,7 @@
 /// @author iefremov
 
 class C {
-  operator |(var val, var val2) {}
+  operator |(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t18.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t18.dart
@@ -11,7 +11,7 @@
 /// @author iefremov
 
 class C {
-  operator ^(var val, var val2) {}
+  operator ^(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/Operators/arity_1_t19.dart
+++ b/Language/Classes/Instance_Methods/Operators/arity_1_t19.dart
@@ -12,7 +12,7 @@
 /// @issue 42353
 
 class C {
-  operator >>>(var val, var val2) {}
+  operator >>>(val, val2) {}
 //         ^
 // [analyzer] unspecified
 // [cfe] unspecified

--- a/Language/Classes/Instance_Methods/override_fewer_parameters_t02.dart
+++ b/Language/Classes/Instance_Methods/override_fewer_parameters_t02.dart
@@ -11,17 +11,17 @@
 /// @author vasya
 
 class A {
-  f([var x, var y, var z]) {}
+  f([x, y, z]) {}
 }
 
 class C extends A {
-  f([var x, var y]) {}
+  f([x, y]) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(1, 2, 3);
-  new C().f(1, 2);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/override_fewer_parameters_t03.dart
+++ b/Language/Classes/Instance_Methods/override_fewer_parameters_t03.dart
@@ -11,19 +11,19 @@
 /// @author sgrekhov@unipro.ru
 
 class A {
-  f([var x, var y, var z]) {}
+  f([x, y, z]) {}
 }
 
 typedef AAlias = A;
 
 class C extends AAlias {
-  f([var x, var y]) {}
+  f([x, y]) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(1, 2, 3);
-  new C().f(1, 2);
+  print(A);
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t03.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t03.dart
@@ -11,13 +11,13 @@
 /// @author iefremov
 
 class A {
-  f({var x, var y}) {
+  f({x, y}) {
     return x + y;
   }
 }
 
 class C extends A {
-  f({var y, var x}) {
+  f({y, x}) {
     return x + y;
   }
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t04.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t04.dart
@@ -11,13 +11,13 @@
 /// @author iefremov
 
 class A {
-  f({var x1, var x2, var y1, var y2}) {
+  f({x1, x2, y1, y2}) {
     return '$x1$y2';
   }
 }
 
 class C extends A {
-  f({var x1, var x2, var y2, var y1}) {
+  f({x1, x2, y2, y1}) {
     return '$x1$y2';
   }
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t05.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t05.dart
@@ -12,17 +12,16 @@
 /// @author rodionov
 
 class A {
-  f({var x, var y, var z}) {}
+  f({x, y, z}) {}
 }
 
 class C extends A {
-  f({var x, var y, var zz}) {}
+  f({x, y, zz}) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(x:"Nothing", y:"endures", z:"but");
-  new C().f(x:"Nothing", y:"endures", zz:"but");
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t06.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t06.dart
@@ -12,7 +12,7 @@
 /// @author iefremov
 
 class A {
-  f({var x, var y}) {
+  f({x, y}) {
     return x + y;
   }
 }
@@ -24,7 +24,7 @@ class A2 extends A1 {}
 class A3 extends A2 {}
 
 class C extends A3 {
-  f({var y, var x}) {
+  f({y, x}) {
     return x + y;
   }
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t09.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t09.dart
@@ -11,14 +11,14 @@
 /// @author sgrekhov@unipro.ru
 
 class A {
-  f({var x, var y}) {
+  f({x, y}) {
     return x + y;
   }
 }
 typedef AAlias = A;
 
 class C extends AAlias {
-  f({var y, var x}) {
+  f({y, x}) {
     return x + y;
   }
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t10.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t10.dart
@@ -12,19 +12,18 @@
 /// @author sgrekhov@unipro.ru
 
 class A {
-  f({var x, var y, var z}) {}
+  f({x, y, z}) {}
 }
 
 typedef AAlias = A;
 
 class C extends AAlias {
-  f({var x, var y, var zz}) {}
+  f({x, y, zz}) {}
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
 }
 
 main() {
-  new A().f(x: "Lily", y: "was", z: "here");
-  new C().f(x:"Lily", y:"was", zz:"here");
+  print(C);
 }

--- a/Language/Classes/Instance_Methods/override_named_parameters_t11.dart
+++ b/Language/Classes/Instance_Methods/override_named_parameters_t11.dart
@@ -13,7 +13,7 @@
 /// @author sgrekhov@unipro.ru
 
 class A {
-  f({var x, var y}) { return x + y; }
+  f({x, y}) => x + y;
 }
 typedef AAlias = A;
 
@@ -25,7 +25,7 @@ class A3 extends A2Alias{}
 typedef A3Alias = A3;
 
 class C extends A3Alias {
-  f({var y, var x}) { return x + y; }
+  f({y, x}) => x + y;
 }
 
 main() {


### PR DESCRIPTION
Another bunch found.