### PR TITLE
Update Language/Functions/Formal_Parameters/Optional_Formals/name_t04

### DIFF
--- a/Language/Functions/Formal_Parameters/Optional_Formals/name_t04.dart
+++ b/Language/Functions/Formal_Parameters/Optional_Formals/name_t04.dart
@@ -25,7 +25,9 @@ class C {
 }
 
 main() {
-  dynamic c = C();
-  Expect.equals(1, c.whatever(name: '_', _: 1));
-  Expect.equals(2, c.whatever(name: '_p', _p: 2));
+  if (!isMinified) {
+    dynamic c = C();
+    Expect.equals(1, c.whatever(name: '_', _: 1));
+    Expect.equals(2, c.whatever(name: '_p', _p: 2));
+  }
 }


### PR DESCRIPTION
Skip symbol-based expectations for minified builds.

Similar to other tests that use symbols, we need to skip these expectations on minified builds where symbol names are mangled.