### PR TITLE
Update VM tests to match fixed AOT-compatible framework setup.

### DIFF
--- a/VM/digit_separators_t01.dart
+++ b/VM/digit_separators_t01.dart
@@ -13,6 +13,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'digit_separators_t01_lib.dart' as testee_lib;
 
 void main([args = const <String>[]]) =>
     IsolateTestHarness('digit_separators_t01_lib.dart', args)
@@ -42,4 +43,4 @@ void main([args = const <String>[]]) =>
           ) as InstanceRef;
           Expect.equals(0x40000123.toRadixString(10), response.valueAsString);
         })
-        .run(pauseOnExit: true);
+        .run(pauseOnExit: true, testeeMain: testee_lib.main);

--- a/VM/digit_separators_t01_lib.dart
+++ b/VM/digit_separators_t01_lib.dart
@@ -11,6 +11,5 @@ void testeeMain() {
   debugger();
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t01.dart
+++ b/VM/primary_constructors_t01.dart
@@ -17,6 +17,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t01_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -55,8 +56,12 @@ void main([
     ) async {
       final isolateId = isolateRef.id!;
       final isolate = await service.getIsolate(isolateId);
-      final lib =
-          (await service.getObject(isolateId, isolate.rootLib!.id!)) as Library;
+      final lib = (await service.getObject(
+        isolateId,
+        isolate.libraries!.firstWhere(
+          (l) => l.uri!.contains('primary_constructors_t01_lib'),
+        ).id!,
+      )) as Library;
       final scriptId = lib.scripts!.first.id!;
 
       var breakpoint = await service.addBreakpoint(
@@ -100,4 +105,5 @@ void main([
     .run(
       pauseOnExit: true,
       extraArgs: ['--enable-experiment=primary-constructors'],
+      testeeMain: testee_lib.main,
     );

--- a/VM/primary_constructors_t01_lib.dart
+++ b/VM/primary_constructors_t01_lib.dart
@@ -29,6 +29,5 @@ void testeeMain() {
   var c3 = C3(5, 6); // LINE_G
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t02.dart
+++ b/VM/primary_constructors_t02.dart
@@ -19,6 +19,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t02_lib.dart' as testee_lib;
 
 void main([args = const <String>[]]) =>
     IsolateTestHarness('primary_constructors_t02_lib.dart', args)
@@ -48,4 +49,5 @@ void main([args = const <String>[]]) =>
         .run(
           pauseOnExit: true,
           extraArgs: ['--enable-experiment=primary-constructors'],
+          testeeMain: testee_lib.main,
         );

--- a/VM/primary_constructors_t02_lib.dart
+++ b/VM/primary_constructors_t02_lib.dart
@@ -16,6 +16,5 @@ void testeeMain() {
   C1('xxx'); // LINE_C
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t03.dart
+++ b/VM/primary_constructors_t03.dart
@@ -19,6 +19,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t03_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -124,4 +125,5 @@ void main([
     .run(
       pauseOnExit: true,
       extraArgs: ['--enable-experiment=primary-constructors'],
+      testeeMain: testee_lib.main,
     );

--- a/VM/primary_constructors_t03_lib.dart
+++ b/VM/primary_constructors_t03_lib.dart
@@ -38,6 +38,5 @@ void testeeMain() {
   C3('xxx'); // LINE_M
 } // LINE_N
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t04.dart
+++ b/VM/primary_constructors_t04.dart
@@ -18,6 +18,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t04_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -82,4 +83,5 @@ void main([
     .run(
       pauseOnExit: true,
       extraArgs: ['--enable-experiment=primary-constructors'],
+      testeeMain: testee_lib.main,
     );

--- a/VM/primary_constructors_t04_lib.dart
+++ b/VM/primary_constructors_t04_lib.dart
@@ -29,6 +29,5 @@ void testeeMain() {
   var c3 = C3(5, 6);
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t05.dart
+++ b/VM/primary_constructors_t05.dart
@@ -19,6 +19,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t05_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -112,4 +113,5 @@ void main([
     .run(
       pauseOnExit: true,
       extraArgs: ['--enable-experiment=primary-constructors'],
+      testeeMain: testee_lib.main,
     );

--- a/VM/primary_constructors_t05_lib.dart
+++ b/VM/primary_constructors_t05_lib.dart
@@ -34,6 +34,5 @@ void testeeMain() {
   ET3(3); // LINE_M
 } // LINE_N
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t06.dart
+++ b/VM/primary_constructors_t06.dart
@@ -19,6 +19,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t06_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -64,4 +65,5 @@ void main([
     .run(
       pauseOnExit: true,
       extraArgs: ['--enable-experiment=primary-constructors'],
+      testeeMain: testee_lib.main,
     );

--- a/VM/primary_constructors_t06_lib.dart
+++ b/VM/primary_constructors_t06_lib.dart
@@ -23,6 +23,5 @@ void testeeMain() {
   ET2(2);
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/primary_constructors_t07.dart
+++ b/VM/primary_constructors_t07.dart
@@ -18,6 +18,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'primary_constructors_t07_lib.dart' as testee_lib;
 
 void main([args = const <String>[]]) =>
     IsolateTestHarness('primary_constructors_t07_lib.dart', args)
@@ -46,4 +47,5 @@ void main([args = const <String>[]]) =>
         .run(
           pauseOnExit: true,
           extraArgs: ['--enable-experiment=primary-constructors'],
+          testeeMain: testee_lib.main,
         );

--- a/VM/primary_constructors_t07_lib.dart
+++ b/VM/primary_constructors_t07_lib.dart
@@ -18,6 +18,5 @@ void testeeMain() {
   C1('c1'); // LINE_C
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/private_named_parameters_t01.dart
+++ b/VM/private_named_parameters_t01.dart
@@ -17,6 +17,7 @@ import 'package:vm_service/vm_service.dart';
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../../../../pkg/vm_service/test/common/test_helper.dart';
 import '../Utils/expect.dart';
+import 'private_named_parameters_t01_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -152,4 +153,5 @@ void main([
         '--enable-experiment=primary-constructors',
         '--enable-experiment=private-named-parameters',
       ],
+      testeeMain: testee_lib.main,
     );

--- a/VM/private_named_parameters_t01_lib.dart
+++ b/VM/private_named_parameters_t01_lib.dart
@@ -26,6 +26,5 @@ void testeeMain() {
   C3(x: 1); // LINE_G
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/private_named_parameters_t02.dart
+++ b/VM/private_named_parameters_t02.dart
@@ -18,6 +18,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'private_named_parameters_t02_lib.dart' as testee_lib;
 
 void main([
   args = const <String>[],
@@ -55,4 +56,5 @@ void main([
         '--enable-experiment=primary-constructors',
         '--enable-experiment=private-named-parameters',
       ],
+      testeeMain: testee_lib.main,
     );

--- a/VM/private_named_parameters_t02_lib.dart
+++ b/VM/private_named_parameters_t02_lib.dart
@@ -20,6 +20,5 @@ void testeeMain() {
   debugger();
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/static_extensions_t01.dart
+++ b/VM/static_extensions_t01.dart
@@ -21,6 +21,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'static_extensions_t01_lib.dart' as testee_lib;
 
 void main([args = const <String>[]]) =>
     IsolateTestHarness('static_extensions_t01_lib.dart', args)
@@ -39,4 +40,5 @@ void main([args = const <String>[]]) =>
         .run(
           pauseOnExit: true,
           extraArgs: ['--enable-experiment=static-extensions'],
+          testeeMain: testee_lib.main,
         );

--- a/VM/static_extensions_t01_lib.dart
+++ b/VM/static_extensions_t01_lib.dart
@@ -17,6 +17,5 @@ void testeeMain() {
   debugger();
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);

--- a/VM/static_extensions_t02.dart
+++ b/VM/static_extensions_t02.dart
@@ -21,6 +21,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../../../pkg/vm_service/test/common/service_test_common.dart';
 import '../Utils/expect.dart';
+import 'static_extensions_t02_lib.dart' as testee_lib;
 
 void main([args = const <String>[]]) =>
     IsolateTestHarness('static_extensions_t02_lib.dart', args)
@@ -33,4 +34,5 @@ void main([args = const <String>[]]) =>
         .run(
           pauseOnExit: true,
           extraArgs: ['--enable-experiment=static-extensions'],
+          testeeMain: testee_lib.main,
         );

--- a/VM/static_extensions_t02_lib.dart
+++ b/VM/static_extensions_t02_lib.dart
@@ -18,6 +18,5 @@ void testeeMain() {
   C.foo(); // LINE_C
 }
 
-void main() {
-  startServiceTest(testeeConcurrent: testeeMain);
-}
+Future<void> main([args = const <String>[]]) =>
+    startServiceTest(testeeConcurrent: testeeMain);


### PR DESCRIPTION
Through further testing I realized that the previous setup of this framework was incompatible with the way test_runner + AOT works. This change maintains the clarity of having the code under test be in a separate library from the test entrypoint while also making the test compatible with AOT by having all code be a single program (via the import and tearoff).