### PR TITLE
#2145. Add more tests for evaluation of implicit variable getters

### DIFF
--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t01.dart
@@ -2,7 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Case ⟨Static or library variable⟩. If `d` declares a static or
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Static or library variable⟩. If `d` declares a static or
 /// library variable, the implicitly induced getter of `id` executes as follows:
 /// - Non-constant variable with an initializer. In the case where `d` has an
 ///   initializing expression and is not constant, the implicitly induced getter
@@ -18,7 +28,7 @@ import "../../../Utils/expect.dart";
 String log = "";
 
 writeLog(String i) {
-  log += "$i";
+  log += i;
   return i;
 }
 

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t02.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t02.dart
@@ -2,7 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Case ⟨Static or library variable⟩. If `d` declares a static or
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Static or library variable⟩. If `d` declares a static or
 /// library variable, the implicitly induced getter of `id` executes as follows:
 /// - Non-constant variable with an initializer. In the case where `d` has an
 ///   initializing expression and is not constant, the implicitly induced getter

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t03.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t03.dart
@@ -2,7 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Case ⟨Static or library variable⟩. If `d` declares a static or
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Static or library variable⟩. If `d` declares a static or
 /// library variable, the implicitly induced getter of `id` executes as follows:
 /// - Non-constant variable with an initializer. In the case where `d` has an
 ///   initializing expression and is not constant, the implicitly induced getter

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t04.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t04.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+///
+/// Case ⟨Static or library variable⟩. If `d` declares a static or
+/// library variable, the implicitly induced getter of `id` executes as follows:
+/// - Non-constant variable with an initializer. In the case where `d` has an
+///   initializing expression and is not constant, the implicitly induced getter
+///   of `id` is a late-initialized getter. This determines the semantics of an
+///   invocation.
+///
+/// @description Checks that if the evaluation of `e` throws then the invocation
+/// of `g` completes throwing the same object and does not change the binding of
+/// `v`.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+int count = 0;
+
+int v1 = f();
+final int v2 = f();
+
+int f() {
+  if (count++ == 0) {
+    throw 42;
+  }
+  return 0;
+}
+
+class C {
+  static int v1 = f();
+  static final int v2 = f();
+}
+
+mixin M {
+  static int v1 = f();
+  static final int v2 = f();
+}
+
+enum E {
+  e0;
+  static int v1 = f();
+  static final int v2 = f();
+}
+
+class A {}
+
+extension Ext on A {
+  static int v1 = f();
+  static final int v2 = f();
+}
+
+extension type ET(int _) {
+  static int v1 = f();
+  static final int v2 = f();
+}
+
+main() {
+  try {
+    v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, v1);
+  }
+  count = 0;
+  try {
+    v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, v2);
+  }
+
+  count = 0;
+  try {
+    C.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, C.v1);
+  }
+  count = 0;
+  try {
+    C.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, C.v2);
+  }
+
+  count = 0;
+  try {
+    M.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, M.v1);
+  }
+  count = 0;
+  try {
+    M.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, M.v2);
+  }
+
+  count = 0;
+  try {
+    E.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, E.v1);
+  }
+  count = 0;
+  try {
+    E.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, E.v2);
+  }
+
+  count = 0;
+  try {
+    Ext.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, Ext.v1);
+  }
+  count = 0;
+  try {
+    Ext.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, Ext.v2);
+  }
+
+  count = 0;
+  try {
+    ET.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, ET.v1);
+  }
+  count = 0;
+  try {
+    ET.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, ET.v2);
+  }
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t05.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A01_t05.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+///
+/// Case ⟨Static or library variable⟩. If `d` declares a static or
+/// library variable, the implicitly induced getter of `id` executes as follows:
+/// - Non-constant variable with an initializer. In the case where `d` has an
+///   initializing expression and is not constant, the implicitly induced getter
+///   of `id` is a late-initialized getter. This determines the semantics of an
+///   invocation.
+///
+/// @description Checks that if `v` has already been bound to an object, and `v`
+/// is  `final`, a dynamic error occurs.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+int count = 0;
+
+late final int v = (() {
+  if (count++ == 0) {
+    print(v);
+  }
+  return 42;
+})();
+
+class C {
+  static late final int v = (() {
+    if (count++ == 0) {
+      print(C.v);
+    }
+    return 42;
+  })();
+}
+
+mixin M {
+  static late final int v = (() {
+    if (count++ == 0) {
+      print(M.v);
+    }
+    return 42;
+  })();
+}
+
+enum E {
+  e0;
+  static late final int v = (() {
+    if (count++ == 0) {
+      print(E.v);
+    }
+    return 42;
+  })();
+}
+
+class A {}
+
+extension Ext on A {
+  static late final int v = (() {
+    if (count++ == 0) {
+      print(Ext.v);
+    }
+    return 42;
+  })();
+}
+
+extension type ET(int _) {
+  static late final int v = (() {
+    if (count++ == 0) {
+      print(ET.v);
+    }
+    return 42;
+  })();
+}
+
+void main() {
+  Expect.throws(() {
+    v;
+  });
+  count = 0;
+  Expect.throws(() {
+    C.v;
+  });
+  count = 0;
+  Expect.throws(() {
+    M.v;
+  });
+  count = 0;
+  Expect.throws(() {
+    E.v;
+  });
+  count = 0;
+  Expect.throws(() {
+    Ext.v;
+  });
+  count = 0;
+  Expect.throws(() {
+    ET.v;
+  });
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A03_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A03_t01.dart
@@ -58,7 +58,7 @@ extension type ET(int _) {
 void main() {
   Expect.throws(() {
     v = (() {
-        print(v);
+      print(v);
       return 42;
     })();
   });

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A03_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A03_t01.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-uninitialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that does not have an initializing
+/// expression. An invocation of `g` proceeds as follows: If the variable `v`
+/// has not been bound to an object then a dynamic error occurs. If `v` has been
+/// bound to an object `o′` then the invocation of `g` completes immediately,
+/// returning `o′`.
+/// ...
+/// Case ⟨Static or library variable⟩. If `d` declares a static or library
+/// variable, the implicitly induced getter of `id` executes as follows:
+/// ...
+/// - Variable without an initializer. If `d` declares a variable `id` without
+///   an initializing expression and does not have the modifier `late`, an
+///   invocation of the implicitly induced getter of `id` evaluates to the
+///   object that `id` is bound to.
+///   The variable is always bound to an object in this case. This may be the
+///   `null` object, which is the initial value of some variable declarations
+///   covered by this case.
+///   If `d` declares a variable `id` without an initializing expression and has
+///   the modifier `late`, the implicitly induced getter is a late-uninitialized
+///   getter. This determines the semantics of an invocation.
+///
+/// @description Checks that if `d` declares a variable `id` without an
+/// initializing expression and has the modifier `late` it is a dynamic error if
+/// `v` has not been bound to an object.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+late int v;
+
+class C {
+  static late final int v;
+}
+
+mixin M {
+  static late final int v;
+}
+
+enum E {
+  e0;
+  static late final int v;
+}
+
+class A {}
+
+extension Ext on A {
+  static late final int v;
+}
+
+extension type ET(int _) {
+  static late final int v;
+}
+
+void main() {
+  Expect.throws(() {
+    v = (() {
+        print(v);
+      return 42;
+    })();
+  });
+  Expect.throws(() {
+    C.v = (() {
+      print(C.v);
+      return 42;
+    })();
+  });
+  Expect.throws(() {
+    M.v = (() {
+      print(M.v);
+      return 42;
+    })();
+  });
+  Expect.throws(() {
+    E.v = (() {
+      print(E.v);
+      return 42;
+    })();
+  });
+  Expect.throws(() {
+    Ext.v = (() {
+      print(Ext.v);
+      return 42;
+    })();
+  });
+  Expect.throws(() {
+    ET.v = (() {
+      print(ET.v);
+      return 42;
+    })();
+  });
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A04_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A04_t01.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-uninitialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that does not have an initializing
+/// expression. An invocation of `g` proceeds as follows: If the variable `v`
+/// has not been bound to an object then a dynamic error occurs. If `v` has been
+/// bound to an object `o′` then the invocation of `g` completes immediately,
+/// returning `o′`.
+/// ...
+/// Case ⟨Late, uninitialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and does not have an
+/// initializing expression, the implicitly induced getter of `id` is a
+/// late-uninitialized getter. This determines the semantics of an invocation.
+///
+/// @description Checks that if `d` declares an instance variable `id` without
+/// an initializing expression and has the modifier `late` it is a dynamic error
+/// if `v` has not been bound to an object.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+class C {
+  late final int v;
+}
+
+mixin M {
+  late final int v;
+}
+
+class MA = Object with M;
+
+void main() {
+  C c = C();
+  Expect.throws(() {
+    c.v = (() {
+      print(c.v);
+      return 42;
+    })();
+  });
+
+  M m = MA();
+  Expect.throws(() {
+    m.v = (() {
+      print(m.v);
+      return 42;
+    })();
+  });
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t01.dart
@@ -17,8 +17,8 @@
 /// the implicitly induced getter of `id` is a late-initialized getter. This
 /// determines the semantics of an invocation.
 ///
-/// @description Checks the implicit getter of an initialized instance variable
-/// is late-initialized and evaluated only once.
+/// @description Checks the implicit getter of an initialized late instance
+/// variable is late-initialized and evaluated only once.
 /// @author sgrekhov22@gmail.com
 
 import "../../../Utils/expect.dart";

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t01.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t01.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Late, initialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and an initializing expression,
+/// the implicitly induced getter of `id` is a late-initialized getter. This
+/// determines the semantics of an invocation.
+///
+/// @description Checks the implicit getter of an initialized instance variable
+/// is late-initialized and evaluated only once.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+String log = "";
+
+writeLog(String i) {
+  log += i;
+  return i;
+}
+
+class C {
+  late var a = writeLog("a");
+  late String b = writeLog("b");
+  late final c = writeLog("c");
+  late final String d = writeLog("d");
+}
+
+mixin M {
+  late var a = writeLog("a");
+  late String b = writeLog("b");
+  late final c = writeLog("c");
+  late final String d = writeLog("d");
+}
+
+class MA = Object with M;
+
+main() {
+  C c = C();
+  Expect.equals("a", c.a);
+  Expect.equals("a", log);
+  Expect.equals("a", c.a);
+  Expect.equals("a", log);
+
+  Expect.equals("b", c.b);
+  Expect.equals("ab", log);
+  Expect.equals("b", c.b);
+  Expect.equals("ab", log);
+
+  Expect.equals("c", c.c);
+  Expect.equals("abc", log);
+  Expect.equals("c", c.c);
+  Expect.equals("abc", log);
+
+  Expect.equals("d", c.d);
+  Expect.equals("abcd", log);
+  Expect.equals("d", c.d);
+  Expect.equals("abcd", log);
+
+  log = "";
+  M m = MA();
+  Expect.equals("a", m.a);
+  Expect.equals("a", log);
+  Expect.equals("a", m.a);
+  Expect.equals("a", log);
+
+  Expect.equals("b", m.b);
+  Expect.equals("ab", log);
+  Expect.equals("b", m.b);
+  Expect.equals("ab", log);
+
+  Expect.equals("c", m.c);
+  Expect.equals("abc", log);
+  Expect.equals("c", m.c);
+  Expect.equals("abc", log);
+
+  Expect.equals("d", m.d);
+  Expect.equals("abcd", log);
+  Expect.equals("d", m.d);
+  Expect.equals("abcd", log);
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t02.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t02.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Late, initialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and an initializing expression,
+/// the implicitly induced getter of `id` is a late-initialized getter. This
+/// determines the semantics of an invocation.
+///
+/// @description Checks that it is not an error if during an evaluation of the
+/// initializing expression `id` is invoked.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+int count = 0;
+
+class C {
+  late int v = () {
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  }();
+}
+
+mixin M {
+  late int v = () {
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  }();
+}
+
+class MA = Object with M;
+
+main() {
+  Expect.equals(42, C().v);
+  Expect.equals(42, MA().v);
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t02.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t02.dart
@@ -17,8 +17,8 @@
 /// the implicitly induced getter of `id` is a late-initialized getter. This
 /// determines the semantics of an invocation.
 ///
-/// @description Checks that it is not an error if during an evaluation of the
-/// initializing expression `id` is invoked.
+/// @description Checks that it is not an error if `id` is invoked during an
+/// evaluation of the initializing expression .
 /// @author sgrekhov22@gmail.com
 
 import "../../../Utils/expect.dart";

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t03.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t03.dart
@@ -17,9 +17,9 @@
 /// the implicitly induced getter of `id` is a late-initialized getter. This
 /// determines the semantics of an invocation.
 ///
-/// @description Checks that it is a compile-time error if during an evaluation
-/// of the initializing expression `id` is invoked and the type of the variable
-/// is not specified.
+/// @description Checks that it is a compile-time error if `id` is invoked
+/// during an evaluation of the initializing expression, and the type of the
+/// variable is not specified.
 /// @author sgrekhov22@gmail.com
 
 int count = 0;

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t03.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t03.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Late, initialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and an initializing expression,
+/// the implicitly induced getter of `id` is a late-initialized getter. This
+/// determines the semantics of an invocation.
+///
+/// @description Checks that it is a compile-time error if during an evaluation
+/// of the initializing expression `id` is invoked and the type of the variable
+/// is not specified.
+/// @author sgrekhov22@gmail.com
+
+int count = 0;
+
+class C {
+  late final v = () { // Circularity during type inference
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  }();
+}
+
+mixin M {
+  late final v = () {
+//           ^
+// [analyzer] unspecified
+// [cfe] unspecified
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  }();
+}
+
+main() {
+  print(C);
+  print(M);
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t04.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t04.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Late, initialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and an initializing expression,
+/// the implicitly induced getter of `id` is a late-initialized getter. This
+/// determines the semantics of an invocation.
+///
+/// @description Checks that if the evaluation of `e` throws then the invocation
+/// of `g` completes throwing the same object and does not change the binding of
+/// `v`.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+int count = 0;
+
+int f() {
+  if (count++ == 0) {
+    throw 42;
+  }
+  return 0;
+}
+
+class C {
+  late int v1 = f();
+  late final int v2 = f();
+}
+
+mixin M {
+  late int v1 = f();
+  late final int v2 = f();
+}
+
+class MA = Object with M;
+
+main() {
+  C c = C();
+  try {
+    c.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, c.v1);
+  }
+  count = 0;
+  try {
+    c.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, c.v2);
+  }
+
+  count = 0;
+  M m = MA();
+  try {
+    m.v1;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, m.v1);
+  }
+  count = 0;
+  try {
+    m.v2;
+  } catch (e) {
+    Expect.equals(42, e);
+    Expect.equals(0, m.v2);
+  }
+}

--- a/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t05.dart
+++ b/Language/Variables/Evaluation_of_Implicit_Variable_Getters/definition_A05_t05.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A late-initialized getter is a getter `g` which is implicitly
+/// induced by a non-local variable `v` that has an initializing expression `e`.
+/// An invocation of g proceeds as follows:
+/// If the variable `v` has not been bound to an object then `e` is evaluated to
+/// an object `o`. If `v` has now been bound to an object, and `v` is `final`, a
+/// dynamic error occurs. Otherwise, `v` is bound to `o`, and the evaluation of
+/// `g` completes returning `o`. If the evaluation of `e` throws then the
+/// invocation of `g` completes throwing the same object and stack trace, and
+/// does not change the binding of `v`.
+/// ...
+/// Case ⟨Late, initialized instance variable⟩. If `d` declares an instance
+/// variable `id` which has the modifier `late` and an initializing expression,
+/// the implicitly induced getter of `id` is a late-initialized getter. This
+/// determines the semantics of an invocation.
+///
+/// @description Checks that if `v` has already been bound to an object, and `v`
+/// is  `final`, a dynamic error occurs.
+/// @author sgrekhov22@gmail.com
+
+import "../../../Utils/expect.dart";
+
+int count = 0;
+
+class C {
+  late final int v = (() {
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  })();
+}
+
+mixin M {
+  late final int v = (() {
+    if (count++ == 0) {
+      print(v);
+    }
+    return 42;
+  })();
+}
+
+class MA = Object with M;
+
+void main() {
+  Expect.throws(() {
+    C().v;
+  });
+  count = 0;
+  Expect.throws(() {
+    MA().v;
+  });
+}


### PR DESCRIPTION
It's possible to add some more tests for certain statements. However, these tests would be trivial — they would only check that the getter returns the object to which it is bound. This behavior is already covered by thousands of lines of code.