### PR TITLE
#3912. Updated assertions in tests for super-mixins. Part 2.

### DIFF
--- a/LanguageFeatures/Super-mixins/implementation_t01.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t01.dart
@@ -2,16 +2,34 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C.
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces.
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 
@@ -31,8 +49,7 @@ class A implements B, C {
 
 mixin M on B, C {}
 
-class MA extends A with M {
-}
+class MA extends A with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/implementation_t02.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t02.dart
@@ -2,16 +2,34 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C.
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces.
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 

--- a/LanguageFeatures/Super-mixins/implementation_t03.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t03.dart
@@ -2,17 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with implements only one of the interfaces
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class with implements only one of the interfaces.
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 
@@ -33,9 +51,8 @@ mixin M on B, C {}
 class MA extends A with M {}
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t04.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t04.dart
@@ -2,18 +2,36 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with implements only one of the interfaces but not implemented
-/// interface is not abstract
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class with implements only one of the interfaces but not
+/// implemented interface is not an abstract.
 /// @author sgrekhov@unipro.ru
 
 abstract class B {
@@ -33,10 +51,9 @@ mixin M on B, C {}
 class MA extends A with M {
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 }
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t05.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t05.dart
@@ -2,17 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with extends only one of the interfaces
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class which extends only one of the interfaces.
 /// @author sgrekhov@unipro.ru
 
 class B {
@@ -31,10 +49,9 @@ mixin M on B, C {}
 class MA extends A with M {
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 }
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t06.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t06.dart
@@ -2,18 +2,36 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with extends only one of the interfaces but not implemented
-/// interface is not abstract
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class which extends only one of the interfaces but not
+/// implemented interface is not abstract.
 /// @author sgrekhov@unipro.ru
 
 class B {
@@ -32,10 +50,9 @@ mixin M on B, C {}
 class MA extends A with M {
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 }
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t07.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t07.dart
@@ -2,17 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with mixins only one of the interfaces
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class which mixins only one of the interfaces.
 /// @author sgrekhov@unipro.ru
 
 mixin class B {
@@ -31,10 +49,9 @@ mixin M on B, C {}
 class MA extends A with M {
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 }
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t08.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t08.dart
@@ -2,18 +2,36 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C. Test the case when mixin declaration is applied
-/// to the class with mixins only one of the interfaces but not implemented
-/// interface is not abstract
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test the case when mixin declaration
+/// is applied to the class which mixins only one of the interfaces but not
+/// implemented interface is not abstract.
 /// @author sgrekhov@unipro.ru
 
 mixin class B {
@@ -32,10 +50,9 @@ mixin M on B, C {}
 class MA extends A with M {
 //                      ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 }
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/implementation_t09.dart
+++ b/LanguageFeatures/Super-mixins/implementation_t09.dart
@@ -2,16 +2,34 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion In a mixin declaration like
-/// mixin A<X extends S, Y extends T> on B, C implements D, E { body }
-/// the on clause declares the interfaces B and C as super-class constraints of
-/// the mixin. Having a super-class constaint allows the mixin declaration
-/// instance members to perform super-invocations (like super.foo()) if they are
-/// allowed by a class implementing both B and C. The mixin introduced by A can
-/// then only be applied to classes that implement both B and C.
+/// @assertion Let `M` be a mixin declaration of the form
+/// ```
+/// mixin N<X1 extends B1, ..., Xs extends Bs> on T1, ..., Tn
+///       implements I1, ..., Ik { members }
+/// ```
+/// ...
+/// Let `MS` be the interface declared by the class declaration
+/// ```
+/// abstract class Msuper<P1, ..., Pm> implements T1, ..., Tn {}
+/// ```
+/// where `Msuper` is a fresh name.
+/// ...
+/// Let `MI` be the interface that would be defined by the class declaration
+/// ```
+/// abstract class N<X1 extends B1, ..., Xs extends Bs>
+///       implements T1, ..., Tn, I1, ..., Ik { members′ }
+/// ```
+/// where `members′` are the member declarations of the mixin declaration `M`
+/// except that all superinvocations are treated as if `super` was a valid
+/// expression with static type `MS`. It is a compile-time error for the mixin
+/// `M` if this `N` class declaration would cause a compile-time error, that is,
+/// if the required superinterfaces, the implemented interfaces and the
+/// declarations do not define a consistent interface, if any member declaration
+/// contains a compile-time error other than a super-invocation, or if a
+/// super-invocation is not valid against the interface `MS`.
 ///
-/// @description Checks that mixin declaration can only be applied to classes
-/// that implement both B and C.Test type parameters
+/// @description Check that a mixin declaration can only be applied to classes
+/// that implement all required interfaces. Test type parameters.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -24,6 +42,7 @@ class Y extends T {}
 abstract class I {
   int get gi1;
 }
+
 abstract class J {
   int get gj1;
 }
@@ -49,8 +68,7 @@ mixin M<X extends S, Y extends T> on B<X>, C<Y> implements I, J {
   int get gj1 => 4;
 }
 
-class MA extends A with M<X, Y> {
-}
+class MA extends A with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/member_declaration_t01.dart
+++ b/LanguageFeatures/Super-mixins/member_declaration_t01.dart
@@ -2,18 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// . . .
-/// and member declarations are not allowed to have the same name as the mixin
-/// declaration.
+/// @assertion It is a compile-time error if a class named `C` declares a member
+/// with basename `C`.
 ///
-/// @description Checks that it is a compile error if a mixin member has the same
-/// name as a mixin declaration.
+/// @description Checks that it is a compile-time error if a mixin member has
+/// the same name as a mixin declaration.
 /// @author ngl@unipro.ru
 
 class I {}

--- a/LanguageFeatures/Super-mixins/member_declaration_t02.dart
+++ b/LanguageFeatures/Super-mixins/member_declaration_t02.dart
@@ -2,18 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion A mixin declaration defines an interface. The interface for this
-/// mixin declaration is equivalent to the interface of the class declared as:
-///  abstract class A<X extends S, Y extends T> extends A$super<X, Y>
-///    implements D, E { body' }
-/// where body' contains abstract declarations corresponding to the instance
-/// members of body of the mixin A.
-/// . . .
-/// and member declarations are not allowed to have the same name as the mixin
-/// declaration.
+/// @assertion It is a compile-time error if a class named `C` declares a member
+/// with basename `C`.
 ///
-/// @description Checks that it is a compile error if a mixin member has the same
-/// name as a mixin declaration. Test type parameters
+/// @description Checks that it is a compile-time error if a mixin member has
+/// the same name as a mixin declaration. Test a mixin with type parameters.
 /// @author sgrekhov@unipro.ru
 
 class S {}

--- a/LanguageFeatures/Super-mixins/mixin_application_t01.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t01.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'extends' implementation of 'on' clause interfaces
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'extends' implementation of 'on' clause interfaces.
 /// @author ngl@unipro.ru
 /// @author sgrekhov@unipro.ru
 
@@ -27,12 +27,14 @@ class A {
   String a3() => "A.a3";
   String operator -() => a1.substring(0, 1);
 }
+
 abstract class B extends A {
   String get b1;
   void set b2(String v);
   String b3();
   String operator ~();
 }
+
 class C extends B {
   String get b1 => "C.b1";
   void set b2(String v) {
@@ -51,8 +53,7 @@ mixin M on A, B {
   String operator +(M v) => v.m1 + '+1';
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t02.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t02.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'extends' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'extends' implementation of 'on' clause interfaces and 'implements'
+/// part of the mixin.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -27,6 +27,7 @@ class I {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 2);
 }
+
 abstract class J {
   String get j1;
   void set j2(String v);
@@ -42,12 +43,14 @@ class A {
   String a3() => "A.a3";
   String operator +(A v) => v.a1.substring(0, 1);
 }
+
 abstract class B extends A {
   String get b1;
   void set b2(String v);
   String b3();
   String operator -(B v);
 }
+
 class C extends B implements J {
   String get b1 => "C.b1";
   void set b2(String v) {
@@ -79,8 +82,7 @@ mixin M on A, B implements I, J {
   String operator ~() => i1.substring(0, 1);
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t03.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t03.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'implements' implementation of 'on' clause interfaces
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'implements' implementation of 'on' clause interfaces.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -26,12 +26,14 @@ class A {
   String a3() => "A.a3";
   String operator ~() => a1.substring(3);
 }
+
 abstract class B {
   String get b1;
   void set b2(String v);
   String b3();
   String operator -();
 }
+
 class C implements A, B {
   String get a1 => "C.a1";
   set a2(String v) {
@@ -56,8 +58,7 @@ mixin M on A, B {
   String m3() => "m3";
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t04.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t04.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'implements' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'implements' implementation of 'on' clause interfaces and 'implements'
+/// part of the mixin
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -27,6 +27,7 @@ class I {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 1);
 }
+
 abstract class J {
   String get j1;
   void set j2(String v);
@@ -41,11 +42,13 @@ class A {
   }
   String a3() => "A.a3";
 }
+
 abstract class B {
   String get b1;
   void set b2(String v);
   String b3();
 }
+
 class C implements A, B, J {
   String get a1 => "C.a1";
   set a2(String v) {
@@ -81,8 +84,7 @@ mixin M on A, B implements I, J {
   String operator ~() => i1.substring(2, 3);
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t05.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t05.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'mixin' implementation of 'on' clause interfaces
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'mixin' implementation of 'on' clause interfaces.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -26,6 +26,7 @@ mixin class A {
   String a3() => "A.a3";
   String operator ~() => a1.substring(0, 1);
 }
+
 abstract class B {
   String get b1;
   void set b2(String v);
@@ -50,8 +51,7 @@ mixin M on A, B {
   String m3() => "m3";
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t06.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t06.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'mixin' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'mixin' implementation of 'on' clause interfaces and 'implements' part
+/// of the mixin.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -43,6 +43,7 @@ mixin class A {
   String a3() => "A.a3";
   String operator +(A v) => v.a1.substring(0, 1);
 }
+
 abstract class B extends A {
   String get b1;
   void set b2(String v);
@@ -79,8 +80,7 @@ mixin M on A, B implements I, J {
   String operator ~() => i1.substring(2, 3);
 }
 
-class MA extends C with M {
-}
+class MA extends C with M {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t07.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t07.dart
@@ -2,17 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'extends' implementation of 'on' clause interfaces and type
-/// parameters
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'extends' implementation of 'on' clause interfaces and type parameters.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -38,6 +37,7 @@ abstract class B<T> extends A<T> {
   String b3();
   String operator -();
 }
+
 class C<T> extends B<T> {
   String get b1 => "C.b1";
   void set b2(String v) {
@@ -55,8 +55,7 @@ mixin M<X extends S, Y extends T> on A<X>, B<X> {
   String m3() => "m3";
 }
 
-class MA extends C<X> with M<X, Y> {
-}
+class MA extends C<X> with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t08.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t08.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'extends' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'extends' implementation of 'on' clause interfaces and 'implements'
+/// part of the mixin.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -32,6 +32,7 @@ class I<T> {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 1);
 }
+
 abstract class J<T> {
   String get j1;
   void set j2(String v);
@@ -47,6 +48,7 @@ class A<T> {
   String a3() => "A.a3";
   String operator +(A v) => a1.substring(0, 1);
 }
+
 abstract class B<T> extends A<T> {
   String get b1;
   void set b2(String v);
@@ -83,8 +85,7 @@ mixin M<X extends S, Y extends T> on A<X>, B<X> implements I<X>, J<Y> {
   String operator ~() => i1.substring(0, 3);
 }
 
-class MA extends C<X, Y> with M<X, Y> {
-}
+class MA extends C<X, Y> with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t09.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t09.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'implements' implementation of 'on' clause interfaces
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'implements' implementation of 'on' clause interfaces.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -31,12 +31,14 @@ class A<T1> {
   String a3() => "A.a3";
   String operator ~() => a1.substring(0, 1);
 }
+
 abstract class B<T1> {
   String get b1;
   void set b2(String v);
   String b3();
   String operator -() => b1.substring(0, 1);
 }
+
 class C<T1, S1> implements A<T1>, B<S1> {
   String get a1 => "C.a1";
   set a2(String v) {
@@ -61,8 +63,7 @@ mixin M<X1 extends S, Y1 extends T> on A<Y1>, B<X1> {
   String m3() => "m3";
 }
 
-class MA<X1 extends S, Y1 extends T> extends C<Y1, X1> with M<X1, Y1> {
-}
+class MA<X1 extends S, Y1 extends T> extends C<Y1, X1> with M<X1, Y1> {}
 
 main() {
   MA<X, Y> ma = new MA<X, Y>();

--- a/LanguageFeatures/Super-mixins/mixin_application_t10.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t10.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'implements' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'implements' implementation of 'on' clause interfaces and 'implements'
+/// part of the mixin.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -32,6 +32,7 @@ class I<T> {
   String i3() => "I.i3";
   String operator ~() => i1.substring(0, 1);
 }
+
 abstract class J<T> {
   String get j1;
   void set j2(String v);
@@ -47,12 +48,14 @@ class A<T> {
   String a3() => "A.a3";
   String operator +(A v) => a1.substring(0, 1);
 }
+
 abstract class B<T> {
   String get b1;
   void set b2(String v);
   String b3();
   String operator -(B v) => b1.substring(0, 1);
 }
+
 class C<T1, T2, T3> implements A<T1>, B<T2>, J<T3> {
   String get a1 => "C.a1";
   set a2(String v) {
@@ -91,8 +94,7 @@ mixin M<X extends S, Y extends T>  on A<X>, B<Y> implements I<S>, J<T> {
   String operator ~() => i1.substring(0, 3);
 }
 
-class MA extends C<X, Y, T> with M<X, Y> {
-}
+class MA extends C<X, Y, T> with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t11.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t11.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'mixin' implementation of 'on' clause interfaces
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'mixin' implementation of 'on' clause interfaces.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -59,8 +59,7 @@ mixin M<X extends S, Y extends T> on A<X>, B<Y> {
   String m3() => "m3";
 }
 
-class MA extends C<X, Y> with M<X, Y> {
-}
+class MA extends C<X, Y> with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t12.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t12.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that there is no compile error if a mixin is applied to a
-/// class that implements all the 'on' type requirements of the mixin
-/// declaration. Test 'mixin' implementation of 'on' clause interfaces and
-/// 'implements' part of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Check that it is not an error if a mixin is applied to a class
+/// that implements all of the on-type requirements of the mixin declaration.
+/// Test 'mixin' implementation of 'on' clause interfaces and 'implements' part
+/// of the mixin.
 /// @author sgrekhov@unipro.ru
 
 import "../../Utils/expect.dart";
@@ -86,8 +86,7 @@ mixin M<X extends S, Y extends T> on A<X>, B<X> implements I<X>, J<Y> {
   String operator ~() => i1.substring(0, 3);
 }
 
-class MA extends C<X, Y> with M<X, Y> {
-}
+class MA extends C<X, Y> with M<X, Y> {}
 
 main() {
   MA ma = new MA();

--- a/LanguageFeatures/Super-mixins/mixin_application_t13.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t13.dart
@@ -2,15 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
 ///
-/// @description Checks that it is a compile error if a mixin is applied to a
-/// class that does not implement all the 'on' type requirements of the mixin
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
+///
+/// @description Checks that it is a compile-time error if a mixin is applied to
+/// a class that does not implement all the 'on' type requirements of the mixin
 /// declaration.
 /// @author sgrekhov@unipro.ru
 
@@ -24,18 +24,15 @@ class J<T> {}
 class B<T> {}
 class C<T> {}
 
-mixin M<X extends S, Y extends T> on B<X>, C<Y> implements I<S>, J<T> {
-}
+mixin M<X extends S, Y extends T> on B<X>, C<Y> implements I<S>, J<T> {}
 
-class A<T1, T2, T3, T4> implements B<T1>, C<T2>, I<T3>, J<T4> {
-}
+class A<T1, T2, T3, T4> implements B<T1>, C<T2>, I<T3>, J<T4> {}
 
-  class MA extends A<X, Y, S, S> with M<X, Y> {
-//^
+class MA extends A<X, Y, S, S> with M<X, Y> {}
+//    ^^
 // [analyzer] unspecified
 // [cfe] unspecified
-}
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/mixin_application_t14.dart
+++ b/LanguageFeatures/Super-mixins/mixin_application_t14.dart
@@ -2,16 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion Mixin application semantics is mostly unchanged, except that it's
-/// a compile-time error to apply a mixin to a class that doesn't implement all
-/// the 'on' type requirements of the mixin declaration, or apply a mixin
-/// containing super-invocations to a class that doesn't have a concrete
-/// implementation of the super-invoked members compatible with the
-/// super-constraint interface.
+/// @assertion Let `S` be a class, `M` be a mixin with required superinterfaces
+/// `T1, ..., Tn`, combined superinterface `MS`, implemented interfaces
+/// `I1, ..., Ik` and members as member declarations, and let `N` be a name.
+///
+/// It is a compile-time error to apply `M` to `S` if `S` does not implement,
+/// directly or indirectly, all of `T1, ..., Tn`.
 ///
 /// @description Checks that it is a compile error if a mixin is applied to a
 /// class that does not implement all the 'on' type requirements of the mixin
-/// declaration. Test omitted 'on'
+/// declaration. Test omitted 'on'.
 /// @author sgrekhov@unipro.ru
 
 class I {}
@@ -24,9 +24,8 @@ mixin M on B, C implements I, J {}
 class MA with M {}
 //            ^
 // [analyzer] unspecified
-//    ^
 // [cfe] unspecified
 
 main() {
-  new MA();
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t01.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t01.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors.
 /// @author ngl@unipro.ru
-
 
 class I {}
 class J {}
@@ -29,5 +28,6 @@ class MA extends A with M {}
 // [cfe] unspecified
 
 main() {
-  new MA();
+  print(M);
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t02.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t02.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors. Test
-/// named constructor
+/// named constructor.
 /// @author sgrekhov@unipro.ru
 
 class I {}

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t03.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t03.dart
@@ -2,14 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors. Test
-/// factory constructor
+/// factory constructor.
+/// @author sgrekhov@unipro.ru
 /// @issue 24767
 /// @issue 34804
-/// @author sgrekhov@unipro.ru
 
 class I {}
 class J {}
@@ -29,5 +29,5 @@ class A implements B, C, I, J {}
 class MA extends A with M {}
 
 main() {
-  new MA();
+  print(M);
 }

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t04.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t04.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors.
 /// @author ngl@unipro.ru
@@ -31,5 +31,6 @@ class MA extends A with M {}
 // [cfe] unspecified
 
 main() {
-  new MA();
+  print(M);
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t05.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t05.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors.
 /// @author sgrekhov@unipro.ru
@@ -31,5 +31,6 @@ class MA extends A with M {}
 // [cfe] unspecified
 
 main() {
-  new MA();
+  print(M);
+  print(MA);
 }

--- a/LanguageFeatures/Super-mixins/mixin_constructor_t06.dart
+++ b/LanguageFeatures/Super-mixins/mixin_constructor_t06.dart
@@ -2,14 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// @assertion The mixinMember production allows the same instance or static
-/// members that a class would allow, but no constructors (for now).
+/// @assertion It is a compile-time error to declare a constructor in a
+/// mixin-declaration.
 ///
 /// @description Checks that mixin declaration doesn't allow constructors.
+/// @author sgrekhov@unipro.ru
 /// @issue 24767
 /// @issue 34804
-/// @author sgrekhov@unipro.ru
-
 
 class S {}
 class T {}
@@ -32,5 +31,5 @@ class A implements B, C, I, J {}
 class MA<X extends S, Y extends T> extends A with M<X, Y> {}
 
 main() {
-  new MA();
+  print(M);
 }


### PR DESCRIPTION
This is an experimental PR demonstrating how co19 tests from `LanguageFeatures` can be migrated to the `Language` folder. The full process will be as follows:
- For language features that are already integrated into the current specification, update the assertions to use the wording from the specification.
- Rename the tests (if necessary) and move them to the appropriate folder under `Language`.