### PR TITLE
#4173. Static detection of OBJECT types for OBJECT and nullable tests

### DIFF
--- a/TypeSystem/upper-lower-bounds/README.md
+++ b/TypeSystem/upper-lower-bounds/README.md
@@ -74,3 +74,122 @@ Note that extension members cannot be invoked on a `dynamic` receiver: for a `dy
 `v` the call `v.expectStaticType<Exactly<Object?>>()` is a dynamic invocation which
 checks nothing statically (and fails at run time), which is why the second column is not
 applicable to the last row.
+
+Required checks for every TOP and OBJECT type
+=============================================
+
+The snippets below are the checks that a test should include once it has concluded that
+the static type of `v` is a particular TOP or OBJECT type. Each step rules out some of
+the remaining mutual subtypes; comments list what is still possible after that step.
+
+`v` is `void`
+-------------
+
+```dart
+print(v); // Type `void` cannot be used.
+//    ^
+// [analyzer] unspecified
+// [cfe] unspecified
+```
+
+`v` is `FutureOr<void>`
+-----------------------
+
+```dart
+print(await v); // Type `void` cannot be used.
+//          ^
+// [analyzer] unspecified
+// [cfe] unspecified
+```
+
+`v` is `dynamic`
+----------------
+
+```dart
+if (1 > 2) {
+  v.checkDynamic;
+}
+```
+
+`v` is `FutureOr<dynamic>`
+--------------------------
+
+```dart
+if (1 > 2) {
+  (await v).checkDynamic;
+}
+```
+
+`v` is `Object?`
+----------------
+
+```dart
+v.expectStaticType<Exactly<Object?>>();
+// Remaining: `dynamic`, `Object?`, `FutureOr<dynamic>`, `FutureOr<Object?>`,
+// `FutureOr<Object>?`, `FutureOr<FutureOr<Object?>>`, ...
+v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>(); // Compile-time error if `v` is `FutureOr<Object>?`.
+v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>(); // Remaining: `Object?`.
+```
+
+`v` is `FutureOr<Object?>`
+--------------------------
+
+```dart
+v.expectStaticType<Exactly<Object?>>();
+// Remaining: `dynamic`, `Object?`, `FutureOr<dynamic>`, `FutureOr<Object>?`,
+// `FutureOr<Object?>`, `FutureOr<FutureOr<Object?>>`,
+// `FutureOr<FutureOr<Object>?>?`, ...
+v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object?>>>();
+// Remaining: `dynamic`, `FutureOr<dynamic>`, `FutureOr<Object?>`,
+// `FutureOr<FutureOr<Object?>>`, `FutureOr<FutureOr<Object>?>?`, ...
+v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>(); // Compile-time error if `v` is `FutureOr<FutureOr<Object>?>?`.
+v = probeFutureOr2()..expectStaticType<Exactly<Future<FutureOr<Object>>>>(); // Remaining: `FutureOr<Object?>`.
+```
+
+`v` is `Object`
+---------------
+
+```dart
+v.expectStaticType<Exactly<Object>>();
+// Remaining: `Object`, `FutureOr<Object>`, `FutureOr<FutureOr<Object>>`, ...
+v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>(); // Remaining: `Object`.
+```
+
+If `v` is `dynamic`, `v.expectStaticType<Exactly<Object>>()` is a dynamic invocation: it
+checks nothing statically and fails at run time. To reject `dynamic` at compile time,
+add:
+
+```dart
+if (1 > 2) {
+  v.checkNotDynamic;
+//  ^^^^^^^^^^^^^^^
+// [analyzer] unspecified
+// [cfe] unspecified
+}
+```
+
+`v` is `FutureOr<Object>`
+-------------------------
+
+```dart
+v.expectStaticType<Exactly<Object>>();
+// Remaining: `dynamic`, `Object`, `FutureOr<Object>`,
+// `FutureOr<FutureOr<Object>>`, ...
+v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+// Remaining: `FutureOr<Object>`, `FutureOr<FutureOr<Object>>`, ...
+v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
+// Remaining: `FutureOr<Object>`.
+```
+
+`v` is `FutureOr<Object>?`
+--------------------------
+
+```dart
+v.expectStaticType<Exactly<Object?>>();
+// Remaining: `dynamic`, `Object?`, `FutureOr<dynamic>`, `FutureOr<Object>?`,
+// `FutureOr<Object?>`, `FutureOr<FutureOr<Object?>>`, ...
+v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+// Remaining: `FutureOr<Object>?`, `FutureOr<FutureOr<Object>>?`, ...
+v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
+// Remaining: `FutureOr<Object>?`.
+```

--- a/TypeSystem/upper-lower-bounds/up_A13_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A13_t01.dart
@@ -25,9 +25,8 @@ void f1(Object x, FutureOr<Object> y) {
   // `v` is `Object` because MORETOP(Object, FutureOr<Object>) = true
   var v = (1 > 2) ? x : y;
   // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
@@ -35,9 +34,8 @@ void f2(Object x, FutureOr<FutureOr<Object>> y) {
   // `v` is `Object` because MORETOP(Object, FutureOr<FutureOr<Object>>) = true
   var v = (1 > 2) ? x : y;
   // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
@@ -48,11 +46,9 @@ void f3(FutureOr<Object> x, FutureOr<FutureOr<Object>> y) {
   var v = (1 > 2) ? x : y;
   // Check that static type of `v` is really `FutureOr<Object>`, neither
   // `Object` nor `FutureOr<FutureOr<Object>>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `Object`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
-  // Check that `v` is not `FutureOr<FutureOr<Object>>`.
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 

--- a/TypeSystem/upper-lower-bounds/up_A13_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A13_t01.dart
@@ -13,6 +13,8 @@
 /// and OBJECT(`T2`) and MORETOP(`T1`, `T2`). Test that `Object` is more top
 /// than `FutureOr<Object>`. Note that none of TOP(`T`), BOTTOM(`T`), or
 /// NULL(`T`) holds when OBJECT(`T`), and `T` is not an intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:async';

--- a/TypeSystem/upper-lower-bounds/up_A13_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A13_t02.dart
@@ -13,6 +13,8 @@
 /// and OBJECT(`T2`) and not MORETOP(`T1`, `T2`). Test that `Object` is more top
 /// than `FutureOr<Object>`. Note that none of TOP(`T`), BOTTOM(`T`), or
 /// NULL(`T`) holds when OBJECT(`T`), and `T` is not an intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:async';
