### PR TITLE
Fixes #3915. Add tests for augmentation with `with` clause

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t27.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t27.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A class, enum, extension type, mixin, or mixin class augmentation
+/// may specify `extends`, `implements` and `with` clauses (when otherwise
+/// supported). The types in these clauses are appended to the introductory
+/// declarations' clauses of the same kind, and if that clause did not exist
+/// previously, then it is added with the new types.
+///
+/// @description Checks that an augment of a class may specify a `with` clause
+/// and invocations of members of 'super' works as expected.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import '../../Utils/expect.dart';
+
+StringBuffer log = StringBuffer();
+
+mixin M1 {
+  String v = 'M1';
+  String get g => 'M1';
+  String m() => 'M1';
+  void set s(String v) {
+    log.write('$v;');
+  }
+}
+
+mixin M2 on M1 {
+  late String v = '${super.v} and M2';
+  String get g => '${super.g} and M2';
+  String m() => '${super.m()} and M2';
+  void set s(String v) {
+    log.write('${super.s = v} and M2');
+  }
+}
+
+class C with M1 {}
+
+augment class C with M2 {}
+
+main() {
+  Expect.equals('M1 and M2', C().v);
+  Expect.equals('M1 and M2', C().g);
+  Expect.equals('M1 and M2', C().m());
+  C().s = 'M1';
+  Expect.equals('M1;M1 and M2', log.toString());
+}

--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t28.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t28.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A class, enum, extension type, mixin, or mixin class augmentation
+/// may specify `extends`, `implements` and `with` clauses (when otherwise
+/// supported). The types in these clauses are appended to the introductory
+/// declarations' clauses of the same kind, and if that clause did not exist
+/// previously, then it is added with the new types.
+///
+/// @description Checks that an augment of an enum may specify a `with` clause
+/// and invocations of members of 'super' works as expected.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import '../../Utils/expect.dart';
+
+StringBuffer log = StringBuffer();
+
+mixin M1 {
+  String get g => 'M1';
+  String m() => 'M1';
+  void set s(String v) {
+    log.write('$v;');
+  }
+}
+
+mixin M2 on M1 {
+  String get g => '${super.g} and M2';
+  String m() => '${super.m()} and M2';
+  void set s(String v) {
+    log.write('${super.s = v} and M2');
+  }
+}
+
+enum E with M1 {
+  e0;
+}
+
+augment enum E with M2 {;}
+
+main() {
+  Expect.equals('M1 and M2', E.e0.g);
+  Expect.equals('M1 and M2', E.e0.m());
+  E.e0.s = 'M1';
+  Expect.equals('M1;M1 and M2', log.toString());
+}

