### PR TITLE
#4173. Update/add more tests for intersection types

### DIFF
--- a/TypeSystem/upper-lower-bounds/up_A08_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A08_t01.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/TypeSystem/upper-lower-bounds/up_A08_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A08_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/TypeSystem/upper-lower-bounds/up_A08_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A08_t02.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -11,27 +11,33 @@
 ///   - otherwise UP(`B1a`, `T2`) where `B1a` is the greatest closure of `B1`
 ///     with respect to `X1`, as defined in inference.md.
 ///
-/// @description Check that upper bound of intersection types is calculated as
-/// expected
+/// @description Check that UP(`X1 & B1`, `T2`) = `X1` if `T2 != X1 & B1`,
+/// not TOP(`T2`), `T2` is not an intersection type, not BOTTOM(`T2`) and
+/// `T2` <: `X1`. We also use the fact that TOP(`X1 & B1`) never holds.
 /// @author sgrekhov22@gmail.com
 
-import '../../Utils/expect.dart';
 import '../../Utils/static_type_helper.dart';
 
-int? foo() => DateTime.now().millisecondsSinceEpoch.isEven? null : 1;
+// ignore_for_file: dead_code
 
-void f<X extends num>(X x) {
-  if (x is int) { // `x` promoted to `X & int`.
-    var y1 = 2 > 1 ? x : null;
-    Expect.isTrue(y1?.isEven);
-    y1.expectStaticType<Exactly<int?>>();
+class A {}
+class B1 extends A {}
 
-    var y2 = 1 > 2 ? foo() : x;
-    Expect.isTrue(y2?.isEven);
-    y2.expectStaticType<Exactly<int?>>();
+void f1<X1, T2 extends X1>(X1 x1, T2 t2) {
+  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
+    var v = (1 > 2) ? x1 : t2; // UP(X1 & B1, T2) = X1 because T2 <: X1
+    v.expectStaticType<Exactly<X1>>();
+  }
+}
+
+void f2<X1 extends A, T2 extends X1>(X1 x1, T2 t2) {
+  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
+    var v = (1 > 2) ? x1 : t2; // UP(X1 & B1, T2) = X1 because T2 <: X1
+    v.expectStaticType<Exactly<X1>>();
   }
 }
 
 void main() {
-  f<num>(42);
+  f1<num, int>(1, 2);
+  f2<A, B1>(A(), B1());
 }

--- a/TypeSystem/upper-lower-bounds/up_A08_t03.dart
+++ b/TypeSystem/upper-lower-bounds/up_A08_t03.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @assertion We define the upper bound of two types `T1` and `T2` to be
+/// UP(`T1`,`T2`) as follows.
+/// ...
+/// - UP(`X1 & B1`, `T2`) =
+///   - `T2` if `X1 <: T2`
+///   - otherwise `X1` if `T2` <: `X1`
+///   - otherwise UP(`B1a`, `T2`) where `B1a` is the greatest closure of `B1`
+///     with respect to `X1`, as defined in inference.md.
+///
+/// @description Check that UP(`X1 & B1`, `T2`) = UP(`B1a`, `T2`) where `B1a` is
+/// the greatest closure of `B1` with respect to `X1` if the first two
+/// conditions are not met and also `T2 != X1 & B1`, not TOP(`T2`), `T2` is not
+/// an intersection type and not BOTTOM(`T2`). We also use the fact that
+/// TOP(`X1 & B1`) never holds.
+/// @author sgrekhov22@gmail.com
+
+import '../../Utils/static_type_helper.dart';
+
+class A {}
+class A2 extends A {}
+class B1 extends A2 {}
+
+void f1<X1 extends A, T2 extends A2>(X1 x1, T2 t2) {
+  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
+    // UP(X1 & B1, T2) = UP(B1a, T2), where B1a is the greatest closure of `B1`
+    // with respect to `X1` (`B1` in this case with respect to anything) and
+    // UP(`B1a`, `T2`) == UP(`B1`, `T2`) = `A2`.
+    var v = (1 > 2) ? x1 : t2;
+    v.expectStaticType<Exactly<A2>>();
+  }
+}
+
+void f2<X1 extends A2, T2 extends A2, B1 extends A2>(X1 x1, T2 t2) {
+  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
+    // UP(X1 & B1, T2) = UP(B1a, T2), where B1a is
+    // the greatest closure of `B1` with respect to `X1` (which is again `B1`).
+    var v = (1 > 2) ? x1 : t2;
+    v.expectStaticType<Exactly<A2>>();
+  }
+}
+
+void main() {
+  f1(A2(), A2());
+  f2(A2(), A2());
+}

--- a/TypeSystem/upper-lower-bounds/up_A08_t04.dart
+++ b/TypeSystem/upper-lower-bounds/up_A08_t04.dart
@@ -18,26 +18,27 @@
 
 import '../../Utils/static_type_helper.dart';
 
