### PR TITLE
Fixes #3823. Update expected errors positions

### DIFF
--- a/LanguageFeatures/Augmentations/applying_augmentations_A01_t05.dart
+++ b/LanguageFeatures/Augmentations/applying_augmentations_A01_t05.dart
@@ -20,6 +20,9 @@ augment Null f1();
 // [cfe] unspecified
 
 abstract int Function() f2;
+//                      ^^
+// [analyzer] unspecified
+// [cfe] unspecified
 
 augment int f2() => 42;
 //          ^^
@@ -27,6 +30,9 @@ augment int f2() => 42;
 // [cfe] unspecified
 
 Null f3();
+//       ^
+// [analyzer] unspecified
+// [cfe] unspecified
 
 augment final f3 = () {};
 //            ^^


### PR DESCRIPTION
Here we have incomplete declarations with erroneous augmentations that are supposed to make them complete. Because the augmenting declarations contain errors, the introductory ones remain incomplete and produce errors. This fix adds these errors to the expected results.