--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t29.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t29.dart
@@ -19,9 +19,9 @@ import '../../Utils/expect.dart';
 StringBuffer log = StringBuffer();
 
 class A {
-  String v = 'M1';
-  String get g => 'M1';
-  String m() => 'M1';
+  String v = 'A';
+  String get g => 'A';
+  String m() => 'A';
   void set s(String v) {
     log.write('$v;');
   }
@@ -41,9 +41,9 @@ class C extends A {}
 augment class C with M2 {}
 
 main() {
-  Expect.equals('M1 and M2', C().v);
-  Expect.equals('M1 and M2', C().g);
-  Expect.equals('M1 and M2', C().m());
-  C().s = 'M1';
-  Expect.equals('M1;M1 and M2', log.toString());
+  Expect.equals('A and M2', C().v);
+  Expect.equals('A and M2', C().g);
+  Expect.equals('A and M2', C().m());
+  C().s = 'A';
+  Expect.equals('A;A and M2', log.toString());
 }

--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t29.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t29.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A class, enum, extension type, mixin, or mixin class augmentation
+/// may specify `extends`, `implements` and `with` clauses (when otherwise
+/// supported). The types in these clauses are appended to the introductory
+/// declarations' clauses of the same kind, and if that clause did not exist
+/// previously, then it is added with the new types.
+///
+/// @description Checks that an augment of a class may specify a `with` clause
+/// and invocations of members of 'super' works as expected.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import '../../Utils/expect.dart';
+
+StringBuffer log = StringBuffer();
+
+class A {
+  String v = 'M1';
+  String get g => 'M1';
+  String m() => 'M1';
+  void set s(String v) {
+    log.write('$v;');
+  }
+}
+
+mixin M2 on A {
+  late String v = '${super.v} and M2';
+  String get g => '${super.g} and M2';
+  String m() => '${super.m()} and M2';
+  void set s(String v) {
+    log.write('${super.s = v} and M2');
+  }
+}
+
+class C extends A {}
+
+augment class C with M2 {}
+
+main() {
+  Expect.equals('M1 and M2', C().v);
+  Expect.equals('M1 and M2', C().g);
+  Expect.equals('M1 and M2', C().m());
+  C().s = 'M1';
+  Expect.equals('M1;M1 and M2', log.toString());
+}

--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t30.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t30.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A class, enum, extension type, mixin, or mixin class augmentation
+/// may specify `extends`, `implements` and `with` clauses (when otherwise
+/// supported). The types in these clauses are appended to the introductory
+/// declarations' clauses of the same kind, and if that clause did not exist
+/// previously, then it is added with the new types.
+///
+/// @description Checks that an augment of a class may specify a `with` clause
+/// and interface members are implemented as expected.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import '../../Utils/expect.dart';
+
+StringBuffer log = StringBuffer();
+
+mixin M1 {
+  String v = 'M1';
+  String get g => 'M1';
+  String m() => 'M1';
+  void set s(String v) {
+    log.write('$v;');
+  }
+}
+
+mixin M2 on M1 {
+  late String v = '${super.v} and M2';
+  String get g => '${super.g} and M2';
+  String m() => '${super.m()} and M2';
+  void set s(String v) {
+    log.write('${super.s = v} and M2');
+  }
+}
+
+class C {}
+
+augment class C with M1 implements M2 {}
+
+main() {
+  Expect.equals('M1', C().v);
+  Expect.equals('M1', C().g);
+  Expect.equals('M1', C().m());
+  C().s = 'M1';
+  Expect.equals('M1;', log.toString());
+}

--- a/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t31.dart
+++ b/LanguageFeatures/Augmentations/augmenting_class_like_declarations_A02_t31.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion A class, enum, extension type, mixin, or mixin class augmentation
+/// may specify `extends`, `implements` and `with` clauses (when otherwise
+/// supported). The types in these clauses are appended to the introductory
+/// declarations' clauses of the same kind, and if that clause did not exist
+/// previously, then it is added with the new types.
+///
+/// @description Checks that an augment of a enum may specify a `with` clause
+/// and interface members are implemented as expected.
+/// @author sgrekhov22@gmail.com
+
+// SharedOptions=--enable-experiment=augmentations
+
+import '../../Utils/expect.dart';
+
+StringBuffer log = StringBuffer();
+
+mixin M1 {
+  String get g => 'M1';
+  String m() => 'M1';
+  void set s(String v) {
+    log.write('$v;');
+  }
+}
+
+mixin M2 on M1 {
+  String get g => '${super.g} and M2';
+  String m() => '${super.m()} and M2';
+  void set s(String v) {
+    log.write('${super.s = v} and M2');
+  }
+}
+
+enum E {
+  e0;
+}
+
+augment enum E with M1 implements M2 {}
+
+main() {
+  Expect.equals('M1', E.e0.g);
+  Expect.equals('M1', E.e0.m());
+  E.e0.s = 'M1';
+  Expect.equals('M1;', log.toString());
+}


### PR DESCRIPTION
`augmenting_class_like_declarations_A02_t20-27.dart` check that augmentation may add `with` clause. These tests add missing cases.