-// ignore_for_file: dead_code
-
-class A {}
-class B1 extends A {}
-
-void f1<T2, X1 extends T2>(X1 x1, T2 t2) {
-  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
-    var v = (1 > 2) ? x1 : t2; // UP(X1 & B1, T2) = T2 because X1 <: T2
-    v.expectStaticType<Exactly<T2>>();
+void test1<T1 extends num, T2 extends T1>(
+  T1 Function(T1 x) f1,
+  T2 Function(T2 x) f2,
+) {
+  if (f1 is T2 Function(T1 x)) {
+    var v1 = (1 > 2) ? f1 : f2;
+    v1.expectStaticType<Exactly<T2 Function(T2 x)>>();
   }
 }
 
-void f2<T2 extends A, X1 extends T2>(X1 x1, T2 t2) {
-  if (x1 is B1) { // `x1` promoted to `X1 & B1`.
-    var v = (1 > 2) ? x1 : t2; // UP(X1 & B1, T2) = T2 because X1 <: T2
-    v.expectStaticType<Exactly<T2>>();
+void test2<T1 extends num, T2 extends T1>(
+    T1 Function({T1 x}) f1,
+    T2 Function({T2 x}) f2,
+    ) {
+  if (f1 is T2 Function({T1 x})) {
+    var v1 = (1 > 2) ? f1 : f2;
+    v1.expectStaticType<Exactly<T2 Function({T2 x})>>();
   }
 }
 
-void main() {
-  f1<num, int>(1, 2);
-  f2<A, B1>(B1(), A());
+main() {
+  test1((x) => 1, (x) => 2);
+  test2(({x}) => 1, ({x}) => 2);
 }

--- a/TypeSystem/upper-lower-bounds/up_A09_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A09_t02.dart
@@ -16,9 +16,7 @@
 /// `X2 <: T1`. We also use the fact that TOP(`X2 & B2`) never holds.
 /// @author sgrekhov22@gmail.com
 
-import 'dart:async';
 import '../../Utils/static_type_helper.dart';
-import 'up_lib.dart';
 
 // ignore_for_file: dead_code
 

--- a/TypeSystem/upper-lower-bounds/up_A09_t04.dart
+++ b/TypeSystem/upper-lower-bounds/up_A09_t04.dart
@@ -12,32 +12,33 @@
 ///     with respect to `X2`, as defined in inference.md.
 ///
 /// @description Check that UP(`T1`, `X2 & B2`) = `X2` if `T1 != X2 & B2`,
-/// not TOP(`T1`), `T1` is not  an intersection type, not BOTTOM(`T1`) and
+/// not TOP(`T1`), `T1` is not an intersection type, not BOTTOM(`T1`) and
 /// `T1 <: X2`. We also use the fact that TOP(`X2 & B2`) never holds.
 /// @author sgrekhov22@gmail.com
 
 import '../../Utils/static_type_helper.dart';
 
-// ignore_for_file: dead_code
-
-class A {}
-class B2 extends A {}
-
-void f1<X2, T1 extends X2>(T1 t1, X2 x2) {
-  if (x2 is B2) { // `x2` promoted to `X2 & B2`.
-    var v = (1 > 2) ? t1 : x2; // UP(T1, X2 & B2) = X2 because T1 <: X2
-    v.expectStaticType<Exactly<X2>>();
+void test1<T1 extends num, T2 extends T1>(
+  T2 Function(T2 x) f1,
+  T1 Function(T1 x) f2,
+) {
+  if (f2 is T2 Function(T1 x)) {
+    var v1 = (1 > 2) ? f1 : f2;
+    v1.expectStaticType<Exactly<T2 Function(T2 x)>>();
   }
 }
 
-void f2<X2 extends A, T1 extends X2>(T1 t1, X2 x2) {
-  if (x2 is B2) { // `x2` promoted to `X2 & B2`.
-    var v = (1 > 2) ? t1 : x2; // UP(T1, X2 & B2) = X2 because T1 <: X2
-    v.expectStaticType<Exactly<X2>>();
+void test2<T1 extends num, T2 extends T1>(
+    T2 Function({T2 x}) f1,
+    T1 Function({T1 x}) f2,
+    ) {
+  if (f2 is T2 Function({T1 x})) {
+    var v1 = (1 > 2) ? f1 : f2;
+    v1.expectStaticType<Exactly<T2 Function({T2 x})>>();
   }
 }
 
-void main() {
-  f1<num, int>(1, 2);
-  f2<A, B2>(B2(), A());
+main() {
+  test1((x) => 1, (x) => 2);
+  test2(({x}) => 1, ({x}) => 2);
 }


### PR DESCRIPTION
Tests `up_A08_t*.dart` are now mirrors of appropriate `up_A09_T*.dart` tests.