### PR TITLE
Fixes #3825. Don't try to extend `String`

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t02.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t02.dart
@@ -18,19 +18,11 @@ import 'augmentation_libraries_lib.dart';
 
 class A {}
 
-class C {}
-
 augment class A extends FinalClass {}
 //                      ^^^^^^^^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-augment class C extends String {}
-//                      ^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
-
 main() {
   print(A);
-  print(C);
 }


### PR DESCRIPTION
The test checks that it is an error if augmentations adds `extends C` clause where `C` is a final class. But in case of `String` there will be also a compile time error because this class cannot be extended. So this check should be removed.