### PR TITLE
#2303. Make `Link.createSync()` tests stronger

### DIFF
--- a/LibTest/io/Link/createSync_A03_t01.dart
+++ b/LibTest/io/Link/createSync_A03_t01.dart
@@ -40,8 +40,13 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Link link = createTempLinkSync(parent: sandbox, target: sandbox.path);
   Directory newTarget = createTempDirectorySync(parent: sandbox);
-  Expect.throws(() {link.createSync(newTarget.path);});
+  Expect.throws(() {link.createSync(newTarget.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t02.dart
+++ b/LibTest/io/Link/createSync_A03_t02.dart
@@ -40,7 +40,12 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Link link = createTempLinkSync(parent: sandbox);
-  Expect.throws(() {link.createSync(link.targetSync());});
+  Expect.throws(() {link.createSync(link.targetSync(), recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t03.dart
+++ b/LibTest/io/Link/createSync_A03_t03.dart
@@ -40,8 +40,13 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target.path);
-  Expect.throws(() {link.createSync(link.targetSync());});
+  Expect.throws(() {link.createSync(link.targetSync(), recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t04.dart
+++ b/LibTest/io/Link/createSync_A03_t04.dart
@@ -40,9 +40,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target1 = createTempFileSync(parent: sandbox);
   File target2 = createTempFileSync(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target1.path);
-  Expect.throws(() {link.createSync(target2.path);});
+  Expect.throws(() {link.createSync(target2.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t05.dart
+++ b/LibTest/io/Link/createSync_A03_t05.dart
@@ -40,8 +40,13 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   String target = getTempFilePath(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target);
-  Expect.throws(() {link.createSync(target);});
+  Expect.throws(() {link.createSync(target, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t06.dart
+++ b/LibTest/io/Link/createSync_A03_t06.dart
@@ -40,9 +40,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   String target1 = getTempFilePath(parent: sandbox);
   String target2 = getTempFilePath(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target1);
-  Expect.throws(() {link.createSync(target2);});
+  Expect.throws(() {link.createSync(target2, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t07.dart
+++ b/LibTest/io/Link/createSync_A03_t07.dart
@@ -41,9 +41,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   File existing = createTempFileSync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(target.path);});
+  Expect.throws(() {link.createSync(target.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t08.dart
+++ b/LibTest/io/Link/createSync_A03_t08.dart
@@ -41,9 +41,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(target.path);});
+  Expect.throws(() {link.createSync(target.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t09.dart
+++ b/LibTest/io/Link/createSync_A03_t09.dart
@@ -41,9 +41,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Directory existing = createTempDirectorySync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(target.path);});
+  Expect.throws(() {link.createSync(target.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t10.dart
+++ b/LibTest/io/Link/createSync_A03_t10.dart
@@ -41,9 +41,14 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: sandbox.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(target.path);});
+  Expect.throws(() {link.createSync(target.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t11.dart
+++ b/LibTest/io/Link/createSync_A03_t11.dart
@@ -41,8 +41,13 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File existing = createTempFileSync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(sandbox.path);});
+  Expect.throws(() {link.createSync(sandbox.path, recursive: recursive);});
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t12.dart
+++ b/LibTest/io/Link/createSync_A03_t12.dart
@@ -41,9 +41,16 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(sandbox.path);});
+  Expect.throws(() {
+    link.createSync(sandbox.path, recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t13.dart
+++ b/LibTest/io/Link/createSync_A03_t13.dart
@@ -41,8 +41,15 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Directory existing = createTempDirectorySync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(sandbox.path);});
+  Expect.throws(() {
+    link.createSync(sandbox.path, recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t14.dart
+++ b/LibTest/io/Link/createSync_A03_t14.dart
@@ -41,9 +41,16 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Directory target = createTempDirectorySync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(sandbox.path);});
+  Expect.throws(() {
+    link.createSync(sandbox.path, recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t15.dart
+++ b/LibTest/io/Link/createSync_A03_t15.dart
@@ -41,8 +41,15 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File existing = createTempFileSync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(getTempFilePath(parent: sandbox));});
+  Expect.throws(() {
+    link.createSync(getTempFilePath(parent: sandbox), recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t16.dart
+++ b/LibTest/io/Link/createSync_A03_t16.dart
@@ -41,9 +41,16 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   File target = createTempFileSync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(getTempFilePath(parent: sandbox));});
+  Expect.throws(() {
+    link.createSync(getTempFilePath(parent: sandbox), recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t17.dart
+++ b/LibTest/io/Link/createSync_A03_t17.dart
@@ -41,8 +41,15 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Directory existing = createTempDirectorySync(parent: sandbox);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(getTempFilePath(parent: sandbox));});
+  Expect.throws(() {
+    link.createSync(getTempFilePath(parent: sandbox), recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/createSync_A03_t18.dart
+++ b/LibTest/io/Link/createSync_A03_t18.dart
@@ -41,9 +41,16 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) {
+void test(Directory sandbox, {required bool recursive}) {
   Directory target = createTempDirectorySync(parent: sandbox);
   Link existing = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(existing.path);
-  Expect.throws(() {link.createSync(getTempFilePath(parent: sandbox));});
+  Expect.throws(() {
+    link.createSync(getTempFilePath(parent: sandbox), recursive: recursive);
+  });
+}
+
+void _main(Directory sandbox) {
+  test(sandbox, recursive: false);
+  test(sandbox, recursive: true);
 }


### PR DESCRIPTION
It's important to tests `createSync()` with both possible values of `recursive`. Especially when the target of a link is a not existing entity and `recursive` is `true` (check that this entity is not created by mistake).