### PR TITLE
Fixes #3226. Update `Expect.equals()` to fail on two NaN.

### DIFF
--- a/LibTest/core/double/clamp_A01_t04.dart
+++ b/LibTest/core/double/clamp_A01_t04.dart
@@ -6,6 +6,7 @@
 /// Returns this num clamped to be in the range lowerLimit-upperLimit.
 /// The comparison is done using compareTo and therefore takes -0.0 into account.
 /// This also implies that double.nan is treated as the maximal double value.
+///
 /// @description Checks that returns num clamped to be in the range
 /// lowerLimit-upperLimit, where one of the limits is double.nan
 /// @author sgrekhov@unipro.ru
@@ -13,7 +14,7 @@
 import "../../../Utils/expect.dart";
 
 check(num expected, num lowerLimit, num upperLimit, num value) {
-  Expect.equals(expected, value.clamp(lowerLimit, upperLimit));
+  Expect.equalsOrNaN(expected, value.clamp(lowerLimit, upperLimit));
 }
 
 main() {

--- a/LibTest/core/int/clamp_A01_t04.dart
+++ b/LibTest/core/int/clamp_A01_t04.dart
@@ -13,7 +13,7 @@
 import "../../../Utils/expect.dart";
 
 check(num expected, num lowerLimit, num upperLimit, num value) {
-  Expect.equals(expected, value.clamp(lowerLimit, upperLimit));
+  Expect.equalsOrNaN(expected, value.clamp(lowerLimit, upperLimit));
 }
 
 main() {

--- a/LibTest/isolate/Isolate/addOnExitListener_A01_t02.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A01_t02.dart
@@ -13,7 +13,6 @@
 ///
 /// @description Check that isolate sends given response value on responsePort,
 /// when it terminates.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";
@@ -27,7 +26,7 @@ Future test(Object? value) async {
   onExit.listen(
     (data) {
       onExit.close();
-      Expect.equals(value, data);
+      Expect.equalsOrNaN(value, data);
     }
   );
   server.isolate.addOnExitListener(onExit.sendPort, response: value);

--- a/LibTest/isolate/Isolate/addOnExitListener_A01_t03.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A01_t03.dart
@@ -13,7 +13,6 @@
 ///
 /// @description Check that isolate sends event on responsePort,
 /// when it terminates with error. Parameter response is not specified.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";

--- a/LibTest/isolate/Isolate/addOnExitListener_A01_t04.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A01_t04.dart
@@ -13,7 +13,6 @@
 ///
 /// @description Check that isolate sends given response value on responsePort,
 /// when it terminates with error.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";
@@ -27,7 +26,7 @@ Future test(Object? value) async {
   onExit.listen(
     (data) {
       onExit.close();
-      Expect.equals(value, data);
+      Expect.equalsOrNaN(value, data);
     }
   );
   server.isolate.addOnExitListener(onExit.sendPort, response:value);

--- a/LibTest/isolate/Isolate/addOnExitListener_A01_t05.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A01_t05.dart
@@ -13,7 +13,6 @@
 ///
 /// @description Check that several listeners can be added and each receive
 /// given response when isolate terminates.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";

--- a/LibTest/isolate/Isolate/addOnExitListener_A02_t02.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A02_t02.dart
@@ -13,7 +13,6 @@
 /// @description Check that isolate sends single event on responsePort,
 /// which is supplied several times to addOnExitListener() of the same isolate.
 /// Always the same value for parameter response is specified.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";

--- a/LibTest/isolate/Isolate/addOnExitListener_A02_t03.dart
+++ b/LibTest/isolate/Isolate/addOnExitListener_A02_t03.dart
@@ -14,7 +14,6 @@
 /// which is supplied several times to addOnExitListener() of the same isolate.
 /// Different values for parameter response are specified. Check that only last
 /// used value is used.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";

--- a/LibTest/isolate/Isolate/ping_A01_t02.dart
+++ b/LibTest/isolate/Isolate/ping_A01_t02.dart
@@ -13,7 +13,6 @@
 ///
 /// @description Check various values for response argument in ping().
 /// The isolate is continuously running. Priority is default.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";
@@ -41,7 +40,7 @@ Future test(List<Object?> values) async {
   for (Object? value in values) {
     ReceivePort pingPort = new ReceivePort();
     isolate.ping(pingPort.sendPort, response:value);
-    Expect.equals(value, await pingPort.first);
+    Expect.equalsOrNaN(value, await pingPort.first);
   }
   // clean up
   isolate.kill(priority:Isolate.immediate);

--- a/LibTest/isolate/Isolate/ping_A02_t02.dart
+++ b/LibTest/isolate/Isolate/ping_A02_t02.dart
@@ -25,7 +25,6 @@
 /// @description Check various values for response argument in ping() call with
 /// given response port and priority IMMEDIATE. The isolate is continuously
 /// running.
-///
 /// @author a.semenov@unipro.ru
 
 import "dart:isolate";
@@ -53,7 +52,7 @@ Future test(List<Object?> values) async {
   for (Object? value in values) {
     ReceivePort pingPort = new ReceivePort();
     isolate.ping(pingPort.sendPort, response:value, priority:Isolate.immediate);
-    Expect.equals(value, await pingPort.first);
+    Expect.equalsOrNaN(value, await pingPort.first);
   }
   // clean up
   isolate.kill(priority:Isolate.immediate);

--- a/LibTest/isolate/SendPort/send_A01_t01.dart
+++ b/LibTest/isolate/SendPort/send_A01_t01.dart
@@ -10,7 +10,6 @@
 /// of these. List and maps are also allowed to be cyclic.
 ///
 /// @description Checks that various primitive values are sent properly.
-///
 /// @author kaigorodov
 
 import "dart:isolate";
@@ -28,7 +27,7 @@ main() {
   var receivePort = new ReceivePort();
   int i = 0;
   receivePort.listen((message) {
-    Expect.equals(messagesList[i], message);
+    Expect.equalsOrNaN(messagesList[i], message);
     i++;
     if (i == messagesList.length) {
       receivePort.close();

--- a/LibTest/typed_data/Float64x2/sqrt_A01_t01.dart
+++ b/LibTest/typed_data/Float64x2/sqrt_A01_t01.dart
@@ -4,9 +4,9 @@
 
 /// @assertion  Float64x2 sqrt()
 /// Returns the lane-wise square root of this.
+///
 /// @description Checks that the returned value is correct.
 /// @author ngl@unipro.ru
-
 
 import "dart:typed_data";
 import "dart:math";
@@ -14,8 +14,8 @@ import "../../../Utils/expect.dart";
 
 check(obj) {
   var res = obj.sqrt();
-  Expect.equals(sqrt(obj.x), res.x);
-  Expect.equals(sqrt(obj.y), res.y);
+  Expect.equalsOrNaN(sqrt(obj.x), res.x);
+  Expect.equalsOrNaN(sqrt(obj.y), res.y);
 }
 
 main() {

--- a/Utils/expect_common.dart
+++ b/Utils/expect_common.dart
@@ -7,6 +7,15 @@ part of 'expect.dart';
 class Expect {
   /// Checks whether the expected and actual values are equal using `==`.
   static void equals(expected, actual, [String reason = '']) {
+    if (expected != actual) {
+      _fail('Expect.equals(expected: <$expected>, actual: <$actual>$reason) '
+          'fails.');
+    }
+  }
+
+  /// Checks whether the expected and actual values are equal using `==`.
+  /// Two `nan` values are assumed to be equal.
+  static void equalsOrNaN(expected, actual, [String reason = '']) {
     if ((expected != actual) &&
         !((expected is double) &&
             (actual is double) &&
@@ -20,14 +29,14 @@ class Expect {
   /// Checks whether the actual value is [bool] and its value is [true].
   static void isTrue(actual, [String reason = '']) {
     if (!_identical(actual, true)) {
-      _fail('Expect.isTrue($actual$reason) fails.');
+      _fail('Expect.isTrue(<$actual>$reason) fails.');
     }
   }
 
   /// Checks whether the actual value is [bool] and its value is [false].
   static void isFalse(actual, [String reason = '']) {
     if (!_identical(actual, false)) {
-      _fail('Expect.isFalse($actual$reason) fails.');
+      _fail('Expect.isFalse(<$actual>$reason) fails.');
     }
   }
 
@@ -279,13 +288,13 @@ class Expect {
         var savedActual = planned[expected];
         if (savedActual != null) {
           // this pair is planned to investigate
-          Expect.equals(savedActual, actual);
+          Expect.equalsOrNaN(savedActual, actual);
         } else if ((savedActual = processed[expected]) != null) {
           // this pair is checked already
-          Expect.equals(savedActual, actual);
+          Expect.equalsOrNaN(savedActual, actual);
         } else {
           // this pair is not yet investigated
-          Expect.equals(
+          Expect.equalsOrNaN(
               expected.length,
               actual.length,
               'Collection lengths are not equal: '
@@ -294,7 +303,7 @@ class Expect {
           planned[expected] = actual;
         }
       } else {
-        Expect.equals(expected, actual, reason);
+        Expect.equalsOrNaN(expected, actual, reason);
       }
     }
 

--- a/Utils/tests/Expect/equalsOrNaN_A01_t04.dart
+++ b/Utils/tests/Expect/equalsOrNaN_A01_t04.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion static void equalsOrNaN(var expected, var actual, [String reason = ''])
+/// Checks whether the expected and actual values are equal (using `==`).
+///
+/// @description NaNs considered equals
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+main() {
+   Expect.throws((){
+      Expect.equalsOrNaN(double.nan, "string");
+   }, null, "string");
+   Expect.throws((){
+      Expect.equalsOrNaN(double.nan, null);
+   }, null, "null");
+   Expect.throws((){
+      Expect.equalsOrNaN(double.nan, 0);
+   }, null, "zero");
+   Expect.throws((){
+      Expect.equalsOrNaN(double.nan, double.infinity);
+   }, null, "Infinity");
+   Expect.equalsOrNaN(double.nan, double.nan);
+   Expect.equalsOrNaN(0.0/0.0, 0.0/0.0);
+   Expect.equalsOrNaN(double.nan, 0.0/0.0);
+}

--- a/Utils/tests/Expect/equals_A01_t04.dart
+++ b/Utils/tests/Expect/equals_A01_t04.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion static void equals(var expected, var actual, [String reason = ''])
-/// Checks whether the expected and actual values are equal (using [:==:]).
-/// @description NaNs considered equals
+/// Checks whether the expected and actual values are equal (using `==`).
+///
+/// @description NaNs considered not equals
 /// @author varlax
 
 import "../../../Utils/expect.dart";
@@ -22,7 +23,7 @@ main() {
    Expect.throws((){
       Expect.equals(double.nan, double.infinity);
    }, null, "Infinity");
-   Expect.equals(double.nan, double.nan);
-   Expect.equals(0.0/0.0, 0.0/0.0);
-   Expect.equals(double.nan, 0.0/0.0);
+   Expect.notEquals(double.nan, double.nan);
+   Expect.notEquals(0.0/0.0, 0.0/0.0);
+   Expect.notEquals(double.nan, 0.0/0.0);
 }


### PR DESCRIPTION
Now we have:
```dart
Expect.equals(double.nan, double.nan); // Fail
Expect.notEquals(double.nan, double.nan); // Ok
Expect.equalsOrNaN(double.nan, double.nan); // Ok
```