### PR TITLE
#2979. Update assertions in NNBD static errors tests

### DIFF
--- a/LanguageFeatures/nnbd/local_variable_read_A05_t01.dart
+++ b/LanguageFeatures/nnbd/local_variable_read_A05_t01.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile time error to read a local variable when the
-/// variable is potentially unassigned unless the variable is non-final and has
-/// nullable type, or is late
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Checks that it's a compile time error to read a non-late and
-/// non-nullable local variable when the variable is potentially unassigned
+/// non-nullable local variable when the variable is potentially unassigned.
 /// @author sgrekhov@unipro.ru
 
 main() {

--- a/LanguageFeatures/nnbd/local_variable_read_A05_t02.dart
+++ b/LanguageFeatures/nnbd/local_variable_read_A05_t02.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile time error to read a local variable when the
-/// variable is potentially unassigned unless the variable is non-final and has
-/// nullable type, or is late
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Checks that it's a compile time error to read a non-late and
-/// final nullable local variable when the variable is potentially unassigned
+/// `final` nullable local variable when the variable is potentially unassigned.
 /// @author sgrekhov@unipro.ru
 
 main() {

--- a/LanguageFeatures/nnbd/local_variable_read_A05_t03.dart
+++ b/LanguageFeatures/nnbd/local_variable_read_A05_t03.dart
@@ -3,11 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile time error to read a local variable when the
-/// variable is potentially unassigned unless the variable is non-final and has
-/// nullable type, or is late
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
-/// @description Checks that it's not a compile time error to read a non-late and
-/// non-final nullable local variable when the variable is potentially unassigned
+/// @description Checks that it's not a compile time error to read a non-late
+/// and non-final nullable local variable when the variable is potentially
+/// unassigned.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";

--- a/LanguageFeatures/nnbd/local_variable_read_A05_t04.dart
+++ b/LanguageFeatures/nnbd/local_variable_read_A05_t04.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion It is a compile time error to read a local variable when the
-/// variable is potentially unassigned unless the variable is non-final and has
-/// nullable type, or is late
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
-/// @description Checks that it's not a compile time error to read a late
-/// nullable local variable when the variable is potentially unassigned
+/// @description Checks that it's not a compile time error to read a `late`
+/// nullable local variable when the variable is potentially unassigned.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";

--- a/LanguageFeatures/nnbd/static_errors_A08_t01.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t01.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test Never
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type `Never`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40946
 
@@ -31,11 +31,7 @@ class C {
 }
 
 main() {
-  Never n;
-  n.toString();
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
+  print(C);
 
   Function foo = () {
     Never n;
@@ -44,6 +40,10 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+
+  Never n;
+  n.toString();
+//^
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t02.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t02.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test Function
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type `Function`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40946
 
@@ -44,6 +44,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t03.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t03.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test function type
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of a function type.
 /// @author sgrekhov@unipro.ru
 /// @issue 40946
 
@@ -46,6 +46,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t04.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t04.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test some class A
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of some type `A`.
 /// @author sgrekhov@unipro.ru
 /// @issue 40946
 
@@ -46,6 +46,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t06.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t06.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test some type <X extends Object>
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type
+/// `<X extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 class C<X extends Object> {
@@ -30,6 +31,6 @@ void foo<X extends Object>() {
 }
 
 main() {
-  new C<String>().test();
-  foo<String>();
+  print(C);
+  print(foo);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t07.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t07.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test some type <X extends Object?>
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type
+/// `<X extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 class C<X extends Object?> {
@@ -30,6 +31,6 @@ void foo<X extends Object?>() {
 }
 
 main() {
-  new C<String>().test();
-  foo<String>();
+  print(C);
+  print(foo);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t09.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t09.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<Never>
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type
+/// `FutureOr<Never>`.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -45,6 +46,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t10.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t10.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<F> where F is a function type
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type `FutureOr<F>`
+/// where `F` is a function type.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -75,6 +76,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t11.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t11.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<A> where A is some class
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type `FutureOr<A>`
+/// where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -75,6 +76,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t13.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t13.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<T>, where <T extends Object>
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a vat=riable of type
+/// `FutureOr<T>`, where `<T extends Object>`.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -32,6 +33,6 @@ void foo<T extends Object>() {
 }
 
 main() {
-  new C<String>().test();
-  foo<String>();
+  print(C);
+  print(foo);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t14.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t14.dart
@@ -2,13 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<T>, where <T extends Object?>
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type `FutureOr<T>`,
+/// where `<T extends Object?>`.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -32,6 +33,6 @@ void foo<T extends Object?>() {
 }
 
 main() {
-  new C<String>().test();
-  foo<String>();
+  print(C);
+  print(foo);
 }

--- a/LanguageFeatures/nnbd/static_errors_A08_t15.dart
+++ b/LanguageFeatures/nnbd/static_errors_A08_t15.dart
@@ -2,14 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion It is an error if a potentially non-nullable local variable which
-/// has no initializer expression and is not marked late is used before it is
-/// definitely assigned
+/// @assertion It is a compile time error to read a local variable when the
+/// variable is potentially unassigned unless the variable is non-`final` and
+/// has nullable type, or is `late`.
 ///
 /// @description Check that it is an error if a potentially non-nullable local
-/// variable which has no initializer expression and is not marked late is used
-/// before it is definitely assigned. Test FutureOr<FutureOr<A>> where A is some
-/// class
+/// variable which has no initializer expression and is not marked `late` is
+/// read before it is definitely assigned. Test a variable of type
+/// `FutureOr<FutureOr<A>>` where `A` is some class.
 /// @author sgrekhov@unipro.ru
 
 import "dart:async";
@@ -76,6 +76,5 @@ main() {
 // [analyzer] unspecified
 // [cfe] unspecified
   };
-  C.test();
-  new C().test2();
+  print(C);
 }


### PR DESCRIPTION
`static_errors_A08_*` tests will be renamed to `local_variable_read_A05_*` in a separate PR