@@ -21,24 +23,34 @@ import 'up_lib.dart';
 
 void f1(FutureOr<Object> x, Object y) {
   var v = (1 > 2) ? x : y; // MORETOP(FutureOr<Object>, Object) = false
-  // Object and FutureOr<Object> are subtypes of each other, which means that we
-  // can't see the difference using `expectStaticType()` function.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  v = confirmObjectContext(); // Check that `v` is not `FutureOr<Object>`.
+  // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f2(FutureOr<FutureOr<Object>> x, Object y) {
   var v = (1 > 2) ? x : y; // MORETOP(FutureOr<FutureOr<Object>>, Object) = false
-  v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f3(FutureOr<FutureOr<Object>> x, FutureOr<Object> y) {
   // MORETOP(FutureOr<FutureOr<Object>>, FutureOr<Object>) =
   // MORETOP(FutureOr<Object>, Object) = false
   var v = (1 > 2) ? x : y;
-  v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  // Check that static type of `v` is really `FutureOr<Object>`, neither
+  // `Object` nor `FutureOr<FutureOr<Object>>`.
+  // See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
+  // Check that `v` is not `Object`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  // Check that `v` is not `FutureOr<FutureOr<Object>>`.
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {

--- a/TypeSystem/upper-lower-bounds/up_A13_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A13_t02.dart
@@ -24,18 +24,16 @@ import 'up_lib.dart';
 void f1(FutureOr<Object> x, Object y) {
   var v = (1 > 2) ? x : y; // MORETOP(FutureOr<Object>, Object) = false
   // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f2(FutureOr<FutureOr<Object>> x, Object y) {
   var v = (1 > 2) ? x : y; // MORETOP(FutureOr<FutureOr<Object>>, Object) = false
   // Check that static type of `v` is really `Object`, not `FutureOr<Object>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
@@ -45,11 +43,9 @@ void f3(FutureOr<FutureOr<Object>> x, FutureOr<Object> y) {
   var v = (1 > 2) ? x : y;
   // Check that static type of `v` is really `FutureOr<Object>`, neither
   // `Object` nor `FutureOr<FutureOr<Object>>`.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`
-  // Check that `v` is not `Object`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
-  // Check that `v` is not `FutureOr<FutureOr<Object>>`.
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 

--- a/TypeSystem/upper-lower-bounds/up_A14_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A14_t01.dart
@@ -28,28 +28,29 @@ void f1a(Object o, num n) {
   var v = (1 > 2) ? o : n; // UP(Object, num) = Object
   // Object and FutureOr<Object> are subtypes of each other, which means that we
   // can't see the difference using `expectStaticType()` function.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f1b(FutureOr<Object> o, num n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, num) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
-  // Check that `v` is neither `Object` nor `FutureOr<FutureOr<Object>>`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f2a<X extends num>(Object o, X n) {
   var v = (1 > 2) ? o : n; // UP(Object, X) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f2b<X extends num>(FutureOr<Object> o, X n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -57,12 +58,14 @@ void f2b<X extends num>(FutureOr<Object> o, X n) {
 
 void f3a(Object o, Function n) {
   var v = (1 > 2) ? o : n; // UP(Object, Function) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f3b(FutureOr<Object> o, Function n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Function) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -70,12 +73,14 @@ void f3b(FutureOr<Object> o, Function n) {
 
 void f4a(Object o, Record n) {
   var v = (1 > 2) ? o : n; // UP(Object, Record) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f4b(FutureOr<Object> o, Record n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Record) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -83,12 +88,14 @@ void f4b(FutureOr<Object> o, Record n) {
 
 void f5a(Object o, FutureOr<int> n) {
   var v = (1 > 2) ? o : n; // UP(Object, FutureOr<int>) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f5b(FutureOr<Object> o, FutureOr<int> n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FutureOr<int>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -96,12 +103,14 @@ void f5b(FutureOr<Object> o, FutureOr<int> n) {
 
 void f6a(Object o, C n) {
   var v = (1 > 2) ? o : n; // UP(Object, C) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f6b(FutureOr<Object> o, C n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, C) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -109,12 +118,14 @@ void f6b(FutureOr<Object> o, C n) {
 
 void f7a(Object o, D<int, String> n) {
   var v = (1 > 2) ? o : n; // UP(Object, D<int, String>) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f7b(FutureOr<Object> o, D<int, String> n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, D<int, String>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -122,12 +133,14 @@ void f7b(FutureOr<Object> o, D<int, String> n) {
 
 void f8a(Object o, FPositional n) {
   var v = (1 > 2) ? o : n; // UP(Object, FPositional) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f8b(FutureOr<Object> o, FPositional n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FPositional) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -135,12 +148,14 @@ void f8b(FutureOr<Object> o, FPositional n) {
 
 void f9a(Object o, FNamed n) {
   var v = (1 > 2) ? o : n; // UP(Object, FNamed) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f9b(FutureOr<Object> o, FNamed n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FNamed) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -148,12 +163,14 @@ void f9b(FutureOr<Object> o, FNamed n) {
 
 void f10a(Object o, Rec n) {
   var v = (1 > 2) ? o : n; // UP(Object, Rec) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f10b(FutureOr<Object> o, Rec n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Rec) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -161,12 +178,14 @@ void f10b(FutureOr<Object> o, Rec n) {
 
 void f11a(Object o, E n) {
   var v = (1 > 2) ? o : n; // UP(Object, E) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f11b(FutureOr<Object> o, E n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, E) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();

--- a/TypeSystem/upper-lower-bounds/up_A14_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A14_t01.dart
@@ -14,6 +14,8 @@
 /// OBJECT(`T2`) and `T2` is non-nullable. Note that none of TOP(`T`),
 /// BOTTOM(`T`), or NULL(`T`) holds when OBJECT(`T`), and `T` is not an
 /// intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 // ignore_for_file: unused_local_variable
@@ -22,161 +24,175 @@ import 'dart:async';
 import '../../Utils/static_type_helper.dart';
 import 'up_lib.dart';
 
-void f1(Object o, num n) {
+void f1a(Object o, num n) {
   var v = (1 > 2) ? o : n; // UP(Object, num) = Object
   // Object and FutureOr<Object> are subtypes of each other, which means that we
   // can't see the difference using `expectStaticType()` function.
+  // See the table in README.md for more details.
   v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  v = confirmObjectContext(); // Check that `v`'s type is `Object`.
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f2(FutureOr<Object> o, num n) {
+void f1b(FutureOr<Object> o, num n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, num) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext(); // Check that `v`'s type is `FutureOr<Object>`.
+  // Check that `v` is neither `Object` nor `FutureOr<FutureOr<Object>>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f3<X extends num>(Object o, X n) {
+void f2a<X extends num>(Object o, X n) {
   var v = (1 > 2) ? o : n; // UP(Object, X) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f4<X extends num>(FutureOr<Object> o, X n) {
+void f2b<X extends num>(FutureOr<Object> o, X n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f5(Object o, Function n) {
+void f3a(Object o, Function n) {
   var v = (1 > 2) ? o : n; // UP(Object, Function) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f6(FutureOr<Object> o, Function n) {
+void f3b(FutureOr<Object> o, Function n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Function) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f7(Object o, Record n) {
+void f4a(Object o, Record n) {
   var v = (1 > 2) ? o : n; // UP(Object, Record) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f8(FutureOr<Object> o, Record n) {
+void f4b(FutureOr<Object> o, Record n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Record) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f9(Object o, FutureOr<int> n) {
+void f5a(Object o, FutureOr<int> n) {
   var v = (1 > 2) ? o : n; // UP(Object, FutureOr<int>) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f10(FutureOr<Object> o, FutureOr<int> n) {
+void f5b(FutureOr<Object> o, FutureOr<int> n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FutureOr<int>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f11(Object o, C n) {
+void f6a(Object o, C n) {
   var v = (1 > 2) ? o : n; // UP(Object, C) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f12(FutureOr<Object> o, C n) {
+void f6b(FutureOr<Object> o, C n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, C) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f13(Object o, D<int, String> n) {
+void f7a(Object o, D<int, String> n) {
   var v = (1 > 2) ? o : n; // UP(Object, D<int, String>) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f14(FutureOr<Object> o, D<int, String> n) {
+void f7b(FutureOr<Object> o, D<int, String> n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, D<int, String>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f15(Object o, FPositional n) {
+void f8a(Object o, FPositional n) {
   var v = (1 > 2) ? o : n; // UP(Object, FPositional) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f16(FutureOr<Object> o, FPositional n) {
+void f8b(FutureOr<Object> o, FPositional n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FPositional) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f17(Object o, FNamed n) {
+void f9a(Object o, FNamed n) {
   var v = (1 > 2) ? o : n; // UP(Object, FNamed) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f18(FutureOr<Object> o, FNamed n) {
+void f9b(FutureOr<Object> o, FNamed n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FNamed) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f19(Object o, Rec n) {
+void f10a(Object o, Rec n) {
   var v = (1 > 2) ? o : n; // UP(Object, Rec) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f20(FutureOr<Object> o, Rec n) {
+void f10b(FutureOr<Object> o, Rec n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Rec) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f21(Object o, E n) {
+void f11a(Object o, E n) {
   var v = (1 > 2) ? o : n; // UP(Object, E) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f22(FutureOr<Object> o, E n) {
+void f11b(FutureOr<Object> o, E n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, E) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {
-  f1(1, 1);
-  f2(1, 1);
-  f3(1, 1);
-  f4(1, 1);
-  f5(1, () {});
-  f6(1, () {});
-  f7(1, (1,));
-  f8(1, (1,));
-  f9(1, 1);
-  f10(1, 1);
-  f11(1, C());
-  f12(1, C());
-  f13(1, D<int, String>());
-  f14(1, D<int, String>());
-  f15(1, <X extends num>(X x, [int i = 0]) => 0);
-  f16(1, <X extends num>(X x, [int i = 0]) => 0);
-  f17(1, <X extends num>(X x, {int i = 0}) => 0);
-  f18(1, <X extends num>(X x, {int i = 0}) => 0);
-  f19(1, (1, 'two', b: true));
-  f20(1, (1, 'two', b: true));
-  f21(1, E.e0);
-  f22(1, E.e0);
+  f1a(1, 1);
+  f1b(1, 1);
+  f2a(1, 1);
+  f2b(1, 1);
+  f3a(1, () {});
+  f3b(1, () {});
+  f4a(1, (1,));
+  f4b(1, (1,));
+  f5a(1, 1);
+  f5b(1, 1);
+  f6a(1, C());
+  f6b(1, C());
+  f7a(1, D<int, String>());
+  f7b(1, D<int, String>());
+  f8a(1, <X extends num>(X x, [int i = 0]) => 0);
+  f8b(1, <X extends num>(X x, [int i = 0]) => 0);
+  f9a(1, <X extends num>(X x, {int i = 0}) => 0);
+  f9b(1, <X extends num>(X x, {int i = 0}) => 0);
+  f10a(1, (1, 'two', b: true));
+  f10b(1, (1, 'two', b: true));
+  f11a(1, E.e0);
+  f11b(1, E.e0);
 }

--- a/TypeSystem/upper-lower-bounds/up_A14_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A14_t02.dart
@@ -14,352 +14,264 @@
 /// OBJECT(`T2`) and `T2` is not non-nullable. Note that none of TOP(`T`),
 /// BOTTOM(`T`), or NULL(`T`) holds when OBJECT(`T`), and `T` is not an
 /// intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
+// ignore_for_file: unused_local_variable
+
 import 'dart:async';
-import '../../Utils/expect.dart';
 import '../../Utils/static_type_helper.dart';
 import 'up_lib.dart';
 
-void f1(Object o, num? n) {
+void f1a(Object o, num? n) {
   var v = (1 > 2) ? o : n; // UP(Object, num?) = Object?
-  v.expectStaticType<Exactly<Object?>>(); // Check that v's type is TOP.
-  // `Object` and `FutureOr<Object> `are subtypes of each other, which means
-  // that we can't see the difference using `expectStaticType()` function.
-  // `v.expectStaticType<Exactly<Object?>>();` also succeeds. Let's
-  // check that `v` is not `FutureOr<Object?>`
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext(); // Check that `v`'s type is `Object`.
+  // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
+  // other, which means that we can't see the difference using
+  // `expectStaticType()` function. See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object?>>(); // Check that `v`'s type is TOP.
+  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f2(FutureOr<Object> o, num? n) {
+void f1b(FutureOr<Object> o, num? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, num?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext(); // Check that `v`'s type is `FutureOr<Object>`.
+  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f3<X extends num>(Object o, X? n) {
+void f2a<X extends num>(Object o, X? n) {
   var v = (1 > 2) ? o : n; // UP(Object, X?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f4<X extends num>(FutureOr<Object> o, X? n) {
+void f2b<X extends num>(FutureOr<Object> o, X? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f5<X extends num?>(Object o, X n) {
+void f3a<X extends num?>(Object o, X n) {
   var v = (1 > 2) ? o : n; // UP(Object, X?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f6<X extends num?>(FutureOr<Object> o, X n) {
+void f3b<X extends num?>(FutureOr<Object> o, X n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f7(Object o, Function? n) {
+void f4a(Object o, Function? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Function?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f8(FutureOr<Object> o, Function? n) {
+void f4b(FutureOr<Object> o, Function? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Function?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f9(Object o, Record? n) {
+void f5a(Object o, Record? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Record?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f10(FutureOr<Object> o, Record? n) {
+void f5b(FutureOr<Object> o, Record? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Record?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f11(Object o, FutureOr<int>? n) {
+void f6a(Object o, FutureOr<int>? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FutureOr<int>?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f12(FutureOr<Object> o, FutureOr<int>? n) {
+void f6b(FutureOr<Object> o, FutureOr<int>? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FutureOr<int>?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f13(Object o, C? n) {
+void f7a(Object o, C? n) {
   var v = (1 > 2) ? o : n; // UP(Object, C?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f14(FutureOr<Object> o, C? n) {
+void f7b(FutureOr<Object> o, C? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, C?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f15(Object o, D<int, String>? n) {
+void f8a(Object o, D<int, String>? n) {
   var v = (1 > 2) ? o : n; // UP(Object, D<int, String>?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f16(FutureOr<Object> o, D<int, String>? n) {
+void f8b(FutureOr<Object> o, D<int, String>? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, D<int, String>?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f17(Object o, FPositional? n) {
+void f9a(Object o, FPositional? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FPositional?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f18(FutureOr<Object> o, FPositional? n) {
+void f9b(FutureOr<Object> o, FPositional? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FPositional?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f19(Object o, FNamed? n) {
+void f10a(Object o, FNamed? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FNamed?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f20(FutureOr<Object> o, FNamed? n) {
+void f10b(FutureOr<Object> o, FNamed? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FNamed?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f21(Object o, Rec? n) {
+void f11a(Object o, Rec? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Rec?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f22(FutureOr<Object> o, Rec? n) {
+void f11b(FutureOr<Object> o, Rec? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Rec?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f23(Object o, E? n) {
+void f12a(Object o, E? n) {
   var v = (1 > 2) ? o : n; // UP(Object, E?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f24(FutureOr<Object> o, E? n) {
+void f12b(FutureOr<Object> o, E? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, E?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f25(Object o, ET? n) {
+void f13a(Object o, ET? n) {
   var v = (1 > 2) ? o : n; // UP(Object, ET?) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f26(FutureOr<Object> o, ET? n) {
+void f13b(FutureOr<Object> o, ET? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, ET?) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f27(Object o, ET n) {
+void f14a(Object o, ET n) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? o : n; // UP(Object, ET) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip '?'
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f28(FutureOr<Object> o, ET n) {
+void f14b(FutureOr<Object> o, ET n) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, ET) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) {
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f29(Object t1, FutureOr<ET> t2) {
+void f15a(Object t1, FutureOr<ET> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
-  // UP(Object, FutureOr<ET>) = Object?;
-  var v = (1 > 2) ? t1 : t2;
+  var v = (1 > 2) ? t1 : t2; // UP(Object, FutureOr<ET>) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f30(FutureOr<Object> t1, FutureOr<ET> t2) {
+void f15b(FutureOr<Object> t1, FutureOr<ET> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
-  // UP(FutureOr<Object>, FutureOr<ET>) = FutureOr<Object>?;
-  var v = (1 > 2) ? t1 : t2;
-  v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  if (v == null) { // Strip `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  var v = (1 > 2) ? t1 : t2; // UP(FutureOr<Object>, FutureOr<ET>) = FutureOr<Object>?
+  v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {
-  f1(1, 1);
-  f2(1, 1);
-  f3(1, 1);
-  f4(1, 1);
-  f5(1, 1);
-  f5(1, 1);
-  f7(1, () {});
-  f8(1, () {});
-  f9(1, (1,));
-  f10(1, (1,));
-  f11(1, 1);
-  f12(1, 1);
-  f13(1, C());
-  f14(1, C());
-  f15(1, D<int, String>());
-  f16(1, D<int, String>());
-  f17(1, <X extends num>(X x, [int i = 0]) => 0);
-  f18(1, <X extends num>(X x, [int i = 0]) => 0);
-  f19(1, <X extends num>(X x, {int i = 0}) => 0);
-  f20(1, <X extends num>(X x, {int i = 0}) => 0);
-  f21(1, (1, 'two', b: true));
-  f22(1, (1, 'two', b: true));
-  f23(1, E.e0);
-  f24(1, E.e0);
-  f25(1, ET(0));
-  f26(1, ET(0));
-  f27(1, ET(0));
-  f28(1, ET(0));
-  f29(1, ET(0));
-  f30(1, ET(0));
+  f1a(1, 1);
+  f1b(1, 1);
+  f2a(1, 1);
+  f2b(1, 1);
+  f3a(1, 1);
+  f3b(1, 1);
+  f4a(1, () {});
+  f4b(1, () {});
+  f5a(1, (1,));
+  f5b(1, (1,));
+  f6a(1, 1);
+  f6b(1, 1);
+  f7a(1, C());
+  f7b(1, C());
+  f8a(1, D<int, String>());
+  f8b(1, D<int, String>());
+  f9a(1, <X extends num>(X x, [int i = 0]) => 0);
+  f9b(1, <X extends num>(X x, [int i = 0]) => 0);
+  f10a(1, <X extends num>(X x, {int i = 0}) => 0);
+  f10b(1, <X extends num>(X x, {int i = 0}) => 0);
+  f11a(1, (1, 'two', b: true));
+  f11b(1, (1, 'two', b: true));
+  f12a(1, E.e0);
+  f12b(1, E.e0);
+  f13a(1, ET(0));
+  f13b(1, ET(0));
+  f14a(1, ET(0));
+  f14b(1, ET(0));
+  f15a(1, ET(0));
+  f15b(1, ET(0));
 }

--- a/TypeSystem/upper-lower-bounds/up_A14_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A14_t02.dart
@@ -28,23 +28,23 @@ void f1a(Object o, num? n) {
   var v = (1 > 2) ? o : n; // UP(Object, num?) = Object?
   // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
   // other, which means that we can't see the difference using
-  // `expectStaticType()` function. See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object?>>(); // Check that `v`'s type is TOP.
-  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f1b(FutureOr<Object> o, num? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, num?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
-  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f2a<X extends num>(Object o, X? n) {
   var v = (1 > 2) ? o : n; // UP(Object, X?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -52,6 +52,7 @@ void f2a<X extends num>(Object o, X? n) {
 
 void f2b<X extends num>(FutureOr<Object> o, X? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -59,6 +60,7 @@ void f2b<X extends num>(FutureOr<Object> o, X? n) {
 
 void f3a<X extends num?>(Object o, X n) {
   var v = (1 > 2) ? o : n; // UP(Object, X?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -66,6 +68,7 @@ void f3a<X extends num?>(Object o, X n) {
 
 void f3b<X extends num?>(FutureOr<Object> o, X n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, X?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -73,6 +76,7 @@ void f3b<X extends num?>(FutureOr<Object> o, X n) {
 
 void f4a(Object o, Function? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Function?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -80,6 +84,7 @@ void f4a(Object o, Function? n) {
 
 void f4b(FutureOr<Object> o, Function? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Function?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -87,6 +92,7 @@ void f4b(FutureOr<Object> o, Function? n) {
 
 void f5a(Object o, Record? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Record?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -94,6 +100,7 @@ void f5a(Object o, Record? n) {
 
 void f5b(FutureOr<Object> o, Record? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Record?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -101,6 +108,7 @@ void f5b(FutureOr<Object> o, Record? n) {
 
 void f6a(Object o, FutureOr<int>? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FutureOr<int>?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -108,6 +116,7 @@ void f6a(Object o, FutureOr<int>? n) {
 
 void f6b(FutureOr<Object> o, FutureOr<int>? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FutureOr<int>?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -115,6 +124,7 @@ void f6b(FutureOr<Object> o, FutureOr<int>? n) {
 
 void f7a(Object o, C? n) {
   var v = (1 > 2) ? o : n; // UP(Object, C?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -122,6 +132,7 @@ void f7a(Object o, C? n) {
 
 void f7b(FutureOr<Object> o, C? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, C?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -129,6 +140,7 @@ void f7b(FutureOr<Object> o, C? n) {
 
 void f8a(Object o, D<int, String>? n) {
   var v = (1 > 2) ? o : n; // UP(Object, D<int, String>?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -136,6 +148,7 @@ void f8a(Object o, D<int, String>? n) {
 
 void f8b(FutureOr<Object> o, D<int, String>? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, D<int, String>?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -143,6 +156,7 @@ void f8b(FutureOr<Object> o, D<int, String>? n) {
 
 void f9a(Object o, FPositional? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FPositional?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -150,6 +164,7 @@ void f9a(Object o, FPositional? n) {
 
 void f9b(FutureOr<Object> o, FPositional? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FPositional?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -157,6 +172,7 @@ void f9b(FutureOr<Object> o, FPositional? n) {
 
 void f10a(Object o, FNamed? n) {
   var v = (1 > 2) ? o : n; // UP(Object, FNamed?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -164,6 +180,7 @@ void f10a(Object o, FNamed? n) {
 
 void f10b(FutureOr<Object> o, FNamed? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, FNamed?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -171,6 +188,7 @@ void f10b(FutureOr<Object> o, FNamed? n) {
 
 void f11a(Object o, Rec? n) {
   var v = (1 > 2) ? o : n; // UP(Object, Rec?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -178,6 +196,7 @@ void f11a(Object o, Rec? n) {
 
 void f11b(FutureOr<Object> o, Rec? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, Rec?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -185,6 +204,7 @@ void f11b(FutureOr<Object> o, Rec? n) {
 
 void f12a(Object o, E? n) {
   var v = (1 > 2) ? o : n; // UP(Object, E?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -192,6 +212,7 @@ void f12a(Object o, E? n) {
 
 void f12b(FutureOr<Object> o, E? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, E?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -199,6 +220,7 @@ void f12b(FutureOr<Object> o, E? n) {
 
 void f13a(Object o, ET? n) {
   var v = (1 > 2) ? o : n; // UP(Object, ET?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -206,6 +228,7 @@ void f13a(Object o, ET? n) {
 
 void f13b(FutureOr<Object> o, ET? n) {
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, ET?) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -214,6 +237,7 @@ void f13b(FutureOr<Object> o, ET? n) {
 void f14a(Object o, ET n) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? o : n; // UP(Object, ET) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -222,6 +246,7 @@ void f14a(Object o, ET n) {
 void f14b(FutureOr<Object> o, ET n) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? o : n; // UP(FutureOr<Object>, ET) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -230,6 +255,7 @@ void f14b(FutureOr<Object> o, ET n) {
 void f15a(Object t1, FutureOr<ET> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? t1 : t2; // UP(Object, FutureOr<ET>) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -238,6 +264,7 @@ void f15a(Object t1, FutureOr<ET> t2) {
 void f15b(FutureOr<Object> t1, FutureOr<ET> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? t1 : t2; // UP(FutureOr<Object>, FutureOr<ET>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();

--- a/TypeSystem/upper-lower-bounds/up_A15_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A15_t01.dart
@@ -28,28 +28,29 @@ void f1a(num n, Object o) {
   var v = (1 > 2) ? n : o; // UP(num, Object) = Object
   // Object and FutureOr<Object> are subtypes of each other, which means that we
   // can't see the difference using `expectStaticType()` function.
-  // See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  // Check that `v` is not `FutureOr<Object>`.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f1b(num n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(num, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
-  // Check that `v` is neither `Object` nor `FutureOr<FutureOr<Object>>`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f2a<X extends num>(X n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f2b<X extends num>(X n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -57,12 +58,14 @@ void f2b<X extends num>(X n, FutureOr<Object> o) {
 
 void f3a(Function n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Function, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f3b(Function n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Function, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -70,12 +73,14 @@ void f3b(Function n, FutureOr<Object> o) {
 
 void f4a(Record n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Record, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f4b(Record n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Record, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -83,12 +88,14 @@ void f4b(Record n, FutureOr<Object> o) {
 
 void f5a(FutureOr<int> n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f5b(FutureOr<int> n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -96,12 +103,14 @@ void f5b(FutureOr<int> n, FutureOr<Object> o) {
 
 void f6a(C n, Object o) {
   var v = (1 > 2) ? n : o; // UP(C, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f6b(C n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(C, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -109,12 +118,14 @@ void f6b(C n, FutureOr<Object> o) {
 
 void f7a(D<int, String> n, Object o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f7b(D<int, String> n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -122,12 +133,14 @@ void f7b(D<int, String> n, FutureOr<Object> o) {
 
 void f8a(FPositional n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FPositional, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f8b(FPositional n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FPositional, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -135,12 +148,14 @@ void f8b(FPositional n, FutureOr<Object> o) {
 
 void f9a(FNamed n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FNamed, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f9b(FNamed n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FNamed, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -148,12 +163,14 @@ void f9b(FNamed n, FutureOr<Object> o) {
 
 void f10a(Rec n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Rec, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f10b(Rec n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Rec, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -161,12 +178,14 @@ void f10b(Rec n, FutureOr<Object> o) {
 
 void f11a(E n, Object o) {
   var v = (1 > 2) ? n : o; // UP(E, Object) = Object
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
 void f11b(E n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(E, FutureOr<Object>) = FutureOr<Object>
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();

--- a/TypeSystem/upper-lower-bounds/up_A15_t01.dart
+++ b/TypeSystem/upper-lower-bounds/up_A15_t01.dart
@@ -14,6 +14,8 @@
 /// OBJECT(`T1`) and `T1` is non-nullable. Note that none of TOP(`T`),
 /// BOTTOM(`T`), or NULL(`T`) holds when OBJECT(`T`), and `T` is not an
 /// intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 // ignore_for_file: unused_local_variable
@@ -22,161 +24,175 @@ import 'dart:async';
 import '../../Utils/static_type_helper.dart';
 import 'up_lib.dart';
 
-void f1(num n, Object o) {
+void f1a(num n, Object o) {
   var v = (1 > 2) ? n : o; // UP(num, Object) = Object
   // Object and FutureOr<Object> are subtypes of each other, which means that we
   // can't see the difference using `expectStaticType()` function.
+  // See the table in README.md for more details.
   v.expectStaticType<Exactly<Object>>(); // Check that `v`'s type is `OBJECT`.
-  v = confirmObjectContext(); // Check that `v`'s type is `Object`.
+  // Check that `v` is not `FutureOr<Object>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f2(num n, FutureOr<Object> o) {
+void f1b(num n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(num, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext(); // Check that `v`'s type is `FutureOr<Object>`.
+  // Check that `v` is neither `Object` nor `FutureOr<FutureOr<Object>>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f3<X extends num>(X n, Object o) {
+void f2a<X extends num>(X n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f4<X extends num>(X n, FutureOr<Object> o) {
+void f2b<X extends num>(X n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f5(Function n, Object o) {
+void f3a(Function n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Function, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f6(Function n, FutureOr<Object> o) {
+void f3b(Function n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Function, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f7(Record n, Object o) {
+void f4a(Record n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Record, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f8(Record n, FutureOr<Object> o) {
+void f4b(Record n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Record, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f9(FutureOr<int> n, Object o) {
+void f5a(FutureOr<int> n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f10(FutureOr<int> n, FutureOr<Object> o) {
+void f5b(FutureOr<int> n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f11(C n, Object o) {
+void f6a(C n, Object o) {
   var v = (1 > 2) ? n : o; // UP(C, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f12(C n, FutureOr<Object> o) {
+void f6b(C n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(C, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f13(D<int, String> n, Object o) {
+void f7a(D<int, String> n, Object o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f14(D<int, String> n, FutureOr<Object> o) {
+void f7b(D<int, String> n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f15(FPositional n, Object o) {
+void f8a(FPositional n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FPositional, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f16(FPositional n, FutureOr<Object> o) {
+void f8b(FPositional n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FPositional, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f17(FNamed n, Object o) {
+void f9a(FNamed n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FNamed, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f18(FNamed n, FutureOr<Object> o) {
+void f9b(FNamed n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FNamed, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f19(Rec n, Object o) {
+void f10a(Rec n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Rec, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f20(Rec n, FutureOr<Object> o) {
+void f10b(Rec n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Rec, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f21(E n, Object o) {
+void f11a(E n, Object o) {
   var v = (1 > 2) ? n : o; // UP(E, Object) = Object
   v.expectStaticType<Exactly<Object>>();
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
 }
 
-void f22(E n, FutureOr<Object> o) {
+void f11b(E n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(E, FutureOr<Object>) = FutureOr<Object>
   v.expectStaticType<Exactly<Object>>();
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {
-  f1(1, 1);
-  f2(1, 1);
-  f3(1, 1);
-  f4(1, 1);
-  f5(() {}, 1);
-  f6(() {}, 1);
-  f7((1,), 1);
-  f8((1,), 1);
-  f9(1, 1);
-  f10(1, 1);
-  f11(C(), 1);
-  f12(C(), 1);
-  f13(D<int, String>(), 1);
-  f14(D<int, String>(), 1);
-  f15(<X extends num>(X x, [int i = 0]) => 0, 1);
-  f16(<X extends num>(X x, [int i = 0]) => 0, 1);
-  f17(<X extends num>(X x, {int i = 0}) => 0, 1);
-  f18(<X extends num>(X x, {int i = 0}) => 0, 1);
-  f19((1, 'two', b: true), 1);
-  f20((1, 'two', b: true), 1);
-  f21(E.e0, 1);
-  f22(E.e0, 1);
+  f1a(1, 1);
+  f1b(1, 1);
+  f2a(1, 1);
+  f2b(1, 1);
+  f3a(() {}, 1);
+  f3b(() {}, 1);
+  f4a((1,), 1);
+  f4b((1,), 1);
+  f5a(1, 1);
+  f5b(1, 1);
+  f6a(C(), 1);
+  f6b(C(), 1);
+  f7a(D<int, String>(), 1);
+  f7b(D<int, String>(), 1);
+  f8a(<X extends num>(X x, [int i = 0]) => 0, 1);
+  f8b(<X extends num>(X x, [int i = 0]) => 0, 1);
+  f9a(<X extends num>(X x, {int i = 0}) => 0, 1);
+  f9b(<X extends num>(X x, {int i = 0}) => 0, 1);
+  f10a((1, 'two', b: true), 1);
+  f10b((1, 'two', b: true), 1);
+  f11a(E.e0, 1);
+  f11b(E.e0, 1);
 }

--- a/TypeSystem/upper-lower-bounds/up_A15_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A15_t02.dart
@@ -28,23 +28,24 @@ void f1a(num? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(num?, Object) = Object?
   // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
   // other, which means that we can't see the difference using
-  // `expectStaticType()` function. See the table in README.md for more details.
-  v.expectStaticType<Exactly<Object?>>(); // Check that `v`'s type is TOP.
-  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  // `expectStaticType()` function.
+  // See README.md for an explanation of each step in the checks below.
+  v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f1b(num? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(num?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
-  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f2a<X extends num>(X? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -52,6 +53,7 @@ void f2a<X extends num>(X? n, Object o) {
 
 void f2b<X extends num>(X? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -59,6 +61,7 @@ void f2b<X extends num>(X? n, FutureOr<Object> o) {
 
 void f3a<X extends num?>(X n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -66,6 +69,7 @@ void f3a<X extends num?>(X n, Object o) {
 
 void f3b<X extends num?>(X n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -73,6 +77,7 @@ void f3b<X extends num?>(X n, FutureOr<Object> o) {
 
 void f4a(Function? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Function?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -80,6 +85,7 @@ void f4a(Function? n, Object o) {
 
 void f4b(Function? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Function?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -87,6 +93,7 @@ void f4b(Function? n, FutureOr<Object> o) {
 
 void f5a(Record? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Record?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -94,6 +101,7 @@ void f5a(Record? n, Object o) {
 
 void f5b(Record? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Record?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -101,6 +109,7 @@ void f5b(Record? n, FutureOr<Object> o) {
 
 void f6a(FutureOr<int>? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -108,6 +117,7 @@ void f6a(FutureOr<int>? n, Object o) {
 
 void f6b(FutureOr<int>? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -115,6 +125,7 @@ void f6b(FutureOr<int>? n, FutureOr<Object> o) {
 
 void f7a(C? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(C?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -122,6 +133,7 @@ void f7a(C? n, Object o) {
 
 void f7b(C? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(C?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -129,6 +141,7 @@ void f7b(C? n, FutureOr<Object> o) {
 
 void f8a(D<int, String>? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -136,6 +149,7 @@ void f8a(D<int, String>? n, Object o) {
 
 void f8b(D<int, String>? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -143,6 +157,7 @@ void f8b(D<int, String>? n, FutureOr<Object> o) {
 
 void f9a(FPositional? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FPositional?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -150,6 +165,7 @@ void f9a(FPositional? n, Object o) {
 
 void f9b(FPositional? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FPositional?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -157,6 +173,7 @@ void f9b(FPositional? n, FutureOr<Object> o) {
 
 void f10a(FNamed? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FNamed?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -164,6 +181,7 @@ void f10a(FNamed? n, Object o) {
 
 void f10b(FNamed? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FNamed?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -171,6 +189,7 @@ void f10b(FNamed? n, FutureOr<Object> o) {
 
 void f11a(Rec? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Rec?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -178,6 +197,7 @@ void f11a(Rec? n, Object o) {
 
 void f11b(Rec? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Rec?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -185,6 +205,7 @@ void f11b(Rec? n, FutureOr<Object> o) {
 
 void f12a(E? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(E?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -192,6 +213,7 @@ void f12a(E? n, Object o) {
 
 void f12b(E? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(E?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -199,6 +221,7 @@ void f12b(E? n, FutureOr<Object> o) {
 
 void f13a(ET? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(ET?, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -206,6 +229,7 @@ void f13a(ET? n, Object o) {
 
 void f13b(ET? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(ET?, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -214,6 +238,7 @@ void f13b(ET? n, FutureOr<Object> o) {
 void f14a(ET n, Object o) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? n : o; // UP(ET, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -222,6 +247,7 @@ void f14a(ET n, Object o) {
 void f14b(ET n, FutureOr<Object> o) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? n : o; // UP(ET, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
@@ -230,6 +256,7 @@ void f14b(ET n, FutureOr<Object> o) {
 void f15a(FutureOr<ET> t1, Object t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? t1 : t2; // UP(FutureOr<ET>, Object) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -238,6 +265,7 @@ void f15a(FutureOr<ET> t1, Object t2) {
 void f15b(FutureOr<ET> t1, FutureOr<Object> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? t1 : t2; // UP(FutureOr<ET>, FutureOr<Object>) = FutureOr<Object>?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();

--- a/TypeSystem/upper-lower-bounds/up_A15_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A15_t02.dart
@@ -14,352 +14,264 @@
 /// OBJECT(`T1`) and `T1` is not non-nullable. Note that none of TOP(`T`),
 /// BOTTOM(`T`), or NULL(`T`) holds when OBJECT(`T`), and `T` is not an
 /// intersection type.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
+// ignore_for_file: unused_local_variable
+
 import 'dart:async';
-import '../../Utils/expect.dart';
 import '../../Utils/static_type_helper.dart';
 import 'up_lib.dart';
 
-void f1(num? n, Object o) {
+void f1a(num? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(num?, Object) = Object?
-  v.expectStaticType<Exactly<Object?>>(); // Check that v's type is TOP.
-  // `Object` and `FutureOr<Object> `are subtypes of each other, which means
-  // that we can't see the difference using `expectStaticType()` function.
-  // `v.expectStaticType<Exactly<FutureOr<Object?>>>();` also succeeds. Let's
-  // check that `v` is not `FutureOr<Object?>`
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext(); // Check that `v`'s type is `Object`.
+  // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
+  // other, which means that we can't see the difference using
+  // `expectStaticType()` function. See the table in README.md for more details.
+  v.expectStaticType<Exactly<Object?>>(); // Check that `v`'s type is TOP.
+  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f2(num? n, FutureOr<Object> o) {
+void f1b(num? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(num?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext(); // Check that `v`'s type is `FutureOr<Object>`.
+  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f3<X extends num>(X? n, Object o) {
+void f2a<X extends num>(X? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f4<X extends num>(X? n, FutureOr<Object> o) {
+void f2b<X extends num>(X? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f5<X extends num?>(X n, Object o) {
+void f3a<X extends num?>(X n, Object o) {
   var v = (1 > 2) ? n : o; // UP(X?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f6<X extends num?>(X n, FutureOr<Object> o) {
+void f3b<X extends num?>(X n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(X?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f7(Function? n, Object o) {
+void f4a(Function? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Function?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f8(Function? n, FutureOr<Object> o) {
+void f4b(Function? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Function?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f9(Record? n, Object o) {
+void f5a(Record? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Record?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f10(Record? n, FutureOr<Object> o) {
+void f5b(Record? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Record?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f11(FutureOr<int>? n, Object o) {
+void f6a(FutureOr<int>? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f12(FutureOr<int>? n, FutureOr<Object> o) {
+void f6b(FutureOr<int>? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FutureOr<int>?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f13(C? n, Object o) {
+void f7a(C? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(C?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f14(C? n, FutureOr<Object> o) {
+void f7b(C? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(C?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f15(D<int, String>? n, Object o) {
+void f8a(D<int, String>? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f16(D<int, String>? n, FutureOr<Object> o) {
+void f8b(D<int, String>? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(D<int, String>?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f17(FPositional? n, Object o) {
+void f9a(FPositional? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FPositional?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f18(FPositional? n, FutureOr<Object> o) {
+void f9b(FPositional? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FPositional?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f19(FNamed? n, Object o) {
+void f10a(FNamed? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(FNamed?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f20(FNamed? n, FutureOr<Object> o) {
+void f10b(FNamed? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(FNamed?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f21(Rec? n, Object o) {
+void f11a(Rec? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(Rec?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f22(Rec? n, FutureOr<Object> o) {
+void f11b(Rec? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(Rec?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f23(E? n, Object o) {
+void f12a(E? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(E?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f24(E? n, FutureOr<Object> o) {
+void f12b(E? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(E?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f25(ET? n, Object o) {
+void f13a(ET? n, Object o) {
   var v = (1 > 2) ? n : o; // UP(ET?, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f26(ET? n, FutureOr<Object> o) {
+void f13b(ET? n, FutureOr<Object> o) {
   var v = (1 > 2) ? n : o; // UP(ET?, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f27(ET n, Object o) {
+void f14a(ET n, Object o) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? n : o; // UP(ET, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f28(ET n, FutureOr<Object> o) {
+void f14b(ET n, FutureOr<Object> o) {
   // `ET` is neither non-nullable (`ET <: Object` is false) nor nullable
   var v = (1 > 2) ? n : o; // UP(ET, FutureOr<Object>) = FutureOr<Object>?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip the `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
-void f29(FutureOr<ET> t1, Object t2) {
+void f15a(FutureOr<ET> t1, Object t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
-  // UP(FutureOr<ET>, Object) = Object?;
-  var v = (1 > 2) ? t1 : t2;
+  var v = (1 > 2) ? t1 : t2; // UP(FutureOr<ET>, Object) = Object?
   v.expectStaticType<Exactly<Object?>>();
-  if (v == null) { // Strip `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmObjectContext();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
-void f30(FutureOr<ET> t1, FutureOr<Object> t2) {
+void f15b(FutureOr<ET> t1, FutureOr<Object> t2) {
   // `FutureOr<ET>` is neither non-nullable (`ET <: Object` is false) nor nullable
-  // UP(FutureOr<ET>, FutureOr<Object>) = FutureOr<Object>?;
-  var v = (1 > 2) ? t1 : t2;
-  v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  if (v == null) { // Strip `?`
-    Expect.fail('The actual value must be non-null for the test to complete.');
-    return;
-  }
-  v = confirmFutureOrObjectContext();
+  var v = (1 > 2) ? t1 : t2; // UP(FutureOr<ET>, FutureOr<Object>) = FutureOr<Object>?
+  v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void main() {
-  f1(1, 1);
-  f2(1, 1);
-  f3(1, 1);
-  f4(1, 1);
-  f5(1, 1);
-  f6(1, 1);
-  f7(() {}, 1);
-  f8(() {}, 1);
-  f9((1,), 1);
-  f10((1,), 1);
-  f11(1, 1);
-  f12(1, 1);
-  f13(C(), 1);
-  f14(C(), 1);
-  f15(D<int, String>(), 1);
-  f16(D<int, String>(), 1);
-  f17(<X extends num>(X x, [int i = 0]) => 0, 1);
-  f18(<X extends num>(X x, [int i = 0]) => 0, 1);
-  f19(<X extends num>(X x, {int i = 0}) => 0, 1);
-  f20(<X extends num>(X x, {int i = 0}) => 0, 1);
-  f21((1, 'two', b: true), 1);
-  f22((1, 'two', b: true), 1);
-  f23(E.e0, 1);
-  f24(E.e0, 1);
-  f25(ET(0), 1);
-  f26(ET(0), 1);
-  f27(ET(0), 1);
-  f28(ET(0), 1);
-  f29(ET(0), 1);
-  f30(ET(0), 1);
+  f1a(1, 1);
+  f1b(1, 1);
+  f2a(1, 1);
+  f2b(1, 1);
+  f3a(1, 1);
+  f3b(1, 1);
+  f4a(() {}, 1);
+  f4b(() {}, 1);
+  f5a((1,), 1);
+  f5b((1,), 1);
+  f6a(1, 1);
+  f6b(1, 1);
+  f7a(C(), 1);
+  f7b(C(), 1);
+  f8a(D<int, String>(), 1);
+  f8b(D<int, String>(), 1);
+  f9a(<X extends num>(X x, [int i = 0]) => 0, 1);
+  f9b(<X extends num>(X x, [int i = 0]) => 0, 1);
+  f10a(<X extends num>(X x, {int i = 0}) => 0, 1);
+  f10b(<X extends num>(X x, {int i = 0}) => 0, 1);
+  f11a((1, 'two', b: true), 1);
+  f11b((1, 'two', b: true), 1);
+  f12a(E.e0, 1);
+  f12b(E.e0, 1);
+  f13a(ET(0), 1);
+  f13b(ET(0), 1);
+  f14a(ET(0), 1);
+  f14b(ET(0), 1);
+  f15a(ET(0), 1);
+  f15b(ET(0), 1);
 }

--- a/TypeSystem/upper-lower-bounds/up_A16_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A16_t02.dart
@@ -12,6 +12,8 @@
 /// TOP, BOTTOM, NULL, OBJECT, or an intersection type. Test that if `T1` and
 /// `T2` are not subtypes of each other then `S` is the least upper bound of
 /// `T1` and `T2`.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:async';
@@ -20,42 +22,62 @@ import 'up_lib.dart';
 
 void f1(int? t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int?, String?) = UP(int, String)? = Object?
+  // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
+  // other, which means that we can't see the difference using
+  // `expectStaticType()` function. See the table in README.md for more details.
   v.expectStaticType<Exactly<Object?>>();
+  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String? t1, int? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, int?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f3(C? t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C?, String?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f4(String? t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, C?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f5(C? t1, D? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(A?, B?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f6(D? t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(B?, A?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f7(Function? t1, Record? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function?, Record?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f8(Record? t1, Function? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record?, Function?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f9(List<int>? t1, List<String>? t2) {
@@ -129,12 +151,18 @@ void f21(FutureOr<int>? t1, String? t2) {
   // UP(FutureOr<int>?, String?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f22(String? t1, FutureOr<int>? t2) {
   // UP(String?, FutureOr<int>?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  // Check that `v` is not `Object?`, `FutureOr<Object?>`, `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f23(FutureOr<int>? t1, num? t2) {

--- a/TypeSystem/upper-lower-bounds/up_A16_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A16_t02.dart
@@ -24,15 +24,16 @@ void f1(int? t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int?, String?) = UP(int, String)? = Object?
   // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
   // other, which means that we can't see the difference using
-  // `expectStaticType()` function. See the table in README.md for more details.
+  // `expectStaticType()` function.
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
-  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String? t1, int? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, int?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -40,6 +41,7 @@ void f2(String? t1, int? t2) {
 
 void f3(C? t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C?, String?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -47,6 +49,7 @@ void f3(C? t1, String? t2) {
 
 void f4(String? t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, C?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -54,6 +57,7 @@ void f4(String? t1, C? t2) {
 
 void f5(C? t1, D? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(A?, B?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -61,6 +65,7 @@ void f5(C? t1, D? t2) {
 
 void f6(D? t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(B?, A?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -68,6 +73,7 @@ void f6(D? t1, C? t2) {
 
 void f7(Function? t1, Record? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function?, Record?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -75,6 +81,7 @@ void f7(Function? t1, Record? t2) {
 
 void f8(Record? t1, Function? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record?, Function?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -150,8 +157,8 @@ void f20(int Function()? t1, int Function(int)? t2) {
 void f21(FutureOr<int>? t1, String? t2) {
   // UP(FutureOr<int>?, String?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
@@ -159,8 +166,8 @@ void f21(FutureOr<int>? t1, String? t2) {
 void f22(String? t1, FutureOr<int>? t2) {
   // UP(String?, FutureOr<int>?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  // Check that `v` is not `Object?`, `FutureOr<Object?>`, `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }

--- a/TypeSystem/upper-lower-bounds/up_A17_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A17_t02.dart
@@ -11,6 +11,10 @@
 /// if the operands are not the same type and none of them is TOP, BOTTOM, NULL,
 /// OBJECT, or an intersection type. Test that if `T1` and `T2` are not subtypes
 /// of each other then `S` is the least upper bound of `T1` and `T2`.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:async';
@@ -19,32 +23,48 @@ import 'up_lib.dart';
 
 void f1(int? t1, String t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int?, String) = UP(int, String)? = Object?
+  // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
+  // other, which means that we can't see the difference using
+  // `expectStaticType()` function. See the table in README.md for more details.
   v.expectStaticType<Exactly<Object?>>();
+  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String? t1, int t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, int) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f3(C? t1, String t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C?, String) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f4(String? t1, C t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, C) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f5(Function? t1, Record t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function?, Record) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f6(Record? t1, Function t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record?, Function) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f7(List<int>? t1, List<String> t2) {
@@ -118,12 +138,17 @@ void f19(FutureOr<int>? t1, String t2) {
   // UP(FutureOr<int>?, String) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f20(String? t1, FutureOr<int> t2) {
   // UP(String?, FutureOr<int>) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f21(FutureOr<int>? t1, num t2) {

--- a/TypeSystem/upper-lower-bounds/up_A17_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A17_t02.dart
@@ -25,15 +25,16 @@ void f1(int? t1, String t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int?, String) = UP(int, String)? = Object?
   // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
   // other, which means that we can't see the difference using
-  // `expectStaticType()` function. See the table in README.md for more details.
+  // `expectStaticType()` function.
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
-  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String? t1, int t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, int) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -41,6 +42,7 @@ void f2(String? t1, int t2) {
 
 void f3(C? t1, String t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C?, String) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -48,6 +50,7 @@ void f3(C? t1, String t2) {
 
 void f4(String? t1, C t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String?, C) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -55,6 +58,7 @@ void f4(String? t1, C t2) {
 
 void f5(Function? t1, Record t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function?, Record) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -62,6 +66,7 @@ void f5(Function? t1, Record t2) {
 
 void f6(Record? t1, Function t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record?, Function) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -137,8 +142,8 @@ void f18(int Function()? t1, int Function(int) t2) {
 void f19(FutureOr<int>? t1, String t2) {
   // UP(FutureOr<int>?, String) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
@@ -146,6 +151,7 @@ void f19(FutureOr<int>? t1, String t2) {
 void f20(String? t1, FutureOr<int> t2) {
   // UP(String?, FutureOr<int>) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();

--- a/TypeSystem/upper-lower-bounds/up_A18_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A18_t02.dart
@@ -11,6 +11,8 @@
 /// if the operands are not the same type and none of them is TOP, BOTTOM, NULL,
 /// OBJECT, or an intersection type. Test that if `T1` and `T2` are not subtypes
 /// of each other then `S` is the least upper bound of `T1` and `T2`.
+/// @note README.md contains a detailed explanation of why and how we are
+/// checking the type of TOP and OBJECT.
 /// @author sgrekhov22@gmail.com
 
 import 'dart:async';
@@ -19,32 +21,48 @@ import 'up_lib.dart';
 
 void f1(int t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int, String?) = UP(int, String)? = Object?
+  // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
+  // other, which means that we can't see the difference using
+  // `expectStaticType()` function. See the table in README.md for more details.
   v.expectStaticType<Exactly<Object?>>();
+  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String t1, int? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String, int?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f3(C t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C, String?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f4(String t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String, C?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f5(Function t1, Record? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function, Record?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f6(Record t1, Function? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record, Function?) = Object?
   v.expectStaticType<Exactly<Object?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
+  v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f7(List<int> t1, List<String>? t2) {
@@ -118,12 +136,17 @@ void f19(FutureOr<int> t1, String? t2) {
   // UP(FutureOr<int>, String?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f20(String t1, FutureOr<int>? t2) {
   // UP(String, FutureOr<int>?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
+  v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
+  v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
 
 void f21(FutureOr<int> t1, num? t2) {

--- a/TypeSystem/upper-lower-bounds/up_A18_t02.dart
+++ b/TypeSystem/upper-lower-bounds/up_A18_t02.dart
@@ -23,15 +23,16 @@ void f1(int t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(int, String?) = UP(int, String)? = Object?
   // `Object?`, `FutureOr<Object>?` and `FutureOr<Object?>` are subtypes of each
   // other, which means that we can't see the difference using
-  // `expectStaticType()` function. See the table in README.md for more details.
+  // `expectStaticType()` function.
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
-  // Check that `v` is neither `FutureOr<Object>?` nor `FutureOr<Object?>`.
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
 }
 
 void f2(String t1, int? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String, int?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -39,6 +40,7 @@ void f2(String t1, int? t2) {
 
 void f3(C t1, String? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(C, String?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -46,6 +48,7 @@ void f3(C t1, String? t2) {
 
 void f4(String t1, C? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(String, C?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -53,6 +56,7 @@ void f4(String t1, C? t2) {
 
 void f5(Function t1, Record? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Function, Record?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -60,6 +64,7 @@ void f5(Function t1, Record? t2) {
 
 void f6(Record t1, Function? t2) {
   var v = (1 > 2) ? t1 : t2; // UP(Record, Function?) = Object?
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<Object?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<dynamic>>>();
   v = probeFutureOr()..expectStaticType<Exactly<FutureOr<Object>>>();
@@ -135,8 +140,8 @@ void f18(int Function() t1, int Function(int)? t2) {
 void f19(FutureOr<int> t1, String? t2) {
   // UP(FutureOr<int>, String?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
-  // Check that `v` is neither `Object?` nor `FutureOr<FutureOr<Object>>?`.
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();
 }
@@ -144,6 +149,7 @@ void f19(FutureOr<int> t1, String? t2) {
 void f20(String t1, FutureOr<int>? t2) {
   // UP(String, FutureOr<int>?) = FutureOr<Object>?
   var v = (1 > 2) ? t1 : t2;
+  // See README.md for an explanation of each step in the checks below.
   v.expectStaticType<Exactly<FutureOr<Object>?>>();
   v = probeFuture()..expectStaticType<Exactly<Future<Object>>>();
   v = probeFuture2()..expectStaticType<Exactly<Future<Future<dynamic>>>>();


### PR DESCRIPTION
Reference table for review


| Static type of `v`            | `v.checkDynamic` | `v.expectStaticType` | `probeFuture()`             | `probeFuture2()`          | `probeFutureOr()`             | `probeFutureOr2()`          |
|-------------------------------|------------------|----------------------|-----------------------------|---------------------------|-------------------------------|-----------------------------|
| `Object`                      | error            | `Exactly<Object>`    | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<dynamic>>` |
| `FutureOr<Object>`            | error            | `Exactly<Object>`    | `Future<Object>`            | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<Object>>`  |
| `FutureOr<FutureOr<Object>>`  | error            | `Exactly<Object>`    | `Future<FutureOr<Object>>`  | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>>`  | `Future<FutureOr<Object>>`  |
| `Object?`                     | error            | `Exactly<Object?>`   | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<dynamic>>` |
| `FutureOr<Object?>`           | error            | `Exactly<Object?>`   | `Future<Object?>`           | `Future<Future<dynamic>>` | `FutureOr<Object?>`           | `Future<FutureOr<Object>>`  |
| `FutureOr<Object>?`           | error            | `Exactly<Object?>`   | `Future<Object>`            | `Future<Future<dynamic>>` | `FutureOr<Object>`            | `Future<FutureOr<Object>>`  |
| `FutureOr<FutureOr<Object?>>` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object?>>` | `Future<Future<Object?>>` | `FutureOr<FutureOr<Object?>>` | `Future<FutureOr<Object?>>` |
| `FutureOr<FutureOr<Object>?>` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object>?>` | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>?>` | `Future<FutureOr<Object>>`  |
| `FutureOr<FutureOr<Object>>?` | error            | `Exactly<Object?>`   | `Future<FutureOr<Object>>`  | `Future<Future<Object>>`  | `FutureOr<FutureOr<Object>>`  | `Future<FutureOr<Object>>`  |
| `dynamic`                     | compiles         | not applicable       | `Future<dynamic>`           | `Future<Future<dynamic>>` | `FutureOr<dynamic>`           | `Future<FutureOr<dynamic>>` |
