### PR TITLE
Fixes #3830. Update expected errors locations in static_errors_A05_t04.dart

### DIFF
--- a/LanguageFeatures/nnbd/static_errors_A05_t04.dart
+++ b/LanguageFeatures/nnbd/static_errors_A05_t04.dart
@@ -29,7 +29,6 @@ class C1 {
   C1() {}
 //^^
 // [analyzer] unspecified
-// [cfe] unspecified
 }
 
 abstract class C2 {
@@ -42,7 +41,6 @@ abstract class C2 {
   C2() {}
 //^^
 // [analyzer] unspecified
-// [cfe] unspecified
 }
 
 main() {


### PR DESCRIPTION
It was accidental change done when replacing specific error messages by `unspecified`.