### PR TITLE
Fixes #3769. Use `unspecified` expected errors

### DIFF
--- a/LanguageFeatures/Control-flow-collections/static_semantics_A02_t02.dart
+++ b/LanguageFeatures/Control-flow-collections/static_semantics_A02_t02.dart
@@ -11,112 +11,107 @@
 /// of the type argument used to create the map
 /// @author sgrekhov@unipro.ru
 
-
 main() {
   bool b = true;
   var collection = [3, 1, 4, 1, 5];
 
   Map<String, int> map1 = {if (b) "1": 1.1};
 //                                     ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map2 = {if (b) 1: 1};
 //                                ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map3 = {if (!b) "1": 1.1,};
 //                                      ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map4 = {if (!b) 1: 1};
 //                                 ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map5 = {if (b) for (var v in collection) if (v > 3) "$v": "$v",};
 //                                                                           ^^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-//                                                                               ^
-// [cfe] A value of type 'String' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map6 = {if (b) for (var v in collection) if (v > 3) v: v,};
 //                                                                     ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map7 = {if (!b) for (var v in collection) if (v > 3) "$v": "$v"};
 //                                                                            ^^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-//                                                                                ^
-// [cfe] A value of type 'String' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map<String, int> map8 = {if (!b) for (var v in collection) if (v > 3) v: v,};
 //                                                                      ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
 
   Map map9  = <String, int>{if (b) "1": 1.1};
 //                                      ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map10 = <String, int>{if (b) 1: 1};
 //                                 ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map11 = <String, int>{if (!b) "1": 1.1,};
 //                                       ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map12 = <String, int>{if (!b) 1: 1};
 //                                  ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map13 = <String, int>{if (b) for (var v in collection) if (v > 3) "$v": "$v",};
 //                                                                            ^^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-//                                                                                ^
-// [cfe] A value of type 'String' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map14 = <String, int>{if (b) for (var v in collection) if (v > 3) v: v,};
 //                                                                      ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map15 = <String, int>{if (!b) for (var v in collection) if (v > 3) "$v": "$v"};
 //                                                                             ^^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-//                                                                                 ^
-// [cfe] A value of type 'String' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   Map map16 = <String, int>{if (!b) for (var v in collection) if (v > 3) v: v,};
 //                                                                       ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
 
   const map17 = <String, int>{if (1 > 2) "1": 1.1};
 //                                            ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   const map18 = <String, int>{if (2 > 1) "1": 1.1,};
 //                                            ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   const map19 = <String, int>{if (1 > 2) 1: 1};
 //                                       ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   const map20 = <String, int>{if (2 > 1) 1: 1,};
 //                                       ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
 
   var map21 = const <String, int>{if (1 > 2) "1": 1.1};
 //                                                ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   var map22 = const <String, int>{if (2 > 1) "1": 1.1,};
 //                                                ^^^
-// [analyzer] COMPILE_TIME_ERROR.MAP_VALUE_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'double' can't be assigned to a variable of type 'int'.
+// [analyzer] unspecified
+// [cfe] unspecified
   var map23 = const <String, int>{if (1 > 2) 1: 1};
 //                                           ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
   var map24 = const <String, int>{if (2 > 1) 1: 1,};
 //                                           ^
-// [analyzer] COMPILE_TIME_ERROR.MAP_KEY_TYPE_NOT_ASSIGNABLE
-// [cfe] A value of type 'int' can't be assigned to a variable of type 'String'.
+// [analyzer] unspecified
+// [cfe] unspecified
 }

--- a/LanguageFeatures/Set-literals/disambiguating_A06_t01.dart
+++ b/LanguageFeatures/Set-literals/disambiguating_A06_t01.dart
@@ -18,36 +18,30 @@ main() {
   int x = 1;
   var c1 = {if (2 > 1) x: x + 1, if (1 < 2) x};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_BOTH
-//          ^
-// [cfe] Expected ',' before this.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c2 = {if (2 > 1) "s": "s" else "$x"};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_EITHER
-//                                       ^
-// [cfe] Expected ':' after this.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c3 = {if (2 > 1) "s" else "$x": "x", if (2 > 1) x: x};
 //                     ^^^
-// [analyzer] COMPILE_TIME_ERROR.EXPRESSION_IN_MAP
-// [cfe] Expected ':' after this.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c4 = {for (var i = 0; i < 3; i++) if (2 > 1) "s": "s" else if (2 > 1) x};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_EITHER
-//                                                               ^
-// [cfe] Both Iterable and Map spread elements encountered in ambiguous literal.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c5 = {for (var i in [1, 2, 3]) if (1 > 2) x else if (2 > 1) i: i};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_EITHER
-//                                              ^
-// [cfe] Expected ':' after this.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c6 = {if (1 > 2) for (var i in [1, 2, 3]) i else if (2 > 1) for (var i = 0; i < 3; i++) i: i};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_EITHER
-//                     ^
-// [cfe] Both Iterable and Map spread elements encountered in ambiguous literal.
+// [analyzer] unspecified
+// [cfe] unspecified
   var c7 = {if (2 > 1) for (var i in [1, 2, 3]) i:i else if (2 > 1) for (var i = 0; i < 3; i++) i};
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// [analyzer] COMPILE_TIME_ERROR.AMBIGUOUS_SET_OR_MAP_LITERAL_EITHER
-//                                                       ^
-// [cfe] Both Iterable and Map spread elements encountered in ambiguous literal.
+// [analyzer] unspecified
+// [cfe] unspecified
 }


### PR DESCRIPTION
`unspecified` expects an error at any position in a code line.