### PR TITLE
#3912. Updated assertions in tests for super-mixins. Part 1.

### DIFF
--- a/LanguageFeatures/Super-mixins/compatible_t01.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t01.dart
@@ -2,16 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
-/// @issue 34713
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 
@@ -29,4 +31,5 @@ mixin M on B, C {
 }
 
 main() {
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/compatible_t02.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t02.dart
@@ -2,15 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author ngl@unipro.ru
 
 class T1 {}

--- a/LanguageFeatures/Super-mixins/compatible_t03.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t03.dart
@@ -2,15 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author ngl@unipro.ru
 
 abstract class B1<X extends List<int>> {

--- a/LanguageFeatures/Super-mixins/compatible_t04.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t04.dart
@@ -2,42 +2,41 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author sgrekhov@unipro.ru
-
 
 class S {}
 class T {}
 class X extends S {}
 class Y extends T {}
 
-class A<T> {
-}
-abstract class B<T> extends A<T> {
-}
-class C<T> extends B<T> {
-}
+class A<T> {}
 
-  mixin M<X extends S, Y extends T> on A<X>, B<Y> {
-//^
-// [analyzer] unspecified
-// [cfe] unspecified
-}
+abstract class B<T> extends A<T> {}
 
-class MA extends C<X> with M<X, Y> {
+class C<T> extends B<T> {}
+
+mixin M<X extends S, Y extends T> on A<X>, B<Y> {}
 //    ^
 // [analyzer] unspecified
 // [cfe] unspecified
-}
+
+class MA extends C<X> with M<X, Y> {}
+//                         ^
+// [analyzer] unspecified
+// [cfe] unspecified
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/compatible_t05.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t05.dart
@@ -2,15 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author sgrekhov@unipro.ru
 
 class S {}
@@ -18,43 +21,47 @@ class T {}
 class X extends S {}
 class Y extends T {}
 
-class I<T> {
-}
-abstract class J<T> {
-}
+class I<T> {}
 
-class A<T> {
-}
-abstract class B<T> extends A<T> {
-}
-class C<T, S> extends B<T> implements J<S> {
-}
+abstract class J<T> {}
 
-  mixin M1<X extends S, Y extends T> on A<X>, B<X> implements I<X>, J<X> {}
-  class MA1 extends C<X, Y> with M1<X, Y> {}
-//^
+class A<T> {}
+
+abstract class B<T> extends A<T> {}
+
+class C<T, S> extends B<T> implements J<S> {}
+
+mixin M1<X extends S, Y extends T> on A<X>, B<X> implements I<X>, J<X> {}
+
+class MA1 extends C<X, Y> with M1<X, Y> {}
+//    ^^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-  mixin M2<X extends S, Y extends T> on A<X>, B<Y> implements I<X>, J<Y> {}
-//^
+mixin M2<X extends S, Y extends T> on A<X>, B<Y> implements I<X>, J<Y> {}
+//    ^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-  class MA2 extends C<X, Y> with M2<X, Y> {}
-//                               ^^
+class MA2 extends C<X, Y> with M2<X, Y> {}
+//                             ^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-  mixin M3<X extends S, Y extends T> on A<Y>, B<X> implements I<X>, J<Y> {}
-//^
+mixin M3<X extends S, Y extends T> on A<Y>, B<X> implements I<X>, J<Y> {}
+//    ^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
-  class MA3 extends C<X, Y> with M3<X, Y> {}
-//                               ^^
+class MA3 extends C<X, Y> with M3<X, Y> {}
+//                             ^^
 // [analyzer] unspecified
 // [cfe] unspecified
 
 main() {
+  print(MA1);
+  print(M2);
+  print(MA2);
+  print(M3);
+  print(MA3);
 }

--- a/LanguageFeatures/Super-mixins/compatible_t06.dart
+++ b/LanguageFeatures/Super-mixins/compatible_t06.dart
@@ -2,15 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Further, the interfaces B and C must be compatible. The on clause
-/// introduces a synthetic interface combining B and C, call it A$super, which is
-/// equivalent to the interface of a class declaration of the form:
-///   abstract class A$super<X extends S, Y extends T> implements B, C {}
-/// It is a compile-time error for the mixin declaration if the class declaration
-/// above would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if the interfaces B and C are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// to implement incompatible interfaces.
 /// @author sgrekhov@unipro.ru
 
 class S {}
@@ -35,5 +38,5 @@ class MA<X, Y> extends C<Y, X> with M<Y, X> {
 }
 
 main() {
-  new MA<X, Y>();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/covariance_t01.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t01.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a compile error if mixin is applied to the
-/// class which doesn't implement required interface
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a compile-time error when a mixin is applied
+/// to a class that does not implement all required interfaces.
 /// @author sgrekhov@unipro.ru
 
 class A {
@@ -31,9 +30,8 @@ mixin M on A {
 class MA extends B with M {}
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 
 main() {
-  new MA().test();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/covariance_t02.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t02.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is no compile error if mixin is applied to the
-/// class which does implement required interface
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is not an error if a mixin is applied to a
+/// class which does implement all required interfaces.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";

--- a/LanguageFeatures/Super-mixins/covariance_t03.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t03.dart
@@ -2,19 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a runtime error if mixin is applied to the
-/// class which doesn't implement required interface by using covariant. See
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a run-time error when a mixin is applied
+/// to a class that does not implement all required interfaces by using
+/// `covariant` keyword. See
 /// https://github.com/dart-lang/sdk/issues/35111#issuecomment-437291038
-/// @issue 35111
 /// @author sgrekhov@unipro.ru
+/// @issue 35111
 
 import "../../Utils/expect.dart";
 

--- a/LanguageFeatures/Super-mixins/covariance_t04.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t04.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a compile error if mixin is applied to the
-/// class which doesn't implement required interface
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a compile-time error when a mixin is applied
+/// to a class that does not implement all required interfaces.
 /// @author sgrekhov@unipro.ru
 
 class A {

--- a/LanguageFeatures/Super-mixins/covariance_t05.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t05.dart
@@ -2,18 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is no compile error if mixin is applied to the
-/// class which does implement required interface
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is not an error if a mixin is applied to a
+/// class which does implement all required interfaces.
 /// @author sgrekhov@unipro.ru
-
 
 class A {
   covariant num number = 0;

--- a/LanguageFeatures/Super-mixins/covariance_t06.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t06.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a runtime error if mixin is applied to the
-/// class which doesn't implement required interface by covariant. See
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a run-time error when a mixin is applied
+/// to a class that does not implement all required interfaces by using
+/// `covariant` keyword. See
 /// https://github.com/dart-lang/sdk/issues/35111#issuecomment-437291038
 /// @author sgrekhov@unipro.ru
 /// @issue 35111, 63148

--- a/LanguageFeatures/Super-mixins/covariance_t07.dart
+++ b/LanguageFeatures/Super-mixins/covariance_t07.dart
@@ -2,19 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a runtime error if mixin is applied to the
-/// class which doesn't implement required interface by covariant. See
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a run-time error when a mixin is applied
+/// to a class that does not implement all required interfaces by using
+/// `covariant` keyword. See
 /// https://github.com/dart-lang/sdk/issues/35111#issuecomment-437291038
-/// @issue 35111
 /// @author sgrekhov@unipro.ru
+/// @issue 35111
 
 import "../../Utils/expect.dart";
 

--- a/LanguageFeatures/Super-mixins/declaration_t01.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t01.dart
@@ -2,17 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if classes from implements clause contain methods with the same names but
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if classes in its implements clause contain methods with the same names but
 /// different return types.
 /// @author ngl@unipro.ru
 
@@ -32,4 +33,5 @@ mixin M on B, C implements I, J {}
 // [cfe] unspecified
 
 main() {
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/declaration_t02.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t02.dart
@@ -2,20 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if its super classes contain getters with the same name and different return
-/// types.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if classes in its implements clause contain getters with the same names but
+/// different return types.
 /// @author ngl@unipro.ru
-
 
 class I {
   int get i1 => 1;
@@ -31,4 +31,5 @@ mixin M on B implements I {}
 // [cfe] unspecified
 
 main() {
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/declaration_t03.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t03.dart
@@ -2,18 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if its super classes contain getters with the same name and different return
-/// types. Test several interfaces in 'on' and 'implements' clauses
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if classes in its implements clause contain methods with the same names but
+/// different return types. Test several interfaces in 'on' and 'implements'
+/// clauses.
 /// @author ngl@unipro.ru
 
 class I {
@@ -32,4 +34,5 @@ mixin M on B, C implements I, J {}
 // [cfe] unspecified
 
 main() {
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/declaration_t04.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t04.dart
@@ -2,19 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that mixin declaration may have no implementation of all
-/// declared methods and properties
+/// @description Checks that mixin declaration is allowed to have no
+/// implementations of some of declared methods and properties.
 /// @author sgrekhov@unipro.ru
-
 
 abstract class I {
   int get i1;
@@ -41,4 +41,5 @@ abstract class C {
 mixin M on B, C implements I, J {}
 
 main() {
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/declaration_t05.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t05.dart
@@ -2,17 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if classes from implements clause are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if interfaces in its `implements` clause are incompatible.
 /// @author ngl@unipro.ru
 
 class T1 {}

--- a/LanguageFeatures/Super-mixins/declaration_t06.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t06.dart
@@ -2,17 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if classes from on clause and implements clause are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if interfaces in its `on` and `implements` clauses are incompatible.
 /// @author ngl@unipro.ru
 
 class T1 {}

--- a/LanguageFeatures/Super-mixins/declaration_t07.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t07.dart
@@ -2,17 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if classes from implements clause are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if interfaces in its `implements` clause are incompatible.
 /// @author ngl@unipro.ru
 
 abstract class I1<X extends List<int>> {

--- a/LanguageFeatures/Super-mixins/declaration_t08.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t08.dart
@@ -2,17 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces.
 ///
-/// @description Checks that it is a compile-time error for the mixin declaration
-/// if classes from on clause and implements clause are not compatible.
+/// @description Check that it is a compile-time error for a mixin declaration
+/// if interfaces in its `on` and `implements` clauses are incompatible.
 /// @author ngl@unipro.ru
 
 abstract class I1<X extends List<int>> {

--- a/LanguageFeatures/Super-mixins/declaration_t09.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t09.dart
@@ -2,20 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces. The interface `MS` is called the superinvocation interface of
+/// the mixin declaration `M`. If the mixin declaration `M` has only one
+/// declared superinterface, `T1`, then the superinvocation interface `MS` has
+/// exactly the same members as the interface `T1`.
 ///
-/// @description Checks that a mixin declaration in form
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1extendsB1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// ...
+/// The interface introduced by the mixin declaration `M` has the same member
+/// signatures and superinterfaces as `MI`.
+///
+/// @description Checks that a mixin declaration in the form
+/// ```
 /// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// is equivalent to the interface of the class declared as
-/// abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///   implements D, E { body' }
+/// ```
+/// has the same member signatures and superinterfaces as
+/// ```
+/// abstract class A<X extends S, Y extends T> extends MS<X, Y>
+///       implements D, E { body' }
+/// ```
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";

--- a/LanguageFeatures/Super-mixins/declaration_t10.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t10.dart
@@ -2,20 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces. The interface `MS` is called the superinvocation interface of
+/// the mixin declaration `M`. If the mixin declaration `M` has only one
+/// declared superinterface, `T1`, then the superinvocation interface `MS` has
+/// exactly the same members as the interface `T1`.
 ///
-/// @description Checks that a mixin declaration in form
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1extendsB1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// ...
+/// The interface introduced by the mixin declaration `M` has the same member
+/// signatures and superinterfaces as `MI`.
+///
+/// @description Checks that a mixin declaration in the form
+/// ```
 /// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// is equivalent to the interface of the class declared as
-/// abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///   implements D, E { body' }
+/// ```
+/// has the same member signatures and superinterfaces as
+/// ```
+/// abstract class A<X extends S, Y extends T> extends MS<X, Y>
+///       implements D, E { body' }
+/// ```
 /// @author sgrekhov@unipro.ru
 
 abstract class B {
@@ -79,8 +96,8 @@ class AI4 implements A {
 }
 
 main() {
-  new AI1();
-  new AI2();
-  new AI3();
-  new AI4();
+  print(AI1);
+  print(AI2);
+  print(AI3);
+  print(AI4);
 }

--- a/LanguageFeatures/Super-mixins/declaration_t11.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t11.dart
@@ -2,20 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces. The interface `MS` is called the superinvocation interface of
+/// the mixin declaration `M`. If the mixin declaration `M` has only one
+/// declared superinterface, `T1`, then the superinvocation interface `MS` has
+/// exactly the same members as the interface `T1`.
 ///
-/// @description Checks that a mixin declaration in form
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1extendsB1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// ...
+/// The interface introduced by the mixin declaration `M` has the same member
+/// signatures and superinterfaces as `MI`.
+///
+/// @description Checks that a mixin declaration in the form
+/// ```
 /// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// is equivalent to the interface of the class declared as
-/// abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///   implements D, E { body' }.
+/// ```
+/// has the same member signatures and superinterfaces as
+/// ```
+/// abstract class A<X extends S, Y extends T> extends MS<X, Y>
+///       implements D, E { body' }
+/// ```
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";

--- a/LanguageFeatures/Super-mixins/declaration_t12.dart
+++ b/LanguageFeatures/Super-mixins/declaration_t12.dart
@@ -2,20 +2,37 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// It is a compile time error for the mixin declaration if this class
-/// declarations would not be valid.
+/// @assertion Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name. It is a compile-time error for the mixin
+/// declaration if the `MS` class declaration would cause a compile-time error,
+/// that is, if any member is declared by more than one declared superinterface,
+/// and there is not a most specific signature for that member among the super
+/// interfaces. The interface `MS` is called the superinvocation interface of
+/// the mixin declaration `M`. If the mixin declaration `M` has only one
+/// declared superinterface, `T1`, then the superinvocation interface `MS` has
+/// exactly the same members as the interface `T1`.
 ///
-/// @description Checks that a mixin declaration in form
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1extendsB1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// ...
+/// The interface introduced by the mixin declaration `M` has the same member
+/// signatures and superinterfaces as `MI`.
+///
+/// @description Checks that a mixin declaration in the form
+/// ```
 /// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// is equivalent to the interface of the class declared as
-/// abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///   implements D, E { body' }.
+/// ```
+/// has the same member signatures and superinterfaces as
+/// ```
+/// abstract class A<X extends S, Y extends T> extends MS<X, Y>
+///       implements D, E { body' }
+/// ```
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";


### PR DESCRIPTION
This is an experimental PR demonstrating how co19 tests from `LanguageFeatures` can be migrated to the `Language` folder. The full process will be as follows:
- For language features that are already integrated into the current specification, update the assertions to use the wording from the specification.
- Rename the tests (if necessary) and move them to the appropriate folder under `Language`.