### PR TITLE
#3847. Add function literal inference tests for return type. Part 2.

### DIFF
--- a/TypeSystem/inference/function_literal_inference_A02_t05.dart
+++ b/TypeSystem/inference/function_literal_inference_A02_t05.dart
@@ -1,0 +1,533 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// - For each `return e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(flatten(S), T)` if the
+///   enclosing function is `async`, or `UP(S, T)` otherwise.
+/// ...
+/// The actual returned type of the function literal is the value of `T` after
+/// all `return` and `yield` statements in the block body have been considered.
+///
+/// @description Check that the actual returned type of a function literal is
+/// the value of `T` after all `return`statements in the block body have been
+/// considered.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () {
+  if (1 > 2) {
+    return 0;
+  }
+  return 3.14;
+};
+var f2 = () {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return null;
+};
+var f3 = () {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return 'x';
+};
+var f4 = () {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return Future.value(null);
+};
+var f5 = () {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return <num>[42];
+};
+
+class C {
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<num Function()>>();
+  f2.expectStaticType<Exactly<num? Function()>>();
+  f3.expectStaticType<Exactly<Object Function()>>();
+  f4.expectStaticType<Exactly<Object Function()>>();
+  f5.expectStaticType<Exactly<Object Function()>>();
+
+  C.sf1.expectStaticType<Exactly<num Function()>>();
+  C.sf2.expectStaticType<Exactly<num? Function()>>();
+  C.sf3.expectStaticType<Exactly<Object Function()>>();
+  C.sf4.expectStaticType<Exactly<Object Function()>>();
+  C.sf5.expectStaticType<Exactly<Object Function()>>();
+  C().f1.expectStaticType<Exactly<num Function()>>();
+  C().f2.expectStaticType<Exactly<num? Function()>>();
+  C().f3.expectStaticType<Exactly<Object Function()>>();
+  C().f4.expectStaticType<Exactly<Object Function()>>();
+  C().f5.expectStaticType<Exactly<Object Function()>>();
+
+  M.sf1.expectStaticType<Exactly<num Function()>>();
+  M.sf2.expectStaticType<Exactly<num? Function()>>();
+  M.sf3.expectStaticType<Exactly<Object Function()>>();
+  M.sf4.expectStaticType<Exactly<Object Function()>>();
+  M.sf5.expectStaticType<Exactly<Object Function()>>();
+  MA().f1.expectStaticType<Exactly<num Function()>>();
+  MA().f2.expectStaticType<Exactly<num? Function()>>();
+  MA().f3.expectStaticType<Exactly<Object Function()>>();
+  MA().f4.expectStaticType<Exactly<Object Function()>>();
+  MA().f5.expectStaticType<Exactly<Object Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<num Function()>>();
+  MC.sf2.expectStaticType<Exactly<num? Function()>>();
+  MC.sf3.expectStaticType<Exactly<Object Function()>>();
+  MC.sf4.expectStaticType<Exactly<Object Function()>>();
+  MC.sf5.expectStaticType<Exactly<Object Function()>>();
+  MC().f1.expectStaticType<Exactly<num Function()>>();
+  MC().f2.expectStaticType<Exactly<num? Function()>>();
+  MC().f3.expectStaticType<Exactly<Object Function()>>();
+  MC().f4.expectStaticType<Exactly<Object Function()>>();
+  MC().f5.expectStaticType<Exactly<Object Function()>>();
+
+  E.sf1.expectStaticType<Exactly<num Function()>>();
+  E.sf2.expectStaticType<Exactly<num? Function()>>();
+  E.sf3.expectStaticType<Exactly<Object Function()>>();
+  E.sf4.expectStaticType<Exactly<Object Function()>>();
+  E.sf5.expectStaticType<Exactly<Object Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<num Function()>>();
+  Ext.sf2.expectStaticType<Exactly<num? Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Object Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Object Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Object Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<num Function()>>();
+  ET.sf2.expectStaticType<Exactly<num? Function()>>();
+  ET.sf3.expectStaticType<Exactly<Object Function()>>();
+  ET.sf4.expectStaticType<Exactly<Object Function()>>();
+  ET.sf5.expectStaticType<Exactly<Object Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A02_t06.dart
+++ b/TypeSystem/inference/function_literal_inference_A02_t06.dart
@@ -1,0 +1,533 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// - For each `return e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(flatten(S), T)` if the
+///   enclosing function is `async`, or `UP(S, T)` otherwise.
+/// ...
+/// The actual returned type of the function literal is the value of `T` after
+/// all `return` and `yield` statements in the block body have been considered.
+///
+/// @description Check that the actual returned type of a function literal is
+/// the value of `T` after all `return` statements in the block body have been
+/// considered. Test an async function literal.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () async {
+  if (1 > 2) {
+    return 0;
+  }
+  return 3.14;
+};
+var f2 = () async {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return null;
+};
+var f3 = () async {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return 'x';
+};
+var f4 = () async {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return Future.value(null);
+};
+var f5 = () async {
+  if (1 > 2) {
+    return 0;
+  }
+  if (1 > 2) {
+    return 3.14;
+  }
+  return <num>[42];
+};
+
+class C {
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+
+  var f1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  var f2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  var f3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  var f4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  var f5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    return 3.14;
+  };
+  static var sf2 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return null;
+  };
+  static var sf3 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return 'x';
+  };
+  static var sf4 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return Future.value(null);
+  };
+  static var sf5 = () async {
+    if (1 > 2) {
+      return 0;
+    }
+    if (1 > 2) {
+      return 3.14;
+    }
+    return <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Future<num> Function()>>();
+  f2.expectStaticType<Exactly<Future<num?> Function()>>();
+  f3.expectStaticType<Exactly<Future<Object> Function()>>();
+  f4.expectStaticType<Exactly<Future<num?> Function()>>();
+  f5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  C.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  C.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  C.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  C.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  C.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+  C().f1.expectStaticType<Exactly<Future<num> Function()>>();
+  C().f2.expectStaticType<Exactly<Future<num?> Function()>>();
+  C().f3.expectStaticType<Exactly<Future<Object> Function()>>();
+  C().f4.expectStaticType<Exactly<Future<num?> Function()>>();
+  C().f5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  M.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  M.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  M.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  M.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  M.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+  MA().f1.expectStaticType<Exactly<Future<num> Function()>>();
+  MA().f2.expectStaticType<Exactly<Future<num?> Function()>>();
+  MA().f3.expectStaticType<Exactly<Future<Object> Function()>>();
+  MA().f4.expectStaticType<Exactly<Future<num?> Function()>>();
+  MA().f5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  MC.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  MC.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  MC.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  MC.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+  MC().f1.expectStaticType<Exactly<Future<num> Function()>>();
+  MC().f2.expectStaticType<Exactly<Future<num?> Function()>>();
+  MC().f3.expectStaticType<Exactly<Future<Object> Function()>>();
+  MC().f4.expectStaticType<Exactly<Future<num?> Function()>>();
+  MC().f5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  E.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  E.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  E.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  E.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  E.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  Ext.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<Future<num> Function()>>();
+  ET.sf2.expectStaticType<Exactly<Future<num?> Function()>>();
+  ET.sf3.expectStaticType<Exactly<Future<Object> Function()>>();
+  ET.sf4.expectStaticType<Exactly<Future<num?> Function()>>();
+  ET.sf5.expectStaticType<Exactly<Future<Object> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A04_t01.dart
+++ b/TypeSystem/inference/function_literal_inference_A04_t01.dart
@@ -1,0 +1,344 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// - If the enclosing function is marked `sync*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Iterable<K>;` let `E` be the type such that `Iterable<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+///
+/// @description Check that the return type of a `sync*` function with a single
+/// `yield e;` is `Iterable<X>;`, where `X` is the static type of `e`.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () sync* {
+  yield 0;
+};
+var f2 = () sync* {
+  yield 0 as num;
+};
+var f3 = () sync* {
+  yield 0 as dynamic;
+};
+var f4 = () sync* {
+  yield 0 as Never;
+};
+var f5 = () sync* {
+  yield null;
+};
+var f6 = () sync* {
+  yield Future.value(0);
+};
+var f7 = () sync* {
+  yield <num>[42];
+};
+
+class C {
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    yield 0;
+  };
+  var f2 = () sync* {
+    yield 0 as num;
+  };
+  var f3 = () sync* {
+    yield 0 as dynamic;
+  };
+  var f4 = () sync* {
+    yield 0 as Never;
+  };
+  var f5 = () sync* {
+    yield null;
+  };
+  var f6 = () sync* {
+    yield Future.value(0);
+  };
+  var f7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    yield 0;
+  };
+  var f2 = () sync* {
+    yield 0 as num;
+  };
+  var f3 = () sync* {
+    yield 0 as dynamic;
+  };
+  var f4 = () sync* {
+    yield 0 as Never;
+  };
+  var f5 = () sync* {
+    yield null;
+  };
+  var f6 = () sync* {
+    yield Future.value(0);
+  };
+  var f7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    yield 0;
+  };
+  var f2 = () sync* {
+    yield 0 as num;
+  };
+  var f3 = () sync* {
+    yield 0 as dynamic;
+  };
+  var f4 = () sync* {
+    yield 0 as Never;
+  };
+  var f5 = () sync* {
+    yield null;
+  };
+  var f6 = () sync* {
+    yield Future.value(0);
+  };
+  var f7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () sync* {
+    yield 0;
+  };
+  static var sf2 = () sync* {
+    yield 0 as num;
+  };
+  static var sf3 = () sync* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () sync* {
+    yield 0 as Never;
+  };
+  static var sf5 = () sync* {
+    yield null;
+  };
+  static var sf6 = () sync* {
+    yield Future.value(0);
+  };
+  static var sf7 = () sync* {
+    yield <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  f2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  f3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  f4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  f5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  f6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  f7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  C.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  C.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  C.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  C.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  C.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  C.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  C.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+  C().f1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  C().f2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  C().f3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  C().f4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  C().f5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  C().f6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  C().f7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  M.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  M.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  M.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  M.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  M.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  M.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  M.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+  MA().f1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  MA().f2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MA().f3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  MA().f4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  MA().f5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  MA().f6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  MA().f7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  MC.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MC.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  MC.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  MC.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  MC.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  MC.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+  MC().f1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  MC().f2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MC().f3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  MC().f4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  MC().f5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  MC().f6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  MC().f7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  E.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  E.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  E.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  E.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  E.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  E.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  E.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  Ext.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  Ext.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  Ext.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<Iterable<int> Function()>>();
+  ET.sf2.expectStaticType<Exactly<Iterable<num> Function()>>();
+  ET.sf3.expectStaticType<Exactly<Iterable<dynamic> Function()>>();
+  ET.sf4.expectStaticType<Exactly<Iterable<Never> Function()>>();
+  ET.sf5.expectStaticType<Exactly<Iterable<Null> Function()>>();
+  ET.sf6.expectStaticType<Exactly<Iterable<Future<int>> Function()>>();
+  ET.sf7.expectStaticType<Exactly<Iterable<List<num>> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A04_t02.dart
+++ b/TypeSystem/inference/function_literal_inference_A04_t02.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// - If the enclosing function is marked `sync*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Iterable<K>;` let `E` be the type such that `Iterable<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+///
+/// @description Check that the return type of a `sync*` function with a single
+/// `yield e;` is `Iterable<X>;`, where `X` is the static type of `e` inferred
+/// using the local type inference algorithm.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () sync* {
+  yield 2 > 1 ? 0 : (1 as num?);
+};
+
+class C {
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+mixin M {
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+mixin class MC {
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () sync* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  C.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  C().f1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  M.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MA().f1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MC.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MC().f1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  E.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  Ext.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  ET.sf1.expectStaticType<Exactly<Iterable<num?> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A04_t03.dart
+++ b/TypeSystem/inference/function_literal_inference_A04_t03.dart
@@ -1,0 +1,538 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// - If the enclosing function is marked `sync*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Iterable<K>;` let `E` be the type such that `Iterable<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+/// ...
+/// The actual returned type of the function literal is the value of `T` after
+/// all `return` and `yield` statements in the block body have been considered.
+///
+/// @description Check that the actual returned type of a function literal is
+/// the value of `T` after all `yield` statements in the block body have been
+/// considered.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () sync* {
+  if (1 > 2) {
+    yield 0;
+  }
+  yield 3.14;
+};
+var f2 = () sync* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield null;
+};
+var f3 = () sync* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield 'x';
+};
+var f4 = () sync* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield Future.value(null);
+};
+var f5 = () sync* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield <num>[42];
+};
+
+class C {
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () sync* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  f2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  f3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  f4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  f5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  C.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  C.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  C.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  C.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  C.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  C().f1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  C().f2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  C().f3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  C().f4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  C().f5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  M.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  M.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  M.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  M.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  M.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MA().f1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MA().f2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MA().f3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MA().f4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MA().f5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MC.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MC.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MC.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MC.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MC().f1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  MC().f2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  MC().f3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MC().f4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  MC().f5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  E.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  E.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  E.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  E.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  E.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  Ext.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<Iterable<num> Function()>>();
+  ET.sf2.expectStaticType<Exactly<Iterable<num?> Function()>>();
+  ET.sf3.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  ET.sf4.expectStaticType<Exactly<Iterable<Object> Function()>>();
+  ET.sf5.expectStaticType<Exactly<Iterable<Object> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A05_t01.dart
+++ b/TypeSystem/inference/function_literal_inference_A05_t01.dart
@@ -1,0 +1,345 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// ...
+/// - If the enclosing function is marked `async*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Stream<K>`; let `E` be the type such that `Stream<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+///
+/// @description Check that the return type of an `async*` function with a
+/// single `yield e;` is `Stream<X>`; where `X` is the static type of `e`.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () async* {
+  yield 0;
+};
+var f2 = () async* {
+  yield 0 as num;
+};
+var f3 = () async* {
+  yield 0 as dynamic;
+};
+var f4 = () async* {
+  yield 0 as Never;
+};
+var f5 = () async* {
+  yield null;
+};
+var f6 = () async* {
+  yield Future.value(0);
+};
+var f7 = () async* {
+  yield <num>[42];
+};
+
+class C {
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    yield 0;
+  };
+  var f2 = () async* {
+    yield 0 as num;
+  };
+  var f3 = () async* {
+    yield 0 as dynamic;
+  };
+  var f4 = () async* {
+    yield 0 as Never;
+  };
+  var f5 = () async* {
+    yield null;
+  };
+  var f6 = () async* {
+    yield Future.value(0);
+  };
+  var f7 = () async* {
+    yield <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    yield 0;
+  };
+  var f2 = () async* {
+    yield 0 as num;
+  };
+  var f3 = () async* {
+    yield 0 as dynamic;
+  };
+  var f4 = () async* {
+    yield 0 as Never;
+  };
+  var f5 = () async* {
+    yield null;
+  };
+  var f6 = () async* {
+    yield Future.value(0);
+  };
+  var f7 = () async* {
+    yield <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    yield 0;
+  };
+  var f2 = () async* {
+    yield 0 as num;
+  };
+  var f3 = () async* {
+    yield 0 as dynamic;
+  };
+  var f4 = () async* {
+    yield 0 as Never;
+  };
+  var f5 = () async* {
+    yield null;
+  };
+  var f6 = () async* {
+    yield Future.value(0);
+  };
+  var f7 = () async* {
+    yield <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () async* {
+    yield 0;
+  };
+  static var sf2 = () async* {
+    yield 0 as num;
+  };
+  static var sf3 = () async* {
+    yield 0 as dynamic;
+  };
+  static var sf4 = () async* {
+    yield 0 as Never;
+  };
+  static var sf5 = () async* {
+    yield null;
+  };
+  static var sf6 = () async* {
+    yield Future.value(0);
+  };
+  static var sf7 = () async* {
+    yield <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Stream<int> Function()>>();
+  f2.expectStaticType<Exactly<Stream<num> Function()>>();
+  f3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  f4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  f5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  f6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  f7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  C.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  C.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  C.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  C.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  C.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  C.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  C.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+  C().f1.expectStaticType<Exactly<Stream<int> Function()>>();
+  C().f2.expectStaticType<Exactly<Stream<num> Function()>>();
+  C().f3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  C().f4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  C().f5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  C().f6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  C().f7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  M.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  M.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  M.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  M.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  M.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  M.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  M.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+  MA().f1.expectStaticType<Exactly<Stream<int> Function()>>();
+  MA().f2.expectStaticType<Exactly<Stream<num> Function()>>();
+  MA().f3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  MA().f4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  MA().f5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  MA().f6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  MA().f7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  MC.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  MC.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  MC.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  MC.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  MC.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  MC.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+  MC().f1.expectStaticType<Exactly<Stream<int> Function()>>();
+  MC().f2.expectStaticType<Exactly<Stream<num> Function()>>();
+  MC().f3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  MC().f4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  MC().f5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  MC().f6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  MC().f7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  E.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  E.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  E.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  E.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  E.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  E.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  E.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  Ext.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  Ext.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  Ext.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<Stream<int> Function()>>();
+  ET.sf2.expectStaticType<Exactly<Stream<num> Function()>>();
+  ET.sf3.expectStaticType<Exactly<Stream<dynamic> Function()>>();
+  ET.sf4.expectStaticType<Exactly<Stream<Never> Function()>>();
+  ET.sf5.expectStaticType<Exactly<Stream<Null> Function()>>();
+  ET.sf6.expectStaticType<Exactly<Stream<Future<int>> Function()>>();
+  ET.sf7.expectStaticType<Exactly<Stream<List<num>> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A05_t02.dart
+++ b/TypeSystem/inference/function_literal_inference_A05_t02.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// ...
+/// - If the enclosing function is marked `async*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Stream<K>`; let `E` be the type such that `Stream<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+///
+/// @description Check that the return type of an `async*` function with a
+/// single `yield e;` is `Stream<X>;`, where `X` is the static type of `e`
+/// inferred using the local type inference algorithm.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () async* {
+  yield 2 > 1 ? 0 : (1 as num?);
+};
+
+class C {
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+mixin M {
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+mixin class MC {
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+
+  var f1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () async* {
+    yield 2 > 1 ? 0 : (1 as num?);
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  C.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  C().f1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  M.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MA().f1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MC.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MC().f1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  E.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  Ext.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+  ET.sf1.expectStaticType<Exactly<Stream<num?> Function()>>();
+}

--- a/TypeSystem/inference/function_literal_inference_A05_t03.dart
+++ b/TypeSystem/inference/function_literal_inference_A05_t03.dart
@@ -1,0 +1,539 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion The actual returned type of a function literal with a block body
+/// is computed as follows. Let `T` be `Never` if every control path through the
+/// block exits the block without reaching the end of the block, as computed by
+/// the definite completion analysis specified elsewhere. Let `T` be `Null` if
+/// any control path reaches the end of the block without exiting the block, as
+/// computed by the definite completion analysis specified elsewhere. Let `K` be
+/// the typing context for the function body as computed above from the imposed
+/// return type schema.
+/// ...
+/// - For each `yield e;` statement in the block, let `S` be the inferred type
+///   of `e`, using the local type inference algorithm described below with
+///   typing context `K`, and update `T` to be `UP(S, T)`.
+/// ...
+/// - If the enclosing function is marked `async*`, then for each `yield* e;`
+///   statement in the block, let `S` be the inferred type of `e`, using the
+///   local type inference algorithm described below with a typing context of
+///   `Stream<K>`; let `E` be the type such that `Stream<E>` is a
+///   super-interface of `S;` and update `T` to be `UP(E, T)`.
+/// ...
+/// The actual returned type of the function literal is the value of `T` after
+/// all `return` and `yield` statements in the block body have been considered.
+///
+/// @description Check that the actual returned type of an `async*` function
+/// literal is the value of `T` after all `yield` statements in the block body
+/// have been considered.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+var f1 = () async* {
+  if (1 > 2) {
+    yield 0;
+  }
+  yield 3.14;
+};
+var f2 = () async* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield null;
+};
+var f3 = () async* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield 'x';
+};
+var f4 = () async* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield Future.value(null);
+};
+var f5 = () async* {
+  if (1 > 2) {
+    yield 0;
+  }
+  if (1 > 2) {
+    yield 3.14;
+  }
+  yield <num>[42];
+};
+
+class C {
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+mixin M {
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+mixin class MC {
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+
+  var f1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  var f2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  var f3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  var f4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  var f5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+enum E {
+  e0;
+
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+class A {}
+
+extension Ext on A {
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+extension type ET(int _) {
+  static var sf1 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    yield 3.14;
+  };
+  static var sf2 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield null;
+  };
+  static var sf3 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield 'x';
+  };
+  static var sf4 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield Future.value(null);
+  };
+  static var sf5 = () async* {
+    if (1 > 2) {
+      yield 0;
+    }
+    if (1 > 2) {
+      yield 3.14;
+    }
+    yield <num>[42];
+  };
+}
+
+class MA = Object with M;
+
+main() {
+  f1.expectStaticType<Exactly<Stream<num> Function()>>();
+  f2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  f3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  f4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  f5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  C.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  C.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  C.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  C.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  C.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+  C().f1.expectStaticType<Exactly<Stream<num> Function()>>();
+  C().f2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  C().f3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  C().f4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  C().f5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  M.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  M.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  M.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  M.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  M.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MA().f1.expectStaticType<Exactly<Stream<num> Function()>>();
+  MA().f2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MA().f3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MA().f4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MA().f5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  MC.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  MC.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MC.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MC.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MC.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MC().f1.expectStaticType<Exactly<Stream<num> Function()>>();
+  MC().f2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  MC().f3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MC().f4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  MC().f5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  E.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  E.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  E.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  E.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  E.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  Ext.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  Ext.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  Ext.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  Ext.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  Ext.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+
+  ET.sf1.expectStaticType<Exactly<Stream<num> Function()>>();
+  ET.sf2.expectStaticType<Exactly<Stream<num?> Function()>>();
+  ET.sf3.expectStaticType<Exactly<Stream<Object> Function()>>();
+  ET.sf4.expectStaticType<Exactly<Stream<Object> Function()>>();
+  ET.sf5.expectStaticType<Exactly<Stream<Object> Function()>>();
+}


### PR DESCRIPTION
For review it's enough to review top-level functions only. The other code repeats these functions as static and instance members in classes, mixins, mixin classes, enums, extensions and extension types.