### PR TITLE
Fixes #3730. Fix co19 tests according to Dart 3.13 syntax

### DIFF
--- a/Language/Classes/Constructors/Factories/name_t01.dart
+++ b/Language/Classes/Constructors/Factories/name_t01.dart
@@ -18,6 +18,8 @@
 /// keyword is followed by a name that is not a constructor name.
 /// @author rodionov
 
+// @dart=3.12
+
 class C {
   C();
   factory WrongClass() => C();

--- a/Language/Classes/Constructors/Factories/name_t03.dart
+++ b/Language/Classes/Constructors/Factories/name_t03.dart
@@ -18,6 +18,8 @@
 /// a superinterface of the enclosing class.
 /// @author rodionov
 
+// @dart=3.12
+
 class S {}
 
 class C extends S {

--- a/Language/Classes/Constructors/Factories/name_t04.dart
+++ b/Language/Classes/Constructors/Factories/name_t04.dart
@@ -18,6 +18,8 @@
 /// function type alias available in the same scope.
 /// @author rodionov
 
+// @dart=3.12
+
 typedef foo();
 
 class C {

--- a/Language/Classes/Constructors/Factories/name_t05.dart
+++ b/Language/Classes/Constructors/Factories/name_t05.dart
@@ -18,6 +18,8 @@
 /// unrelated class available in the same scope.
 /// @author iefremov
 
+// @dart=3.12
+
 class Z {}
 
 class C {

--- a/Language/Classes/Constructors/Factories/name_t06.dart
+++ b/Language/Classes/Constructors/Factories/name_t06.dart
@@ -18,6 +18,8 @@
 /// type alias.
 /// @author sgrekhov@unipro.ru
 
+// @dart=3.12
+
 class S {}
 typedef SAlias = S;
 

--- a/Language/Classes/Constructors/Factories/name_t07.dart
+++ b/Language/Classes/Constructors/Factories/name_t07.dart
@@ -18,6 +18,8 @@
 /// type alias.
 /// @author sgrekhov@unipro.ru
 
+// @dart=3.12
+
 class C {
   factory CAlias() => throw "Should not reach here";
 //        ^^^^^^

--- a/Language/Generics/typedef_A01_t03.dart
+++ b/Language/Generics/typedef_A01_t03.dart
@@ -15,12 +15,12 @@
 /// @author iarkh@unipro.ru
 
 class A() {}
-//        ^
-// [analyzer] unspecified
-// [cfe] unspecified
+
 class C<T> {}
+
 @A()  typedef CAlias<T> = C<T>;
 //^
 // [analyzer] unspecified
 // [cfe] unspecified
+
 main() {}

--- a/Language/Variables/syntax_t16.dart
+++ b/Language/Variables/syntax_t16.dart
@@ -26,10 +26,10 @@
 ///   initializedIdentifierList:
 ///     initializedIdentifier (‘, ’ initializedIdentifier)*
 ///   ;
+///
 /// @description Checks that a variable declaration cannot contain the 
 /// 'factory' keyword.
 /// @author kaigorodov
-
 
 class C {
   factory var x = 1;
@@ -39,7 +39,5 @@ class C {
 }
 
 main() {
-  new C();
-//    ^
-// [cfe] unspecified
+  print(C);
 }

--- a/LanguageFeatures/Extension-types/syntax_A05_t02.dart
+++ b/LanguageFeatures/Extension-types/syntax_A05_t02.dart
@@ -23,6 +23,8 @@
 /// `representationDeclaration` declares any optional or named variables
 /// @author sgrekhov22@gmail.com
 
+// @dart=3.12
+
 extension type ET1([int id = 0]) {}
 //                 ^
 // [analyzer] unspecified

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_List_A02_t02.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_List_A02_t02.dart
@@ -20,7 +20,6 @@
 /// result list in correct order.
 /// @author iarkh@unipro.ru
 
-
 import "dart:collection";
 import "../../Utils/expect.dart";
 
@@ -51,7 +50,7 @@ List myLists = [[1, 2, 3, 4, 5],
   []];
 
 main() {
-  myLists.forEach((var list) {
+  myLists.forEach((list) {
     MyIterable it = new MyIterable(list);
     Expect.listEquals(list, [...it]);
     Expect.isFalse(it.getIterator().moveNext());

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_List_A02_t03.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_List_A02_t03.dart
@@ -20,7 +20,6 @@
 /// to the result list in correct order if this spread element is not [null].
 /// @author iarkh@unipro.ru
 
-
 import "dart:collection";
 import "../../Utils/expect.dart";
 
@@ -53,7 +52,7 @@ List myLists = [[1, 2, 3, 4, 5],
   []];
 
 main() {
-  myLists.forEach((var list) {
+  myLists.forEach((list) {
     MyIterable it = new MyIterable(list);
     Expect.listEquals(list, [...?(it as Iterable?)]);
     Expect.isFalse(it.getIterator().moveNext());

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_Map_A02_t02.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_Map_A02_t02.dart
@@ -18,10 +18,10 @@
 ///       a. Evaluate [e1] to a value key.
 ///       b. Evaluate [e2] to a value value.
 ///       c. Call map[key] = value.
+///
 /// @description Checks that elements in the spread element are added to the
 /// result map
 /// @author iarkh@unipro.ru
-
 
 import "dart:collection";
 import "../../Utils/expect.dart";
@@ -45,7 +45,7 @@ List myMaps = <Map>[{1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
   {}];
 
 main() {
-  myMaps.forEach((var m) {
+  myMaps.forEach((m) {
     Map map = new MapBaseImpl.from(m);
     Expect.mapEquals(m, {...map});
   });

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_Map_A02_t03.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_Map_A02_t03.dart
@@ -18,6 +18,7 @@
 ///       a. Evaluate [e1] to a value key.
 ///       b. Evaluate [e2] to a value value.
 ///       c. Call map[key] = value.
+///
 /// @description Checks that elements in the null-aware spread element are added
 /// to the result map if the element is not [null]
 /// @author iarkh@unipro.ru
@@ -44,7 +45,7 @@ List myMaps = <Map>[{1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
   {}];
 
 main() {
-  myMaps.forEach((var m) {
+  myMaps.forEach((m) {
     var map = new MapBaseImpl.from(m) as Map?;
     Expect.mapEquals(m, {...?map});
   });

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_Set_A02_t02.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_Set_A02_t02.dart
@@ -14,10 +14,10 @@
 ///             b. Evaluate set.add(iterator.current).
 ///       iii. Else:
 ///           a. Evaluate [set.add(value)].
+///
 /// @description Checks that elements in the spread element are added to the
 /// result set in correct order.
 /// @author iarkh@unipro.ru
-
 
 import "dart:collection";
 import "../../Utils/expect.dart";
@@ -51,7 +51,7 @@ List mySets = [{1, 2, 3, 4, 5},
   ];
 
 main() {
-  mySets.forEach((var set) {
+  mySets.forEach((set) {
     MyIterable it = new MyIterable(set);
     Expect.setEquals(set, {...it});
     Expect.isFalse(it.getIterator().moveNext());

--- a/LanguageFeatures/Spread-collections/DynamicSemantics_Set_A02_t03.dart
+++ b/LanguageFeatures/Spread-collections/DynamicSemantics_Set_A02_t03.dart
@@ -14,6 +14,7 @@
 ///             b. Evaluate set.add(iterator.current).
 ///       iii. Else:
 ///           a. Evaluate [set.add(value)].
+///
 /// @description Checks that elements in the null-aware spread element are added
 /// to the result set in correct order if this spread element is not [null].
 /// @author iarkh@unipro.ru
@@ -49,7 +50,7 @@ List mySets = [{1, 2, 3, 4, 5},
     {1, 2, 3, 4, 5, 6, 7, 8, 9}];
 
 main() {
-  mySets.forEach((var set) {
+  mySets.forEach((set) {
     var it = new MyIterable(set) as MyIterable?;
     Expect.setEquals(set, {...?it});
     Expect.isFalse((it as MyIterable).getIterator().moveNext());

--- a/LanguageFeatures/nnbd/syntax_A05_t01.dart
+++ b/LanguageFeatures/nnbd/syntax_A05_t01.dart
@@ -17,10 +17,10 @@ class A {}
 
 class C {
   static String staticTest1({required String x}) => x;
-  static String staticTest2({required final x}) => x;
+  static String staticTest2({required x}) => x;
   String instanceTest1({required String x}) => x;
   A instanceTest2({required covariant A x}) => x;
-  String instanceTest3({required final x}) => x;
+  String instanceTest3({required x}) => x;
 }
 
 String test1({required String x}) => x;
@@ -31,7 +31,7 @@ Foo test2 = ({required String x}) => x;
 
 Function test3 = ({required String x}) => x;
 
-String test4({required final x}) => x;
+String test4({required x}) => x;
 
 main() {
   A a = new A();

--- a/LanguageFeatures/nnbd/syntax_A05_t02.dart
+++ b/LanguageFeatures/nnbd/syntax_A05_t02.dart
@@ -17,10 +17,10 @@ class A {}
 
 class C {
   static String staticTest1(int i, {required String x, String y = ""}) => x;
-  static String staticTest2(int i, {required final x, String y = ""}) => x;
+  static String staticTest2(int i, {required x, String y = ""}) => x;
   String instanceTest1(int i, {required String x, String y = ""}) => x;
   A instanceTest2(int i, {required covariant A x, String y = ""}) => x;
-  String instanceTest3(int i, {required final x, String y = ""}) => x;
+  String instanceTest3(int i, {required x, String y = ""}) => x;
 }
 
 String test1(int i, {required String x, String y = ""}) => x;
@@ -31,7 +31,7 @@ Foo test2 = (int i, {required String x, String y = ""}) => x;
 
 Function test3 = (int i, {required String x, String y = ""}) => x;
 
-String test4(int i, {required final x, String y = ""}) => x;
+String test4(int i, {required x, String y = ""}) => x;
 
 main() {
   A a = new A();

--- a/LanguageFeatures/nnbd/syntax_A05_t03.dart
+++ b/LanguageFeatures/nnbd/syntax_A05_t03.dart
@@ -18,10 +18,10 @@ class A {}
 
 class C {
   static String staticTest1(int i, {String y = "", required String x}) => x;
-  static String staticTest2(int i, {String y = "", required final x}) => x;
+  static String staticTest2(int i, {String y = "", required x}) => x;
   String instanceTest1(int i, {String y = "", required String x}) => x;
   A instanceTest2(int i, {String y = "", required covariant A x}) => x;
-  String instanceTest3(int i, {String y = "", required final x}) => x;
+  String instanceTest3(int i, {String y = "", required x}) => x;
 }
 
 String test1(int i, {String y = "", required String x}) => x;
@@ -32,7 +32,7 @@ Foo test2 = (int i, {String y = "", required String x}) => x;
 
 Function test3 = (int i, {String y = "", required String x}) => x;
 
-String test4(int i, {String y = "", required final x}) => x;
+String test4(int i, {String y = "", required x}) => x;
 
 main() {
   A a = new A();

--- a/LibTest/collection/LinkedHashSet/iterator_A01_t02.dart
+++ b/LibTest/collection/LinkedHashSet/iterator_A01_t02.dart
@@ -5,16 +5,17 @@
 /// @assertion
 /// Iterator<E> iterator
 /// Provides an iterator that iterates over the elements in insertion order.
+///
 /// @description Checks that [Iterator] iterates over all elements from the set
 /// in insertion mode.
 /// @author iarkh@unipro.ru
 
-import "../../../Utils/expect.dart";
 import "dart:collection";
+import "../../../Utils/expect.dart";
 
 void checkIterator(LinkedHashSet set, List list) {
   Iterator it = set.iterator;
-  list.forEach((var element) {
+  list.forEach((element) {
     it.moveNext();
     Expect.equals(element, it.current);
   });


### PR DESCRIPTION
Some tests fixed, for some `dart=3.12` version is added. These tests will test the old functionality and I'll add new tests for Primary constructors feature that will test the new syntax.