### PR TITLE
#4173. Static detection of TOP and OBJECT types

### DIFF
--- a/TypeSystem/upper-lower-bounds/README.md
+++ b/TypeSystem/upper-lower-bounds/README.md
@@ -1,0 +1,76 @@
+Some tests in this directory need to tell apart types that are mutual subtypes, such
+as `Object` and `FutureOr<Object>`, or `dynamic`, `Object?`, `FutureOr<Object?>` and
+`FutureOr<Object>?`. No subtype-based check can do this: `expectStaticType<Exactly<T>>()`,
+assignability and type parameter bounds are all defined in terms of subtyping, and
+[NORM](https://github.com/dart-lang/language/blob/main/resources/type-system/normalization.md)
+treats `FutureOr<Object>` and `Object` as the same type. The following probes make the
+difference visible at compile time.
+
+```dart
+Future<X> probeFuture<X>() => Future<X>.value(0 as dynamic);
+FutureOr<X> probeFutureOr<X>() => 0 as dynamic;
+Future<Future<X>> probeFuture2<X>() =>
+    Future<Future<X>>.value(Future<X>.value(0 as dynamic));
+Future<FutureOr<X>> probeFutureOr2<X>() => Future<FutureOr<X>>.value(0 as dynamic);
+```
+
+Type inference matches the type of a probe against the context type of the invocation.
+Because
+[subtype constraint generation](https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#subtype-constraint-generation)
+decomposes types syntactically rather than by subtyping, equivalent context types
+produce solutions for `X` that are *not* equivalent, and those solutions can be
+inspected with `expectStaticType`. A cascade is used so that the assertion is applied to
+the probe itself while the enclosing assignment (or argument position) still provides the
+context type:
+
+```dart
+v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+```
+
+A `dynamic` receiver, on the other hand, accepts any member access, so `v.checkDynamic`
+(a getter which is deliberately not declared anywhere) compiles if and only if the static
+type of `v` is `dynamic`. Such an access throws `NoSuchMethodError` at run time, so it
+has to be guarded:
+
+```dart
+if (1 > 2) {
+  v.checkDynamic;
+}
+```
+
+A single probe only looks at the outermost `FutureOr` of the context type, so a probe with
+one level of nesting cannot tell `FutureOr<Object>` from `FutureOr<FutureOr<Object>>`: it
+infers `X` as `Object` in the first case and as `FutureOr<Object>` in the second, and
+those two solutions are again mutual subtypes. Probes with two levels of nesting shift the
+inference variable one `FutureOr` deeper, and each of the ten types below then gets a
+distinct signature of static checks:
+
+| Static type of `v`            | `v.checkDynamic` | `v.expectStaticType` | `probeFuture()`             | `probeFuture2()`          | `probeFutureOr()`             | `probeFutureOr2()`          |
+|-------------------------------|------------------|----------------------|-----------------------------|---------------------------|-------------------------------|-----------------------------|
+| `Object`                      | error            | `Exactly<Object>`    | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<dynamic>>` |
+| `FutureOr<Object>`            | error            | `Exactly<Object>`    | `Future<Object>`            | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<Object>>`  |
+| `FutureOr<FutureOr<Object>>`  | error            | `Exactly<Object>`    | `Future<FutureOr<Object>>`  | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>>`  | `Future<FutureOr<Object>>`  |
+| `Object?`                     | error            | `Exactly<Object?>`   | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<dynamic>>` |
+| `FutureOr<Object?>`           | error            | `Exactly<Object?>`   | `Future<Object?>`           | `Future<Future<dynamic>>` | `FutureOr<Object?>`           | `Future<FutureOr<Object>>`  |
+| `FutureOr<Object>?`           | error            | `Exactly<Object?>`   | `Future<Object>`            | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<Object>>`  |
+| `FutureOr<FutureOr<Object?>>` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object?>>` | `Future<Future<Object?>>` | `FutureOr<FutureOr<Object?>>` | `Future<FutureOr<Object?>>` |
+| `FutureOr<FutureOr<Object>?>` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object>?>` | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>?>` | `Future<FutureOr<Object>>`  |
+| `FutureOr<FutureOr<Object>>?` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object>>`  | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>>`  | `Future<FutureOr<Object>>`  |
+| `dynamic`                     | compiles         | not applicable       | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<dynamic>`           | `Future<FutureOr<dynamic>>` |
+
+The four probe columns list the types that are actually inferred; any equivalent spelling
+passes the corresponding assertion just as well. This is what makes some of the cells
+coincide even though they are spelled differently: `Future<Object?>` and `Future<dynamic>`
+are mutual subtypes, and so are `FutureOr<Object?>` and `FutureOr<dynamic>`. In
+particular, `FutureOr<FutureOr<Object?>>` and `dynamic` have the same signature in all
+four probe columns, and `checkDynamic` is the only check that separates them.
+
+The pattern generalizes to deeper nesting: a probe with `k` nested `Future`s infers `X` as
+`Object` if and only if the context type has at least `k` nested `FutureOr`s, and
+replacing the innermost `Future` with `FutureOr` makes the probe report whether the type
+at that level is nullable.
+
+Note that extension members cannot be invoked on a `dynamic` receiver: for a `dynamic`
+`v` the call `v.expectStaticType<Exactly<Object?>>()` is a dynamic invocation which
+checks nothing statically (and fails at run time), which is why the second column is not
+applicable to the last row.

--- a/TypeSystem/upper-lower-bounds/up_A13_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A13_t01.dart
@@ -20,25 +20,38 @@ import '../../Utils/static_type_helper.dart';
 import 'up_lib.dart';
 
 void f1(Object x, FutureOr<Object> y) {
-  var v = (1 > 2) ? x : y; // MORETOP(Object, FutureOr<Object>) = true
-  // Object and FutureOr<Object> are subtypes of each other, which means that we
-  // can't see the difference using `expectStaticType()` function.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  v = confirmObjectContext(); // Check that `v` is not `FutureOr<Object>`.
+  // `v` is `Object` because MORETOP(Object, FutureOr<Object>) = true
+  var v = (1 > 2) ? x : y;
+  // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f2(Object x, FutureOr<FutureOr<Object>> y) {
-  var v = (1 > 2) ? x : y; // MORETOP(Object, FutureOr<FutureOr<Object>>) = true
-  v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  // `v` is `Object` because MORETOP(Object, FutureOr<FutureOr<Object>>) = true
+  var v = (1 > 2) ? x : y;
+  // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f3(FutureOr<Object> x, FutureOr<FutureOr<Object>> y) {
+  // `v` is `FutureOr<Object>` because
   // MORETOP(FutureOr<Object>, FutureOr<FutureOr<Object>>) =
   // MORETOP(Object, FutureOr<Object>) = true
   var v = (1 > 2) ? x : y;
-  v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  // Check that static type of `v` is really `FutureOr<Object>`, neither
+  // `Object` nor `FutureOr<FutureOr<Object>>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `Object`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  // Check that `v` is not `FutureOr<FutureOr<Object>>`.
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {

--- a/TypeSystem/upper-lower-bounds/up_lib.dart
+++ b/TypeSystem/upper-lower-bounds/up_lib.dart
@@ -92,3 +92,65 @@ Future<X> confirmFutureOrObjectContext<X>() {
 /// }
 /// ```
 X nonNull<X>(X? x) => x as X;
+
+/// A helper function used to distinguish between the types `Object` and
+/// `FutureOr<Object>` statically.
+///
+/// - `Object` context imposes no constraints on `X`, so `X` is `dynamic`;
+/// - the `FutureOr<Object>` context is decomposed into
+///   `Future<X> <: Future<Object>`, which gives `X <: Object`, so `X` is
+///   `Object`.
+/// The difference between `dynamic` and `Object` can be seen statically.
+Future<X> probeFuture<X>() => Future<X>.value(0 as dynamic);
+
+/// A helper function used to distinguish between the types `Object?` and
+/// `FutureOr<Object?>` statically.
+///
+/// - the `Object?` context is decomposed into `FutureOr<X> <: Object`, which
+///   gives `X <: Object`, so `X` is `Object`;
+/// - the `FutureOr<Object?>` context is decomposed into `X <: Object?`, so `X`
+///   is `Object?`.
+/// The difference can be seen statically because `FutureOr<Object>` is not a
+/// top type, unlike `FutureOr<Object?>`.
+///
+/// Note that a `dynamic` context imposes no constraints on `X` either, and
+/// `FutureOr<dynamic>` and `FutureOr<Object?>` are mutual subtypes, so this
+/// probe does not distinguish `dynamic` from `FutureOr<Object?>`. Use
+/// [probeFutureOr2] for that.
+FutureOr<X> probeFutureOr<X>() => 0 as dynamic;
+
+/// A helper function used to distinguish between the types `FutureOr<Object>`
+/// and `FutureOr<FutureOr<Object>>` statically. [probeFuture] cannot do it,
+/// because it infers `X` as `Object` in the former case and as
+/// `FutureOr<Object>` in the latter, and these two types are mutual subtypes.
+///
+/// - the `FutureOr<Object>` context is decomposed into
+///   `Future<Future<X>> <: Future<Object>`, that is, `Future<X> <: Object`,
+///   which imposes no constraints on `X`, so `X` is `dynamic`;
+/// - the `FutureOr<FutureOr<Object>>` context is decomposed into
+///   `Future<X> <: FutureOr<Object>` and then into `X <: Object`, so `X` is
+///   `Object`.
+/// The difference between `dynamic` and `Object` can be seen statically.
+///
+/// In general, a probe with `k` nested `Future`s infers `X` as `Object` if and
+/// only if the context type has at least `k` nested `FutureOr`s.
+Future<Future<X>> probeFuture2<X>() =>
+    Future<Future<X>>.value(Future<X>.value(0 as dynamic));
+
+/// A helper function used to distinguish `FutureOr<Object?>` from both
+/// `FutureOr<FutureOr<Object?>>` and `dynamic` statically. Neither
+/// [probeFutureOr], which cannot tell `FutureOr<Object?>` from `dynamic`, nor
+/// [probeFuture2], which sees no nullability at all, is able to do it.
+///
+/// - the `FutureOr<Object?>` context is decomposed into
+///   `FutureOr<X> <: Object?` and then into `FutureOr<X> <: Object`, which
+///   gives `X <: Object`, so `X` is `Object`;
+/// - the `FutureOr<FutureOr<Object?>>` context is decomposed into
+///   `FutureOr<X> <: FutureOr<Object?>`, which gives `X <: Object?`, so `X` is
+///   `Object?`;
+/// - the `dynamic` context imposes no constraints on `X`, so `X` is `dynamic`.
+///   `FutureOr<Object>` is not a top type, unlike `FutureOr<Object?>` and
+///   `FutureOr<dynamic>`, so the difference can be seen statically. The last
+///   two contexts, however, produce mutual subtypes, so `checkDynamic` remains
+///   the only check that separates `FutureOr<FutureOr<Object?>>` from `dynamic`.
+Future<FutureOr<X>> probeFutureOr2<X>() => Future<FutureOr<X>>.value(0 as dynamic);


### PR DESCRIPTION
This is an example of a solution for statically distinguishing between different TOP and OBJECT types. The key to this solution is the table in README.md, which defines how many checks we should perform. Please review it. If this solution is acceptable, I'll update all our UP and DOWN tests to use it.