### PR TITLE
#3779. Fix isDirectory and isFile tests. Add tests for `typeSync`

### DIFF
--- a/LibTest/io/FileSystemEntity/isDirectorySync_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isDirectorySync_A01_t03.dart
@@ -20,6 +20,8 @@ main() async {
 }
 
 void _main(Directory sandbox) {
+  // dirLink will be a link to a temp directory in the sandbox because no target
+  // is passed
   final dirLink = getTempLinkSync(parent: sandbox);
   Expect.isTrue(FileSystemEntity.isDirectorySync(dirLink.path));
   Expect.equals(FileSystemEntityType.directory,
@@ -31,6 +33,7 @@ void _main(Directory sandbox) {
   Expect.equals(FileSystemEntityType.file,
       FileSystemEntity.typeSync(fileLink.path));
 
+  // notExisting will be a path to a non-existing file in the sandbox
   final notExisting = getTempFilePath(parent: sandbox);
   final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
   Expect.isFalse(FileSystemEntity.isDirectorySync(brokenLink.path));

--- a/LibTest/io/FileSystemEntity/isDirectorySync_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isDirectorySync_A01_t03.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion bool isDirectorySync(String path)
-/// Synchronously checks if typeSync(path) returns
-/// FileSystemEntityType.directory.
+/// Synchronously checks if `typeSync(path)` returns
+/// [FileSystemEntityType.directory].
 ///
-/// @description Checks that this property Synchronously checks if typeSync(path)
-/// returns FileSystemEntityType.directory. Test Directory
-/// @issue 30410
+/// @description Checks that this property synchronously checks if
+/// `typeSync(path)` returns [FileSystemEntityType.directory]. Test a [Link].
 /// @author sgrekhov@unipro.ru
+/// @issue 30410
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -20,8 +20,20 @@ main() async {
 }
 
 void _main(Directory sandbox) {
-  Link link = getTempLinkSync(parent: sandbox);
-  Expect.isFalse(FileSystemEntity.isDirectorySync(link.path));
-  Expect.equals(FileSystemEntityType.link,
-      FileSystemEntity.typeSync(link.path));
+  final dirLink = getTempLinkSync(parent: sandbox);
+  Expect.isTrue(FileSystemEntity.isDirectorySync(dirLink.path));
+  Expect.equals(FileSystemEntityType.directory,
+       FileSystemEntity.typeSync(dirLink.path));
+
+  final target = getTempFileSync(parent: sandbox);
+  final fileLink = getTempLinkSync(parent: sandbox, target: target.path);
+  Expect.isFalse(FileSystemEntity.isDirectorySync(fileLink.path));
+  Expect.equals(FileSystemEntityType.file,
+      FileSystemEntity.typeSync(fileLink.path));
+
+  final notExisting = getTempFilePath(parent: sandbox);
+  final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
+  Expect.isFalse(FileSystemEntity.isDirectorySync(brokenLink.path));
+  Expect.equals(FileSystemEntityType.notFound,
+      FileSystemEntity.typeSync(brokenLink.path));
 }

--- a/LibTest/io/FileSystemEntity/isDirectory_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isDirectory_A01_t03.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion Future<bool> isDirectory(String path)
-/// Checks if type(path) returns FileSystemEntityType.directory.
+/// Checks if `type(path)` returns [FileSystemEntityType.directory].
 ///
-/// @description Checks that this property returns true if type(path) returns
-/// FileSystemEntityType.directory. Test Link
-/// @issue 24821, 30410
+/// @description Checks that this property returns `true` if `type(path)`
+/// returns [FileSystemEntityType.directory] and false otherwise. Test a [Link].
 /// @author sgrekhov@unipro.ru
+/// @issue 24821, 30410
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -19,11 +19,20 @@ main() async {
 }
 
 void _main(Directory sandbox) async {
-  Link link = getTempLinkSync(parent: sandbox);
-  asyncStart();
-  bool result = await FileSystemEntity.isDirectory(link.path);
-  Expect.isFalse(result);
-  FileSystemEntityType t = await FileSystemEntity.type(link.path);
-  Expect.equals(FileSystemEntityType.link, t);
-  asyncEnd();
+  final dirLink = getTempLinkSync(parent: sandbox);
+  Expect.isTrue(await FileSystemEntity.isDirectory(dirLink.path));
+  final type1 = await FileSystemEntity.type(dirLink.path);
+  Expect.equals(FileSystemEntityType.directory, type1);
+
+  final target = getTempFileSync(parent: sandbox);
+  final fileLink = getTempLinkSync(parent: sandbox, target: target.path);
+  Expect.isFalse(await FileSystemEntity.isDirectory(fileLink.path));
+  final type2 = await FileSystemEntity.type(fileLink.path);
+  Expect.equals(FileSystemEntityType.file, type2);
+
+  final notExisting = getTempFilePath(parent: sandbox);
+  final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
+  Expect.isFalse(await FileSystemEntity.isDirectory(brokenLink.path));
+  final type3 = await FileSystemEntity.type(brokenLink.path);
+  Expect.equals(FileSystemEntityType.notFound, type3);
 }

--- a/LibTest/io/FileSystemEntity/isDirectory_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isDirectory_A01_t03.dart
@@ -19,6 +19,8 @@ main() async {
 }
 
 void _main(Directory sandbox) async {
+  // dirLink will be a link to a temp directory in the sandbox because no target
+  // is passed
   final dirLink = getTempLinkSync(parent: sandbox);
   Expect.isTrue(await FileSystemEntity.isDirectory(dirLink.path));
   final type1 = await FileSystemEntity.type(dirLink.path);
@@ -30,6 +32,7 @@ void _main(Directory sandbox) async {
   final type2 = await FileSystemEntity.type(fileLink.path);
   Expect.equals(FileSystemEntityType.file, type2);
 
+  // notExisting will be a path to a non-existing file in the sandbox
   final notExisting = getTempFilePath(parent: sandbox);
   final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
   Expect.isFalse(await FileSystemEntity.isDirectory(brokenLink.path));

--- a/LibTest/io/FileSystemEntity/isFileSync_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isFileSync_A01_t03.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion bool isFileSync(String path)
-/// Synchronously checks if typeSync(path) returns FileSystemEntityType.file.
+/// Synchronously checks if `typeSync(path)` returns [FileSystemEntityType.file]
 ///
-/// @description Checks that this property Synchronously checks if typeSync(path)
-/// returns FileSystemEntityType.file. Test Directory
+/// @description Checks that this property synchronously checks if
+/// `typeSync(path)` returns [FileSystemEntityType.file]. Test a [Link].
 /// @issue 24821, 30410
 /// @author sgrekhov@unipro.ru
 
@@ -19,8 +19,20 @@ main() async {
 }
 
 void _main(Directory sandbox) {
-  Link link = getTempLinkSync(parent: sandbox);
-  Expect.isFalse(FileSystemEntity.isFileSync(link.path));
-  Expect.equals(FileSystemEntityType.link,
-      FileSystemEntity.typeSync(link.path));
+  final dirLink = getTempLinkSync(parent: sandbox);
+  Expect.isFalse(FileSystemEntity.isFileSync(dirLink.path));
+  Expect.equals(FileSystemEntityType.directory,
+      FileSystemEntity.typeSync(dirLink.path));
+
+  final target = getTempFileSync(parent: sandbox);
+  final fileLink = getTempLinkSync(parent: sandbox, target: target.path);
+  Expect.isTrue(FileSystemEntity.isFileSync(fileLink.path));
+  Expect.equals(FileSystemEntityType.file,
+      FileSystemEntity.typeSync(fileLink.path));
+
+  final notExisting = getTempFilePath(parent: sandbox);
+  final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
+  Expect.isFalse(FileSystemEntity.isFileSync(brokenLink.path));
+  Expect.equals(FileSystemEntityType.notFound,
+      FileSystemEntity.typeSync(brokenLink.path));
 }

--- a/LibTest/io/FileSystemEntity/isFileSync_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isFileSync_A01_t03.dart
@@ -19,6 +19,8 @@ main() async {
 }
 
 void _main(Directory sandbox) {
+  // dirLink will be a link to a temp directory in the sandbox because no target
+  // is passed
   final dirLink = getTempLinkSync(parent: sandbox);
   Expect.isFalse(FileSystemEntity.isFileSync(dirLink.path));
   Expect.equals(FileSystemEntityType.directory,
@@ -30,6 +32,7 @@ void _main(Directory sandbox) {
   Expect.equals(FileSystemEntityType.file,
       FileSystemEntity.typeSync(fileLink.path));
 
+  // notExisting will be a path to a non-existing file in the sandbox
   final notExisting = getTempFilePath(parent: sandbox);
   final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
   Expect.isFalse(FileSystemEntity.isFileSync(brokenLink.path));

--- a/LibTest/io/FileSystemEntity/isFile_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isFile_A01_t03.dart
@@ -19,6 +19,8 @@ main() async {
 }
 
 void _main(Directory sandbox) async {
+  // dirLink will be a link to a temp directory in the sandbox because no target
+  // is passed
   final dirLink = getTempLinkSync(parent: sandbox);
   Expect.isFalse(await FileSystemEntity.isFile(dirLink.path));
   final type1 = await FileSystemEntity.type(dirLink.path);
@@ -30,6 +32,7 @@ void _main(Directory sandbox) async {
   final type2 = await FileSystemEntity.type(fileLink.path);
   Expect.equals(FileSystemEntityType.file, type2);
 
+  // notExisting will be a path to a non-existing file in the sandbox
   final notExisting = getTempFilePath(parent: sandbox);
   final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
   Expect.isFalse(await FileSystemEntity.isFile(brokenLink.path));

--- a/LibTest/io/FileSystemEntity/isFile_A01_t03.dart
+++ b/LibTest/io/FileSystemEntity/isFile_A01_t03.dart
@@ -3,11 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// @assertion Future<bool> isFile(String path)
-/// Checks if type(path) returns FileSystemEntityType.file.
-/// @description Checks that this property returns true if type(path) returns
-/// FileSystemEntityType.file. Test Link
-/// @issue 24821, 30410
+/// Checks if `type(path)` returns [FileSystemEntityType.file].
+///
+/// @description Checks that this property returns `true` if `type(path)`
+/// returns [FileSystemEntityType.file]. Test a [Link].
 /// @author sgrekhov@unipro.ru
+/// @issue 24821, 30410
 
 import "dart:io";
 import "../../../Utils/expect.dart";
@@ -18,13 +19,20 @@ main() async {
 }
 
 void _main(Directory sandbox) async {
-  Link link = getTempLinkSync(parent: sandbox);
-  asyncStart();
-  await FileSystemEntity.isFile(link.path).then((result) async {
-    Expect.isFalse(result);
-    await FileSystemEntity.type(link.path).then((t) {
-      Expect.equals(FileSystemEntityType.link, t);
-      asyncEnd();
-    });
-  });
+  final dirLink = getTempLinkSync(parent: sandbox);
+  Expect.isFalse(await FileSystemEntity.isFile(dirLink.path));
+  final type1 = await FileSystemEntity.type(dirLink.path);
+  Expect.equals(FileSystemEntityType.directory, type1);
+
+  final target = getTempFileSync(parent: sandbox);
+  final fileLink = getTempLinkSync(parent: sandbox, target: target.path);
+  Expect.isTrue(await FileSystemEntity.isFile(fileLink.path));
+  final type2 = await FileSystemEntity.type(fileLink.path);
+  Expect.equals(FileSystemEntityType.file, type2);
+
+  final notExisting = getTempFilePath(parent: sandbox);
+  final brokenLink = getTempLinkSync(parent: sandbox, target: notExisting);
+  Expect.isFalse(await FileSystemEntity.isFile(brokenLink.path));
+  final type3 = await FileSystemEntity.type(brokenLink.path);
+  Expect.equals(FileSystemEntityType.notFound, type3);
 }

--- a/LibTest/io/FileSystemEntity/typeSync_A01_t01.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A01_t01.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.notFound]
+/// if `path` does not point to a file system object.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final path = getTempFilePath(parent: sandbox);
+  Expect.equals(FileSystemEntityType.notFound, FileSystemEntity.typeSync(path));
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A01_t01.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A01_t01.dart
@@ -33,6 +33,6 @@ main() async {
 }
 
 void _main(Directory sandbox) {
-  final path = getTempFilePath(parent: sandbox);
+  final path = getTempFilePath(parent: sandbox); // No actual file created
   Expect.equals(FileSystemEntityType.notFound, FileSystemEntity.typeSync(path));
 }

--- a/LibTest/io/FileSystemEntity/typeSync_A02_t01.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A02_t01.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.file] if
+/// `path` points to a file.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final file = getTempFileSync(parent: sandbox);
+  Expect.equals(
+    FileSystemEntityType.file,
+    FileSystemEntity.typeSync(file.path),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A02_t02.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A02_t02.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns
+/// [FileSystemEntityType.directory] if `path` points to a directory.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final dir = getTempDirectorySync(parent: sandbox);
+  Expect.equals(
+    FileSystemEntityType.directory,
+    FileSystemEntity.typeSync(dir.path),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A03_t01.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A03_t01.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.file] if
+/// `path` points to a link, the target is a file and `followLinks` is `true` .
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final file = getTempFileSync(parent: sandbox);
+  final link = getTempLinkSync(parent: sandbox, target: file.path);
+  Expect.equals(
+    FileSystemEntityType.file,
+    FileSystemEntity.typeSync(link.path),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A03_t02.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A03_t02.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.directory]
+/// if `path` points to a link, the target is a directory and `followLinks` is
+/// `true` .
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final dir = getTempDirectorySync(parent: sandbox);
+  final link = getTempLinkSync(parent: sandbox, target: dir.path);
+  Expect.equals(
+    FileSystemEntityType.directory,
+    FileSystemEntity.typeSync(link.path),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A03_t03.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A03_t03.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.notFound]
+/// if `path` points to a link and the target of the link does not exists.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final path = getTempFilePath(parent: sandbox); // File is not created
+  final link = getTempLinkSync(parent: sandbox, target: path);
+  Expect.equals(
+    FileSystemEntityType.notFound,
+    FileSystemEntity.typeSync(link.path),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A03_t04.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A03_t04.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.link]
+/// if `path` points to a link and the target of the link is a file and
+/// `followLinks` is `false`.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final file = getTempFileSync(parent: sandbox);
+  final link = getTempLinkSync(parent: sandbox, target: file.path);
+  Expect.equals(
+    FileSystemEntityType.link,
+    FileSystemEntity.typeSync(link.path, followLinks: false),
+  );
+}

--- a/LibTest/io/FileSystemEntity/typeSync_A03_t05.dart
+++ b/LibTest/io/FileSystemEntity/typeSync_A03_t05.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion typeSync static method
+/// ```
+/// FileSystemEntityType typeSync(
+///   String path, {
+///   bool followLinks = true,
+/// })
+/// ```
+/// Synchronously finds the type of file system object that a path points to.
+///
+/// Returns [FileSystemEntityType.notFound] if `path` does not point to a file
+/// system object or if any other error occurs in looking up the path.
+///
+/// If `path` points to a link and `followLinks` is `true` then the result will
+/// be for the file system object that the link points to. If that object does
+/// not exist then the result will be [FileSystemEntityType.notFound]. If path
+/// points to a link and `followLinks` is false then the result will be
+/// [FileSystemEntityType.link].
+///
+/// @description Checks that this method returns [FileSystemEntityType.link]
+/// if `path` points to a link and the target of the link is a directory and
+/// `followLinks` is `false`.
+/// @author sgrekhov22@gmail.com
+
+import 'dart:io';
+import '../../../Utils/expect.dart';
+import '../file_utils.dart';
+
+main() async {
+  await inSandbox(_main);
+}
+
+void _main(Directory sandbox) {
+  final dir = getTempDirectorySync(parent: sandbox);
+  final link = getTempLinkSync(parent: sandbox, target: dir.path);
+  Expect.equals(
+    FileSystemEntityType.link,
+    FileSystemEntity.typeSync(link.path, followLinks: false),
+  );
+}

--- a/LibTest/io/file_utils.dart
+++ b/LibTest/io/file_utils.dart
@@ -97,6 +97,13 @@ Future<Directory> getTempDirectory({Directory? parent, String? name}) async {
   return dir.create();
 }
 
+/// Returns a new [Link] in the directory [parent], with the name [name] and the
+/// target [target].
+///
+/// If [parent] is not specified, [Directory.systemTemp] is used.
+/// If [target] is not specified, a temporary directory is created and used as
+/// the link target.
+/// If [name] is not specified, a temporary name is generated.
 Link getTempLinkSync({Directory? parent, String? target, String? name}) {
   parent ??= Directory.systemTemp;
   target ??= getTempDirectorySync(parent: parent).path;
@@ -151,6 +158,13 @@ String getPrefix() {
   return "co19-" + fileName.substring(0, fileName.indexOf(".")) + "_";
 }
 
+/// Synchronously returns the path to a temporary file without actually creating
+/// the file.
+///
+/// If [parent] is specified, the returned path will be in that directory.
+/// Otherwise, [Directory.systemTemp] is used.
+/// If [name] is specified, that file name is used. Otherwise, the result of
+/// [getTempFileName] is used.
 String getTempFilePath({Directory? parent, String? name}) {
   parent ??= Directory.systemTemp;
   name ??= getPrefix() + getTempFileName();


### PR DESCRIPTION
`isDirectory` and `isFile` tests were failing. But these properties behave exactly as specified. Therefore tests were updated and new tests for `typeSync()` added. `typeSync()` works as intended.