### PR TITLE
Fixes #3995. Fix typos in augmenting_functions_A08_t01.dart

### DIFF
--- a/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
@@ -59,13 +59,13 @@ class C {
 }
 
 augment class C {
-  augment String staticMethod1();
-  augment String staticMethod2([int v = 0]);
-  augment String staticMethod3({int v = 0});
+  augment static void staticMethod1();
+  augment static void staticMethod2([int v = 0]);
+  augment static void staticMethod3({int v = 0});
 
-  augment String instanceMethod1();
-  augment String instanceMethod2([int v = 0]);
-  augment String instanceMethod3({int v = 0});
+  augment void instanceMethod1();
+  augment void instanceMethod2([int v = 0]);
+  augment void instanceMethod3({int v = 0});
 }
 
 mixin M {
@@ -82,28 +82,20 @@ mixin M {
 // [analyzer] unspecified
 // [cfe] unspecified
 
+  // No errors below. Mixins are allowed to declare abstract instance methods
   void instanceMethod1();
-//     ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   void instanceMethod2([int v]);
-//     ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   void instanceMethod3({int v});
-//     ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }
 
 augment mixin M {
-  augment String staticMethod1();
-  augment String staticMethod2([int v = 0]);
-  augment String staticMethod3({int v = 0});
+  augment static void staticMethod1();
+  augment static void staticMethod2([int v = 0]);
+  augment static void staticMethod3({int v = 0});
 
-  augment String instanceMethod1();
-  augment String instanceMethod2([int v = 0]);
-  augment String instanceMethod3({int v = 0});
+  augment void instanceMethod1();
+  augment void instanceMethod2([int v = 0]);
+  augment void instanceMethod3({int v = 0});
 }
 
 enum E {
@@ -137,13 +129,13 @@ enum E {
 
 augment enum E {
   ;
-  augment String staticMethod1();
-  augment String staticMethod2([int v = 0]);
-  augment String staticMethod3({int v = 0});
+  augment static void staticMethod1();
+  augment static void staticMethod2([int v = 0]);
+  augment static void staticMethod3({int v = 0});
 
-  augment String instanceMethod1();
-  augment String instanceMethod2([int v = 0]);
-  augment String instanceMethod3({int v = 0});
+  augment void instanceMethod1();
+  augment void instanceMethod2([int v = 0]);
+  augment void instanceMethod3({int v = 0});
 }
 
 class A {}
@@ -177,13 +169,13 @@ extension Ext on A {
 }
 
 augment extension Ext {
-  augment String staticMethod1();
-  augment String staticMethod2([int v = 0]);
-  augment String staticMethod3({int v = 0});
+  augment static void staticMethod1();
+  augment static void staticMethod2([int v = 0]);
+  augment static void staticMethod3({int v = 0});
 
-  augment String instanceMethod1();
-  augment String instanceMethod2([int v = 0]);
-  augment String instanceMethod3({int v = 0});
+  augment void instanceMethod1();
+  augment void instanceMethod2([int v = 0]);
+  augment void instanceMethod3({int v = 0});
 }
 
 extension type ET(int _) {
@@ -215,13 +207,13 @@ extension type ET(int _) {
 }
 
 augment extension type ET {
-  augment String staticMethod1();
-  augment String staticMethod2([int v = 0]);
-  augment String staticMethod3({int v = 0});
+  augment static void staticMethod1();
+  augment static void staticMethod2([int v = 0]);
+  augment static void staticMethod3({int v = 0});
 
-  augment String instanceMethod1();
-  augment String instanceMethod2([int v = 0]);
-  augment String instanceMethod3({int v = 0});
+  augment void instanceMethod1();
+  augment void instanceMethod2([int v = 0]);
+  augment void instanceMethod3({int v = 0});
 }
 
 main() {

--- a/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
@@ -94,8 +94,17 @@ augment mixin M {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 enum E {
@@ -134,8 +143,17 @@ augment enum E {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 class A {}
@@ -174,8 +192,17 @@ augment extension Ext {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 extension type ET(int _) {
@@ -212,8 +239,17 @@ augment extension type ET {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
+//             ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 main() {

--- a/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
+++ b/LanguageFeatures/Augmentations/augmenting_functions_A08_t01.dart
@@ -64,8 +64,17 @@ augment class C {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
+//             ^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
 }
 
 mixin M {
@@ -94,17 +103,8 @@ augment mixin M {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }
 
 enum E {
@@ -192,17 +192,8 @@ augment extension Ext {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }
 
 extension type ET(int _) {
@@ -239,17 +230,8 @@ augment extension type ET {
   augment static void staticMethod3({int v = 0});
 
   augment void instanceMethod1();
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod2([int v = 0]);
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
   augment void instanceMethod3({int v = 0});
-//             ^^^^^^^^^^^^^^^
-// [analyzer] unspecified
-// [cfe] unspecified
 }
 
 main() {


### PR DESCRIPTION
The test is still failing because errors for abstract members in extensions and extension types are not produced.