### PR TITLE
#2303. Make `Link.create()` tests stronger

### DIFF
--- a/LibTest/io/Link/create_A03_t01.dart
+++ b/LibTest/io/Link/create_A03_t01.dart
@@ -47,14 +47,23 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Link tmp = createTempLinkSync(parent: sandbox);
   Link link = new Link(tmp.path);
-  asyncStart();
-  await link.create(tmp.targetSync()).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(tmp.targetSync(), recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t02.dart
+++ b/LibTest/io/Link/create_A03_t02.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Directory target = createTempDirectorySync(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox);
   Link link = new Link(tmp.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t03.dart
+++ b/LibTest/io/Link/create_A03_t03.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   File target = createTempFileSync(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(tmp.targetSync()).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(tmp.targetSync(), recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t04.dart
+++ b/LibTest/io/Link/create_A03_t04.dart
@@ -47,16 +47,25 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   File target1 = createTempFileSync(parent: sandbox);
   File target2 = createTempFileSync(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target1.path);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(target2.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target2.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t05.dart
+++ b/LibTest/io/Link/create_A03_t05.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Link target = createTempLinkSync(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target.path);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(tmp.targetSync()).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(tmp.targetSync(), recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t06.dart
+++ b/LibTest/io/Link/create_A03_t06.dart
@@ -47,16 +47,25 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Link target1 = createTempLinkSync(parent: sandbox);
   Link target2 = createTempLinkSync(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target1.path);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(target2.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target2.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t07.dart
+++ b/LibTest/io/Link/create_A03_t07.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   String target = getTempFilePath(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(tmp.targetSync()).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(tmp.targetSync(), recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t08.dart
+++ b/LibTest/io/Link/create_A03_t08.dart
@@ -47,16 +47,25 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   String target1 = getTempFilePath(parent: sandbox);
   String target2 = getTempFilePath(parent: sandbox);
   Link tmp = createTempLinkSync(parent: sandbox, target: target1);
   Link link = Link(tmp.path);
-  asyncStart();
-  await link.create(target2).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target2, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t09.dart
+++ b/LibTest/io/Link/create_A03_t09.dart
@@ -47,15 +47,25 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   File target = createTempFileSync(parent: sandbox);
+  String target2 = getTempFilePath(parent: sandbox);
   File file = createTempFileSync(parent: sandbox);
   Link link = Link(file.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t10.dart
+++ b/LibTest/io/Link/create_A03_t10.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Directory target = createTempDirectorySync(parent: sandbox);
   File file = createTempFileSync(parent: sandbox);
   Link link = Link(file.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t11.dart
+++ b/LibTest/io/Link/create_A03_t11.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   String target = getTempFilePath(parent: sandbox);
   File file = createTempFileSync(parent: sandbox);
   Link link = Link(file.path);
-  asyncStart();
-  await link.create(target).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t12.dart
+++ b/LibTest/io/Link/create_A03_t12.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   File target = createTempFileSync(parent: sandbox);
   Directory dir = createTempDirectorySync(parent: sandbox);
   Link link = Link(dir.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t13.dart
+++ b/LibTest/io/Link/create_A03_t13.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Directory target = createTempDirectorySync(parent: sandbox);
   Directory dir = createTempDirectorySync(parent: sandbox);
   Link link = Link(dir.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t14.dart
+++ b/LibTest/io/Link/create_A03_t14.dart
@@ -47,15 +47,24 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   String target = getTempFilePath(parent: sandbox);
   Directory dir = createTempDirectorySync(parent: sandbox);
   Link link = Link(dir.path);
-  asyncStart();
-  await link.create(target).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t15.dart
+++ b/LibTest/io/Link/create_A03_t15.dart
@@ -47,14 +47,23 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   File target = createTempFileSync(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target.path);
-  asyncStart();
-  await link.create(target.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t16.dart
+++ b/LibTest/io/Link/create_A03_t16.dart
@@ -47,13 +47,22 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   Link link = createTempLinkSync(parent: sandbox, target: sandbox.path);
-  asyncStart();
-  await link.create(sandbox.path).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(sandbox.path, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }

--- a/LibTest/io/Link/create_A03_t17.dart
+++ b/LibTest/io/Link/create_A03_t17.dart
@@ -47,14 +47,23 @@ main() async {
   await inSandbox(_main);
 }
 
-void _main(Directory sandbox) async {
+Future<void> test(Directory sandbox, {required bool recursive}) async {
   String target = getTempFilePath(parent: sandbox);
   Link link = createTempLinkSync(parent: sandbox, target: target);
-  asyncStart();
-  await link.create(target).then((Link created) {
-    Expect.fail("Link create() should fail");
-    asyncEnd();
-  }, onError: (_) {
-    asyncEnd();
-  });
+  await link
+      .create(target, recursive: recursive)
+      .then(
+        (Link created) {
+          Expect.fail("Link create() should fail");
+        },
+        onError: (_) {
+          asyncEnd();
+        },
+      );
+}
+
+void _main(Directory sandbox) async {
+  asyncStart(2);
+  await test(sandbox, recursive: false);
+  await test(sandbox, recursive: true);
 }


### PR DESCRIPTION
It's important to tests `create()` with both possible values of `recursive`. Especially when the target of a link is a not existing entity and recursive is true (check that this entity is not created by mistake).