### PR TITLE
#3847. Add test for upper bound

### DIFF
--- a/TypeSystem/inference/upper_bound_A01_t01.dart
+++ b/TypeSystem/inference/upper_bound_A01_t01.dart
@@ -14,6 +14,9 @@
 ///
 /// @description Check that the subtyping algorithm takes the least/greatest
 /// closure into account.
+/// @note We can't systematically test `UP` and `DOWN` on type schemas, but here
+/// is an example from the feature specification that illustrates that it can
+/// occur.
 /// @author sgrekhov22@gmail.com
 /// @issue 63883
 

--- a/TypeSystem/inference/upper_bound_A01_t01.dart
+++ b/TypeSystem/inference/upper_bound_A01_t01.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We write `UP(T0, T1)` for the upper bound of `T0` and `T1` and
+/// `DOWN(T0, T1)` for the lower bound of `T0` and `T1`. This extends to type
+/// schema as follows:
+/// - We add the axiom that `UP(T, _) == T` and the symmetric version.
+/// - We replace all uses of `T1 <: T2` in the `UP` algorithm by `S1 <: S2`
+///   where `Si` is the least closure of `Ti` with respect to `_`.
+/// - We add the axiom that `DOWN(T, _) == T` and the symmetric version.
+/// - We replace all uses of `T1 <: T2` in the `DOWN` algorithm by `S1 <: S2`
+///   where `Si` is the greatest closure of `Ti` with respect to `_`.
+///
+/// @description Check that the subtyping algorithm takes the least/greatest
+/// closure into account.
+/// @author sgrekhov22@gmail.com
+/// @issue 63883
+
+import '../../Utils/static_type_helper.dart';
+
+class C<X> {
+  C(void Function(X) x);
+}
+T check<T>(C<List<T>> f) {
+  return 42 as T;
+}
+
+void main() {
+  var x = check(C((List<int> x) {})); // Should infer `int` for `T`
+  x.expectStaticType<Exactly<int>>();
+}


### PR DESCRIPTION
@eernstg, this is a test for the upper bound rules described in https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#upper-bound. If you have any advice on how to add more tests for this part of the specification, it would be greatly appreciated.