### PR TITLE
Fix co19 VM tests for primary constructors

### DIFF
--- a/VM/primary_constructors_t02.dart
+++ b/VM/primary_constructors_t02.dart
@@ -32,7 +32,7 @@ void main([args = const <String>[]]) =>
         .addCustomTest((VmService srv, IsolateRef isolateRef) async {
           final islId = isolateRef.id!;
           final xRef1 = await srv.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-          Expect.equals('null', xRef1.valueAsString);
+          Expect.equals('xxx', xRef1.valueAsString);
           final xRef2 =
               await srv.evaluateInFrame(islId, 0, 'this.x') as InstanceRef;
           Expect.equals('null', xRef2.valueAsString);

--- a/VM/primary_constructors_t03.dart
+++ b/VM/primary_constructors_t03.dart
@@ -33,9 +33,9 @@ void main([
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
       final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('42', xRef1.valueAsString);
+      Expect.equals('xxx', xRef1.valueAsString);
       final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('42', xRef2.valueAsString);
+      Expect.equals('null', xRef2.valueAsString);
     })
     .stepInto()
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
@@ -52,9 +52,9 @@ void main([
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
       final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('42', xRef1.valueAsString);
+      Expect.equals('xxx', xRef1.valueAsString);
       final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('42', xRef2.valueAsString);
+      Expect.equals('null', xRef2.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_D')

--- a/VM/primary_constructors_t03.dart
+++ b/VM/primary_constructors_t03.dart
@@ -32,18 +32,18 @@ void main([
     .stoppedAtLine('LINE_A')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('null', xRef2.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('null', yRef.valueAsString);
     })
     .stepInto()
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('yyy', xRef2.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('yyy', yRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_L')
@@ -51,28 +51,28 @@ void main([
     .stoppedAtLine('LINE_C')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('null', xRef2.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('null', yRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_D')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('null', xRef2.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('null', yRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_E')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('yyy', xRef2.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('yyy', yRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_M')
@@ -80,45 +80,45 @@ void main([
     .stoppedAtLine('LINE_F')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('42', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('42', xRef2.valueAsString);
-      final xRef3 = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
-      Expect.equals('42', xRef3.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('42', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('42', yRef.valueAsString);
+      final zRef = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
+      Expect.equals('42', zRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_G')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('xxx', xRef2.valueAsString);
-      final xRef3 = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
-      Expect.equals('null', xRef3.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('xxx', yRef.valueAsString);
+      final zRef = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
+      Expect.equals('null', zRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_H')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('xxx', xRef2.valueAsString);
-      final xRef3 = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
-      Expect.equals('null', xRef3.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('xxx', yRef.valueAsString);
+      final zRef = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
+      Expect.equals('null', zRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_I')
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('xxx', xRef1.valueAsString);
-      final xRef2 = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
-      Expect.equals('xxx', xRef2.valueAsString);
-      final xRef3 = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
-      Expect.equals('zzz', xRef3.valueAsString);
+      final xRef = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
+      Expect.equals('xxx', xRef.valueAsString);
+      final yRef = await service.evaluateInFrame(islId, 0, 'y') as InstanceRef;
+      Expect.equals('xxx', yRef.valueAsString);
+      final zRef = await service.evaluateInFrame(islId, 0, 'z') as InstanceRef;
+      Expect.equals('zzz', zRef.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_N')

--- a/VM/primary_constructors_t05.dart
+++ b/VM/primary_constructors_t05.dart
@@ -33,13 +33,6 @@ void main([
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
       final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('42', xRef1.valueAsString);
-    })
-    .stepInto()
-    .stoppedAtLine('LINE_B')
-    .addCustomTest((VmService service, IsolateRef isolateRef) async {
-      final islId = isolateRef.id!;
-      final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
       Expect.equals('1', xRef1.valueAsString);
     })
     .stepInto()
@@ -49,7 +42,7 @@ void main([
     .addCustomTest((VmService service, IsolateRef isolateRef) async {
       final islId = isolateRef.id!;
       final xRef1 = await service.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-      Expect.equals('42', xRef1.valueAsString);
+      Expect.equals('2', xRef1.valueAsString);
     })
     .stepInto()
     .stoppedAtLine('LINE_D')

--- a/VM/primary_constructors_t07.dart
+++ b/VM/primary_constructors_t07.dart
@@ -31,7 +31,7 @@ void main([args = const <String>[]]) =>
         .addCustomTest((VmService srv, IsolateRef isolateRef) async {
           final islId = isolateRef.id!;
           final xRef1 = await srv.evaluateInFrame(islId, 0, 'x') as InstanceRef;
-          Expect.equals('null', xRef1.valueAsString);
+          Expect.equals('c1', xRef1.valueAsString);
           final xRef2 = await srv.evaluateInFrame(islId, 0, 'y') as InstanceRef;
           Expect.equals('null', xRef2.valueAsString);
         })


### PR DESCRIPTION
Tests updated according to the current behaviour of the debugger